### PR TITLE
Removes the extra slash in the websocket auth url

### DIFF
--- a/packages/core/src/lib/realtime.ts
+++ b/packages/core/src/lib/realtime.ts
@@ -15,7 +15,7 @@ export { pushEventAggregator };
  * @param config The configuration used to open the connection.
  */
 export function connectToAbly(config: Config, authServerUrl = 'https://api.magicbell.com') {
-  const authUrl = `${authServerUrl}/${config.ws.authUrl}`;
+  const authUrl = `${authServerUrl}${config.ws.authUrl}`;
 
   const authHeaders = { 'X-MAGICBELL-API-KEY': config.apiKey };
   if (config.userEmail) authHeaders['X-MAGICBELL-USER-EMAIL'] = config.userEmail;


### PR DESCRIPTION
This gets rid of the extra slash that shows up as `//ws/auth`