### PR TITLE
fix: sync stores to match context on mark-all-as-read

### DIFF
--- a/.changeset/gorgeous-dolls-kneel.md
+++ b/.changeset/gorgeous-dolls-kneel.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/react-headless': patch
+---
+
+ensure that stores are updated to include or remove notification after an mark-all-read action.


### PR DESCRIPTION
This pull ensures that when having multiple stores, of which one holds read notifications and another unread, notifications are properly synchronised when clicking "mark all read".

Before this change, clicking "mark all read" in an inbox that only shows unread notifications (`{ read: false }`), would not remove those notifications from the current tab. Nor would they appear in a tab thats configured with `{ read: true }`.

Note that the implementation is still optimistic. Meaning, we move all notifications around, regardless of other parameters like category or custom attribute matchers.