### PR TITLE
feat: add support for beta methods / feature flags

### DIFF
--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -210,6 +210,10 @@ const magicbell = new MagicBell({
 
   Each request - after the first - includes a header with the response time of the previous request. This helps us to improve the performance of the API. You can opt out of this by setting this option to `false`.
 
+- **features** _Record<string, boolean>_
+
+  A map of feature flags to get access to beta features. See [Feature Flags](#feature-flags) for more information.
+
 ### Configuring Timeout
 
 Timeout can be set globally via the config object:
@@ -291,6 +295,28 @@ const magicbell = new MagicBell({
   telemetry: false,
 });
 ```
+
+### Feature Flags
+
+Features that in beta or early release are "hidden" behind a feature flag. You can enable them by passing a `features` object to the config, provided with a key for each feature that you wish to enable.
+
+Note that these features are behind a flag for a reason. They may change or be removed at any time and are not covered by our semantic versioning (semver) policy.
+
+```js
+const magicbell = new MagicBell({
+  features: {
+    'a-new-beta-feature': true,
+  },
+});
+```
+
+Below is a list of features that are currently behind feature flags.
+
+<!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
+
+_There are no features in beta at this time._
+
+<!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
 ## Resource methods
 

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -32,6 +32,7 @@ export class Client {
   #clientUserAgent: string;
   #options: ClientOptions;
   #logger = new Logger();
+  #features: Record<string, boolean> = {};
 
   #lastRequest: { id: string; runtime: number; duration: number; status: number }[] = [];
 
@@ -57,6 +58,11 @@ export class Client {
     this.#clientUserAgent = getClientUserAgent(options.appInfo);
     this.#userAgent = getUserAgent(options.appInfo);
     this.#clientId = getClientId();
+    this.#features = options.features || {};
+  }
+
+  hasFlag(flag: string) {
+    return this.#features[flag] || false;
   }
 
   async request({ method, path, data, params }: RequestArgs, options?: RequestOptions) {

--- a/packages/magicbell/src/method.ts
+++ b/packages/magicbell/src/method.ts
@@ -5,10 +5,12 @@ import { Resource } from './resource';
 import { ClientOptions, RequestMethod } from './types';
 
 type CreateMethodOptions = {
+  id: string;
   method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH';
   path?: string;
   entity?: string;
   type?: 'list';
+  beta?: boolean;
 };
 
 type IterablePromise<TData, TNode> = Promise<TData> & {
@@ -25,8 +27,12 @@ export function createMethod<TData = any>(
   options: CreateMethodOptions & { type?: never },
 ): (this: Resource, ...args) => Promise<TData>;
 
-export function createMethod({ method, path: _path, type }: CreateMethodOptions) {
+export function createMethod({ method, path: _path, type, id, beta }: CreateMethodOptions) {
   return function methodHandler(this: Resource, ...args) {
+    if (beta && !this.client.hasFlag(id)) {
+      throw new Error(`This is a beta feature, please enable it via the "${id}" flag.`);
+    }
+
     const { path, data, params, options } = normalizeArgs({
       path: joinUrlSegments(this.path, _path),
       method,

--- a/packages/magicbell/src/options.ts
+++ b/packages/magicbell/src/options.ts
@@ -15,6 +15,7 @@ const optionValidators: Record<keyof ClientOptions, (value: unknown) => boolean>
   apiSecret: isString,
   appInfo: isObject,
   debug: isBoolean,
+  features: isObject,
 };
 
 export function isOptionsHash(object) {

--- a/packages/magicbell/src/resources/notification-preferences.ts
+++ b/packages/magicbell/src/resources/notification-preferences.ts
@@ -10,6 +10,7 @@ export class NotificationPreferences extends Resource {
    * Fetch user notification preferences
    **/
   get = createMethod({
+    id: 'notification-preferences-get',
     method: 'GET',
   });
 
@@ -17,6 +18,7 @@ export class NotificationPreferences extends Resource {
    * Update user notification preferences
    **/
   update = createMethod({
+    id: 'notification-preferences-update',
     method: 'PUT',
   });
 }

--- a/packages/magicbell/src/resources/notifications.ts
+++ b/packages/magicbell/src/resources/notifications.ts
@@ -10,6 +10,7 @@ export class Notifications extends Resource {
    * Create notifications
    **/
   create = createMethod({
+    id: 'notifications-create',
     method: 'POST',
   });
 
@@ -17,6 +18,7 @@ export class Notifications extends Resource {
    * Fetch notifications
    **/
   list = createMethod({
+    id: 'notifications-list',
     method: 'GET',
     type: 'list',
   });
@@ -25,6 +27,7 @@ export class Notifications extends Resource {
    * Fetch a notification
    **/
   get = createMethod({
+    id: 'notifications-get',
     method: 'GET',
     path: '{notification_id}',
   });
@@ -33,6 +36,7 @@ export class Notifications extends Resource {
    * Delete a notification
    **/
   delete = createMethod({
+    id: 'notifications-delete',
     method: 'DELETE',
     path: '{notification_id}',
   });
@@ -41,6 +45,7 @@ export class Notifications extends Resource {
    * Mark a notification as read
    **/
   markAsRead = createMethod({
+    id: 'notifications-mark-as-read',
     method: 'POST',
     path: '{notification_id}/read',
   });
@@ -49,6 +54,7 @@ export class Notifications extends Resource {
    * Mark a notification as unread
    **/
   markAsUnread = createMethod({
+    id: 'notifications-mark-as-unread',
     method: 'POST',
     path: '{notification_id}/unread',
   });
@@ -57,6 +63,7 @@ export class Notifications extends Resource {
    * Archive a notification
    **/
   archive = createMethod({
+    id: 'notifications-archive',
     method: 'POST',
     path: '{notification_id}/archive',
   });
@@ -65,6 +72,7 @@ export class Notifications extends Resource {
    * Unarchive a notification
    **/
   unarchive = createMethod({
+    id: 'notifications-unarchive',
     method: 'DELETE',
     path: '{notification_id}/archive',
   });
@@ -73,6 +81,7 @@ export class Notifications extends Resource {
    * Mark all notifications as read
    **/
   markAllRead = createMethod({
+    id: 'notifications-mark-all-read',
     method: 'POST',
     path: 'read',
   });
@@ -81,6 +90,7 @@ export class Notifications extends Resource {
    * Mark all notifications as seen
    **/
   markAllSeen = createMethod({
+    id: 'notifications-mark-all-seen',
     method: 'POST',
     path: 'seen',
   });

--- a/packages/magicbell/src/resources/subscriptions.ts
+++ b/packages/magicbell/src/resources/subscriptions.ts
@@ -10,6 +10,7 @@ export class Subscriptions extends Resource {
    * List subscriptions
    **/
   list = createMethod({
+    id: 'subscriptions-list',
     method: 'GET',
     type: 'list',
   });
@@ -18,6 +19,7 @@ export class Subscriptions extends Resource {
    * Create a topic subscription
    **/
   create = createMethod({
+    id: 'subscriptions-create',
     method: 'POST',
   });
 
@@ -25,6 +27,7 @@ export class Subscriptions extends Resource {
    * Unsubscribe from a topic
    **/
   unsubscribe = createMethod({
+    id: 'subscriptions-unsubscribe',
     method: 'POST',
     path: '{topic}/unsubscribe',
   });
@@ -33,6 +36,7 @@ export class Subscriptions extends Resource {
    * Show a topic subscription
    **/
   get = createMethod({
+    id: 'subscriptions-get',
     method: 'GET',
     path: '{topic}',
   });
@@ -41,6 +45,7 @@ export class Subscriptions extends Resource {
    * Delete topic subscription(s)
    **/
   delete = createMethod({
+    id: 'subscriptions-delete',
     method: 'DELETE',
     path: '{topic}',
   });

--- a/packages/magicbell/src/resources/users.ts
+++ b/packages/magicbell/src/resources/users.ts
@@ -10,6 +10,7 @@ export class Users extends Resource {
    * Create a user
    **/
   create = createMethod({
+    id: 'users-create',
     method: 'POST',
   });
 
@@ -17,6 +18,7 @@ export class Users extends Resource {
    * Update a user
    **/
   update = createMethod({
+    id: 'users-update',
     method: 'PUT',
     path: '{user_id}',
   });
@@ -25,6 +27,7 @@ export class Users extends Resource {
    * Delete a user
    **/
   delete = createMethod({
+    id: 'users-delete',
     method: 'DELETE',
     path: '{user_id}',
   });
@@ -33,6 +36,7 @@ export class Users extends Resource {
    * Update a user by email
    **/
   updateByEmail = createMethod({
+    id: 'users-update-by-email',
     method: 'PUT',
     path: 'email:{user_email}',
   });
@@ -41,6 +45,7 @@ export class Users extends Resource {
    * Delete a user by email
    **/
   deleteByEmail = createMethod({
+    id: 'users-delete-by-email',
     method: 'DELETE',
     path: 'email:{user_email}',
   });
@@ -49,6 +54,7 @@ export class Users extends Resource {
    * Update a user by external ID
    **/
   updateByExternalId = createMethod({
+    id: 'users-update-by-external-id',
     method: 'PUT',
     path: 'external_id:{external_id}',
   });
@@ -57,6 +63,7 @@ export class Users extends Resource {
    * Delete a user by external ID
    **/
   deleteByExternalId = createMethod({
+    id: 'users-delete-by-external-id',
     method: 'DELETE',
     path: 'external_id:{external_id}',
   });

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -16,6 +16,7 @@ export type ClientOptions = {
   idempotencyKey?: string;
   telemetry?: boolean;
   debug?: boolean;
+  features?: Record<string, boolean>;
 };
 
 export type RequestOptions = Pick<


### PR DESCRIPTION
This adds support for beta methods / feature flags to the `magicbell` codegen, and thereby node client.

Meaning, if we add `x-beta: true` to an operation in our openapi spec, the codegen will pick that up, and mark the method as beta. 

Beta methods are methods that have an `x-beta: true` property in the openapi spec:

```json
"/entity": {
  "post": {
    "x-beta": true,
    "operationId": "entity-create",
```

Those methods get documented with a warning mentioning the `operationId` as feature flag, and link to the feature flag section in the readme.

> #### Create Entity
> 
> **Warning**
>
> This method is in preview and is subject to change. It needs to be enabled via the `entity-create` [feature flag](#feature-flags).

When they're invoked while they're not explicitly enabled via a feature flag, they'll throw an error:

```js
magicbell.entity.create({ … });
// » ERROR: This is a beta feature, please enable it via the "entity-create" flag.
```

To enable beta features, a matching feature flags needs to be set. Feature flags map to the operationIds from our openapi spec.

```js
const magicbell = new MagicBell({
  features: {
    'entity-create': true,
  },
});
```