### PR TITLE
fix: ensure that the minified esm file is loaded from unpkg

### DIFF
--- a/.changeset/lazy-ducks-promise.md
+++ b/.changeset/lazy-ducks-promise.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/embeddable': patch
+---
+
+ensure that the minified esm bundle is imported when importing from unpkg.

--- a/packages/embeddable/package.json
+++ b/packages/embeddable/package.json
@@ -5,6 +5,7 @@
   "main": "dist/magicbell.min.js",
   "esmodule": "dist/magicbell.esm.js",
   "module": "dist/magicbell.esm.js",
+  "unpkg": "dist/magicbell.esm.min.js",
   "repository": "git@github.com:magicbell-io/embeddable-web.git",
   "author": "MagicBell <bot@magicbell.io> (https://magicbell.com/)",
   "contributors": [


### PR DESCRIPTION
This should fix the unpkg esm import when used like:

```html
<div id="notifications-inbox" />
<script type="module">
  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';

  var target = document.getElementById('notifications-inbox');
  renderWidget(target,{});
</script>
```