### PR TITLE
fix: sync stores to match context on mark-all-as-seen

### DIFF
--- a/.changeset/rude-cobras-eat.md
+++ b/.changeset/rude-cobras-eat.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/react-headless': patch
+---
+
+ensure that stores are updated to include or remove notification after an mark-all-seen action.


### PR DESCRIPTION
This pull ensures that when having multiple stores, of which one holds seen notifications and another unseen, notifications are properly synchronised when clicking "mark all seen".

Before this change, clicking "mark all seen" in an inbox that only shows seen notifications (`{ seen: false }`), would not remove those notifications from the current tab. Nor would they appear in a tab thats configured with `{ seen: true }`.

Note that the implementation is still optimistic. Meaning, we move all notifications around, regardless of other parameters like category or custom attribute matchers.