### PR TITLE
feat: add pushSubscriptions resource (beta)

### DIFF
--- a/.changeset/two-cats-give.md
+++ b/.changeset/two-cats-give.md
@@ -1,0 +1,7 @@
+---
+'magicbell': minor
+---
+
+Add the `magicbell.pushSubscriptions` resource to manage mobile devices / push subscriptions. Methods that have been made available are `magicbell.pushSubscriptions.create` and `magicbell.pushSubscriptions.delete`. Note that these methods are currently in beta, and need to be enabled via [feature flags](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#feature-flags).
+
+See [#pushSubscriptions](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#pushSubscriptions) for more information.

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -314,7 +314,10 @@ Below is a list of features that are currently behind feature flags.
 
 <!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
 
-_There are no features in beta at this time._
+| Feature Flag                | Description                                              |
+| --------------------------- | -------------------------------------------------------- |
+| `push-subscriptions-create` | Register a device ([docs](#push-subscriptions-create))   |
+| `push-subscriptions-delete` | Unregister a device ([docs](#push-subscriptions-delete)) |
 
 <!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
@@ -628,6 +631,44 @@ await magicbell.notificationPreferences.update(
     userEmail: 'person@example.com',
   },
 );
+```
+
+### Push Subscriptions
+
+#### Register a device
+
+> **Warning**
+>
+> This method is in preview and is subject to change. It needs to be enabled via the `push-subscriptions-create` [feature flag](#feature-flags).
+
+Register a device token for push notifications.
+
+Please keep in mind that mobile push notifications will be delivered to this device only if the channel is configured and enabled.
+
+```js
+await magicbell.pushSubscriptions.create(
+  {
+    device_token: 'x4doKe98yEZ21Kum2Qq39M3b8jkhonuIupobyFnL0wJMSWAZ8zoTp2dyHgV',
+    platform: 'ios',
+  },
+  {
+    userEmail: 'person@example.com',
+  },
+);
+```
+
+#### Unregister a device
+
+> **Warning**
+>
+> This method is in preview and is subject to change. It needs to be enabled via the `push-subscriptions-delete` [feature flag](#feature-flags).
+
+Remove the subscription of a device to mobile push notifications. The device will be discarded immediately.
+
+```js
+await magicbell.pushSubscriptions.delete('{device_token}', {
+  userEmail: 'person@example.com',
+});
 ```
 
 ### Subscriptions

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -11,6 +11,7 @@ import { isOptionsHash } from './options';
 import { Imports } from './resources/imports';
 import { NotificationPreferences } from './resources/notification-preferences';
 import { Notifications } from './resources/notifications';
+import { PushSubscriptions } from './resources/push-subscriptions';
 import { Subscriptions } from './resources/subscriptions';
 import { Users } from './resources/users';
 import { ClientOptions, RequestArgs, RequestMethod, RequestOptions } from './types';
@@ -43,6 +44,7 @@ export class Client {
   imports = new Imports(this);
   notificationPreferences = new NotificationPreferences(this);
   notifications = new Notifications(this);
+  pushSubscriptions = new PushSubscriptions(this);
   subscriptions = new Subscriptions(this);
   users = new Users(this);
 

--- a/packages/magicbell/src/resources/push-subscriptions.ts
+++ b/packages/magicbell/src/resources/push-subscriptions.ts
@@ -1,0 +1,27 @@
+// This file is generated. Do not update manually!
+import { createMethod } from '../method';
+import { Resource } from '../resource';
+
+export class PushSubscriptions extends Resource {
+  path = 'push_subscriptions';
+  entity = 'push_subscription';
+
+  /**
+   * Register a device
+   **/
+  create = createMethod({
+    id: 'push-subscriptions-create',
+    method: 'POST',
+    beta: true,
+  });
+
+  /**
+   * Unregister a device
+   **/
+  delete = createMethod({
+    id: 'push-subscriptions-delete',
+    method: 'DELETE',
+    path: '{device_token}',
+    beta: true,
+  });
+}


### PR DESCRIPTION
Add the `magicbell.pushSubscriptions` resource to manage mobile devices / push subscriptions. Methods that have been made available are `magicbell.pushSubscriptions.create` and `magicbell.pushSubscriptions.delete`. Note that these methods are currently in beta, and need to be enabled via [feature flags](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#feature-flags).

Note that this is a simple sync with our [openapi spec](https://github.com/magicbell-io/public/blob/f15ca0ccfd56b5bf93a8a0a6e8b56071322462fb/openapi/spec/openapi.json). No code has been written.