### PR TITLE
chore: various small changes to `magicbell`

### DIFF
--- a/.changeset/fifty-pianos-happen.md
+++ b/.changeset/fifty-pianos-happen.md
@@ -1,0 +1,8 @@
+---
+'magicbell': minor
+---
+
+- Loads the axios http adapter when `XMLHttpRequest` is unsupported. This allows `magicbell` to be used in for example vscode extensions.
+- Don't persist config if `os.homedir` is unavailable, which is for example the case in vscode extensions.
+- Add support for authentication using `x-magicbell-user-external-id` header.
+- Allow specifying the `userKey`. This allows users to use `magicbell`, without the need to provide the `apiSecret` key to generate the HMAC on runtime.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "magicbell",
+  "name": "magicbell-root",
   "private": true,
   "version": "0.0.0",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -128,8 +128,9 @@ export class Client {
         'X-MAGICBELL-CLIENT-ID': this.#clientId,
         'X-MAGICBELL-CLIENT-USER-AGENT': this.#clientUserAgent,
         'X-MAGICBELL-USER-EMAIL': options.userEmail,
-        'X-MAGICBELL-USER-KEY': computeUserKey(options.apiSecret, options.userEmail),
         'X-MAGICBELL-USER-EXTERNAL-ID': options.userExternalId,
+        'X-MAGICBELL-USER-HMAC':
+          options.userHmac || computeUserKey(options.apiSecret, options.userExternalId || options.userEmail),
       }),
     );
   }

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -129,6 +129,7 @@ export class Client {
         'X-MAGICBELL-CLIENT-USER-AGENT': this.#clientUserAgent,
         'X-MAGICBELL-USER-EMAIL': options.userEmail,
         'X-MAGICBELL-USER-KEY': computeUserKey(options.apiSecret, options.userEmail),
+        'X-MAGICBELL-USER-EXTERNAL-ID': options.userExternalId,
       }),
     );
   }

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -13,6 +13,11 @@ import { Subscriptions } from './resources/subscriptions';
 import { Users } from './resources/users';
 import { ClientOptions, RequestArgs, RequestMethod, RequestOptions } from './types';
 
+// some environments, like vscode extensions, don't have the XMLHttpRequest object defined.
+if (typeof XMLHttpRequest !== 'function') {
+  axios.defaults.adapter = require('axios/lib/adapters/http');
+}
+
 export const DEFAULT_OPTIONS: Partial<ClientOptions> = {
   host: 'https://api.magicbell.com',
   timeout: 30_000,

--- a/packages/magicbell/src/lib/config.ts
+++ b/packages/magicbell/src/lib/config.ts
@@ -1,10 +1,14 @@
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
-import { homedir } from 'os';
+import os from 'os';
 import { join } from 'path';
 
 const _cache = new Map();
+/**
+ * Use a cache object, which is persisted to disk, if we have `homedir` available.
+ * Fe vscode, does not have `homedir` available.
+ */
 export const config = {
-  configDir: join(homedir(), '.magicbell'),
+  configDir: os && 'homedir' in os ? join(os.homedir(), '.magicbell') : null,
 
   get(path, initialValue = null) {
     if (_cache.has(path)) {
@@ -31,12 +35,14 @@ export const config = {
 
   set(path, data) {
     _cache.set(path, data);
+    if (!this.configDir) return;
     mkdirSync(this.configDir, { recursive: true });
     writeFileSync(join(this.configDir, path), JSON.stringify(data, null, 2), 'utf-8');
   },
 
   delete(path) {
     _cache.delete(path);
+    if (!this.configDir) return;
     unlinkSync(join(this.configDir, path));
   },
 };

--- a/packages/magicbell/src/options.ts
+++ b/packages/magicbell/src/options.ts
@@ -8,6 +8,7 @@ const optionValidators: Record<keyof ClientOptions, (value: unknown) => boolean>
   apiKey: isString,
   maxRetries: isNumber,
   userEmail: isString,
+  userExternalId: isString,
   idempotencyKey: isString,
   telemetry: isBoolean,
   apiSecret: isString,

--- a/packages/magicbell/src/options.ts
+++ b/packages/magicbell/src/options.ts
@@ -9,6 +9,7 @@ const optionValidators: Record<keyof ClientOptions, (value: unknown) => boolean>
   maxRetries: isNumber,
   userEmail: isString,
   userExternalId: isString,
+  userHmac: isString,
   idempotencyKey: isString,
   telemetry: isBoolean,
   apiSecret: isString,

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -3,6 +3,7 @@ export type ClientOptions = {
   apiKey: string;
   apiSecret?: string;
   userEmail?: string;
+  userExternalId?: string;
   appInfo?: {
     name: string;
     version?: string;
@@ -18,7 +19,7 @@ export type ClientOptions = {
 
 export type RequestOptions = Pick<
   ClientOptions,
-  'userEmail' | 'idempotencyKey' | 'timeout' | 'maxRetries' | 'maxRetryDelay'
+  'userEmail' | 'userExternalId' | 'idempotencyKey' | 'timeout' | 'maxRetries' | 'maxRetryDelay'
 >;
 
 export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -4,6 +4,7 @@ export type ClientOptions = {
   apiSecret?: string;
   userEmail?: string;
   userExternalId?: string;
+  userHmac?: string;
   appInfo?: {
     name: string;
     version?: string;
@@ -19,7 +20,7 @@ export type ClientOptions = {
 
 export type RequestOptions = Pick<
   ClientOptions,
-  'userEmail' | 'userExternalId' | 'idempotencyKey' | 'timeout' | 'maxRetries' | 'maxRetryDelay'
+  'userEmail' | 'userExternalId' | 'userHmac' | 'idempotencyKey' | 'timeout' | 'maxRetries' | 'maxRetryDelay'
 >;
 
 export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';


### PR DESCRIPTION
Few small changes to `magicbell`:

- Load the axios http adapter when `XMLHttpRequest` is unsupported. This allows `magicbell` to be used in for example vscode extensions.
- Don't persist config if `os.homedir` is unavailable, which is for example the case in vscode extensions.
- Add support for authentication using `x-magicbell-user-external-id` header.
- Allow specifying the `userKey`. This allows users to use `magicbell`, without the need to provide the `apiSecret` key to generate the HMAC on runtime.