### PR TITLE
feat: add imports resource

### DIFF
--- a/.changeset/afraid-insects-accept.md
+++ b/.changeset/afraid-insects-accept.md
@@ -1,0 +1,7 @@
+---
+'magicbell': minor
+---
+
+Add the `magicbell.imports` resource to import users in bulk, and query the status of import jobs. Methods that have been made available are `magicbell.imports.create` and `magicbell.imports.get`.
+
+See [#imports](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#imports) for more information.

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -711,6 +711,52 @@ await magicbell.subscriptions.delete(
 );
 ```
 
+### Imports
+
+#### Create a user import
+
+Send a request to start the import of a list of users. The import allows the creation of slack connections as well.
+
+```js
+await magicbell.imports.create({
+  users: [
+    {
+      external_id: 'ugiabqertz',
+      email: 'johndoe@example.com',
+      first_name: 'John',
+      last_name: 'Doe',
+      custom_attributes: {
+        age: 32,
+        country: 'Spain',
+      },
+      channels: {
+        slack: {
+          providers: [
+            {
+              oauth: {
+                channel_id: 'U039446XF3Y',
+                app: {
+                  app_id: 'your_slack_app_id',
+                  team_id: 'workspace_id_from_slack',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+});
+```
+
+#### Get a user import
+
+Send a request to query the status & errors of the import.
+
+```js
+await magicbell.imports.get('{import_id}');
+```
+
 <!-- AUTO-GENERATED-CONTENT:END (RESOURCE_METHODS) -->
 
 ## Support

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -7,6 +7,7 @@ import { normalizeHeaders } from './lib/headers';
 import { Logger } from './lib/log';
 import { compact, hasOwn, joinAnd, sleep, uuid4 } from './lib/utils';
 import { isOptionsHash } from './options';
+import { Imports } from './resources/imports';
 import { NotificationPreferences } from './resources/notification-preferences';
 import { Notifications } from './resources/notifications';
 import { Subscriptions } from './resources/subscriptions';
@@ -36,6 +37,7 @@ export class Client {
 
   #lastRequest: { id: string; runtime: number; duration: number; status: number }[] = [];
 
+  imports = new Imports(this);
   notificationPreferences = new NotificationPreferences(this);
   notifications = new Notifications(this);
   subscriptions = new Subscriptions(this);

--- a/packages/magicbell/src/resources/imports.ts
+++ b/packages/magicbell/src/resources/imports.ts
@@ -1,0 +1,25 @@
+// This file is generated. Do not update manually!
+import { createMethod } from '../method';
+import { Resource } from '../resource';
+
+export class Imports extends Resource {
+  path = 'imports';
+  entity = 'import';
+
+  /**
+   * Create a user import
+   **/
+  create = createMethod({
+    id: 'imports-create',
+    method: 'POST',
+  });
+
+  /**
+   * Get a user import
+   **/
+  get = createMethod({
+    id: 'imports-get',
+    method: 'GET',
+    path: '{import_id}',
+  });
+}


### PR DESCRIPTION
Add the `magicbell.imports` resource to import users in bulk, and query the status of import jobs. Methods that have been made available are `magicbell.imports.create` and `magicbell.imports.get`.

Note that this is a simple sync with our [openapi spec](https://github.com/magicbell-io/public/blob/f15ca0ccfd56b5bf93a8a0a6e8b56071322462fb/openapi/spec/openapi.json). No code has been written.