### PR TITLE
fix: ensure correct url is used for "subscribe to push window"

### DIFF
--- a/.changeset/beige-coins-report.md
+++ b/.changeset/beige-coins-report.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/magicbell-react': patch
+---
+
+Fix embeddable web notifications: since embeddable aliases axios (redaxios) and redaxios does not implement `.getUri`, the code was failing for the embeddable package (that uses redaxios) but not for the react package (that uses axios).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,6 @@
     "@emotion/react": "^11.4.1",
     "@magicbell/react-headless": "4.2.2",
     "@tippyjs/react": "^4.2.5",
-    "axios": "^0.27.2",
     "dayjs": "^1.11.5",
     "humps": "^2.0.1",
     "immer": "^9.0.7",

--- a/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
+++ b/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
@@ -35,11 +35,13 @@ export default function EnablePushNotificationsBanner() {
   const enablePushNotifications = () => {
     const subscribeUrl = path<string>(['webPush', 'config', 'subscribeUrl'], channels);
 
+    const { backgroundColor, textColor } = theme.header;
+    
     const url = new URL(subscribeUrl);
-    url.searchParams.append('user_email', userEmail);
-    url.searchParams.append('user_external_id', userExternalId);
-    url.searchParams.append('background_color', theme.header.backgroundColor);
-    url.searchParams.append('text_color', theme.header.textColor);
+    if (userEmail) url.searchParams.append('user_email', userEmail);
+    if (userExternalId) url.searchParams.append('user_external_id', userExternalId);
+    if (backgroundColor) url.searchParams.append('background_color', backgroundColor);
+    if (textColor) url.searchParams.append('text_color', textColor);
 
     setRequestedAt(Date.now());
     openWindow(url.toString());

--- a/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
+++ b/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { clientSettings, useConfig } from '@magicbell/react-headless';
-import axios from 'axios';
 import { path, pathOr } from 'ramda';
 import { useLocalStorage } from 'react-use';
 
@@ -35,18 +34,15 @@ export default function EnablePushNotificationsBanner() {
 
   const enablePushNotifications = () => {
     const subscribeUrl = path<string>(['webPush', 'config', 'subscribeUrl'], channels);
-    const url = axios.getUri({
-      url: subscribeUrl,
-      params: {
-        user_email: userEmail,
-        user_external_id: userExternalId,
-        background_color: theme.header.backgroundColor,
-        text_color: theme.header.textColor,
-      },
-    });
+
+    const url = new URL(subscribeUrl);
+    url.searchParams.append('user_email', userEmail);
+    url.searchParams.append('user_external_id', userExternalId);
+    url.searchParams.append('background_color', theme.header.backgroundColor);
+    url.searchParams.append('text_color', theme.header.textColor);
 
     setRequestedAt(Date.now());
-    openWindow(url);
+    openWindow(url.toString());
   };
 
   const closeBanner = () => {

--- a/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
+++ b/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
@@ -36,7 +36,7 @@ export default function EnablePushNotificationsBanner() {
     const subscribeUrl = path<string>(['webPush', 'config', 'subscribeUrl'], channels);
 
     const { backgroundColor, textColor } = theme.header;
-    
+
     const url = new URL(subscribeUrl);
     if (userEmail) url.searchParams.append('user_email', userEmail);
     if (userExternalId) url.searchParams.append('user_external_id', userExternalId);


### PR DESCRIPTION
The "Enable Now" button is broken when using the embeddable JS snippet but not when using the React component.

That is because embeddable [configures](https://github.com/magicbell-io/magicbell-js/blob/8947f760676dec32b09d46bde1fb304ca9920d87/packages/embeddable/vite.config.js#L35) Vite/Rollup to alias axios to redaxios and redaxios [does not implement `getUri`](https://github.com/developit/redaxios/issues/63).

## Repro steps

- clone this repo
- `yarn build`
- add to `example/index.html` the snippet below
- `yarn start:example`
- `open http://localhost:3000`
- you should see one bell at the top (React) and one below (embeddable)
- click on the bell below (embeddable)
- click on "Enable Now"
- notice error in console Uncaught TypeError: Li.getUri is not a function
- clear localstorage (so that you can see “Enable now” again)
- click on the bell above (React)
- click on “Enable Now”
- notice no errors in console

Snippet

```
<div id="notifications-inbox" />

<script type="module">
  import { renderWidget } from '../packages/embeddable/dist/magicbell.esm.js';

  const targetElement = document.getElementById('notifications-inbox');
  const options = {
    apiKey: MY_API_KEY,
    userEmail: MY_USER_EMAIL,
    height: 500,
  };

  renderWidget(targetElement, options);
</script>
```

## Solutions considered

1. use axios instead of redaxios: this would work for sure but we prolly want to keep the deps footprint as small as possible
2. replace `axios.getUri` in React with [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL)

This PR implements 2.

## Difference between `axios.getUri` and `URL`

One thing I noticed that could be problematic is:

```js
const uri = axios.getUri({
  url: "http://example.com",
  params: { p: undefined }
});
// http://example.com

uri2 = new URL('http://example.com')
uri2.searchParams.append("p", undefined)
uri2.toString()
// http://example.com/?p=undefined
```

There may be other encoding differences I'm not aware of.

## Nota bene

I haven't run `yarn changeset` yet because I don't know how you want to bump this change.