### PR TITLE
chore: use action object instead of function

### DIFF
--- a/packages/react-headless/src/stores/notifications/useNotificationStoresCollection.ts
+++ b/packages/react-headless/src/stores/notifications/useNotificationStoresCollection.ts
@@ -205,7 +205,7 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
     const { stores, _repository } = get();
     let promise = Promise.resolve(true);
 
-    // Do not persist the state is this op is a consequence of a remote event.
+    // Do not persist the state if this op is a consequence of a remote event.
     // Neither emit a local event.
     if (options.persist !== false) {
       const params = options.storeId ? stores[options.storeId]?.context : {};

--- a/packages/react/src/components/UserPreferencesPanel/PreferencesCategories.stories.tsx
+++ b/packages/react/src/components/UserPreferencesPanel/PreferencesCategories.stories.tsx
@@ -1,4 +1,3 @@
-import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 import React from 'react';
 
@@ -13,8 +12,8 @@ const Component = ({ apiKey, userEmail, userKey, ...props }) => (
 
 const meta: Meta = {
   component: Component,
-  args: {
-    onChange: action('onChange'),
+  argTypes: {
+    onChange: { action: 'onChange' },
   },
 };
 


### PR DESCRIPTION
Cleanup, fixes a typo and uses the storybook action object instead of function call.