### PR TITLE
feat: add listen method for realtime events

### DIFF
--- a/.changeset/beige-schools-grow.md
+++ b/.changeset/beige-schools-grow.md
@@ -1,0 +1,16 @@
+---
+'magicbell': minor
+---
+
+Released the `.listen` method. With this method you can listen to server sent events in realtime. For example, to do something when new notifications come in, or to trigger an event when a user marks a notification as read.
+
+The following events are currently emitted. Please note that all events are bound to a specific user. See [#realtime](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#realtime) for more information.
+
+| event.name               | description                                |
+| ------------------------ | ------------------------------------------ |
+| `notifications/new`      | a new notification has been created        |
+| `notifications/read`     | a notification has been read               |
+| `notifications/unread`   | a notification has been marked as unread   |
+| `notifications/delete`   | a notification has been deleted            |
+| `notifications/read/all` | all notifications have been marked as read |
+| `notifications/seen/all` | all notifications have been marked as seen |

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -713,6 +713,69 @@ await magicbell.subscriptions.delete(
 
 <!-- AUTO-GENERATED-CONTENT:END (RESOURCE_METHODS) -->
 
+## Realtime
+
+Listen to realtime events using Server Sent Events / EventSource. This feature supports auto-retry for authentication requests, and auto-reconnect when streaming. In case the connection is lost, the client will try to reconnect and resume the stream from the last received event.
+
+It's possible to listen via an async iterator, or via a callback. The listen method is for a single user. Just like with the resource methods, the user email or external-id can be provided via the client, or passed as argument to the listen method.
+
+```js
+const magicbell = new MagicBell({
+  apiKey: 'your-api-key',
+  userEmail: 'someone@example.com',
+});
+
+magicbell.listen({ userEmail: 'someone@example.com' });
+```
+
+**async iterator** - this iterates over all events. Call `break` when you wish to step out of the iteration and stop listening.
+
+```js
+for await (const notification of magicbell.listen()) {
+  console.log(notification.data.id);
+  // break to abort and stop listening
+  if (shouldStop()) break;
+}
+```
+
+**forEach** - similar to the iterator, but in a callback style fashion. Return `false` when you wish to stop listening.
+
+```js
+magicbell.listen().forEach((notification) => {
+  console.log(notification.data.id);
+  // return false to abort and stop listening
+  if (shouldStop()) return false;
+});
+```
+
+### Realtime events
+
+The following events are emitted by the client:
+
+| event.name               | description                                |
+| ------------------------ | ------------------------------------------ |
+| `notifications/new`      | a new notification has been created        |
+| `notifications/read`     | a notification has been read               |
+| `notifications/unread`   | a notification has been marked as unread   |
+| `notifications/delete`   | a notification has been deleted            |
+| `notifications/read/all` | all notifications have been marked as read |
+| `notifications/seen/all` | all notifications have been marked as seen |
+
+### Realtime with extended data
+
+Note that the realtime listener returns a limited set of data. We do this intentionally, so that the listener stays fast, and doesn't use more bandwidth or battery than necessary. If you need more data, you can complement it using the notification resource method.
+
+```js
+for await (let event of client.listen()) {
+  if ('id' in event.data) {
+    const notification = await client.notifications.get(event.data.id);
+    doSomething({ event, notification });
+  } else {
+    doSomething({ event });
+  }
+}
+```
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `magicbell` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -56,6 +56,7 @@
     "ast-types": "^0.14.2",
     "json5": "^2.2.1",
     "openapi-types": "^12.0.2",
+    "portfinder": "^1.0.32",
     "recast": "^0.21.2"
   },
   "dependencies": {

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "axios-retry": "^3.3.1",
+    "eventsource": "^2.0.2",
     "qs": "^6.11.0",
     "tsx": "^3.9.0"
   }

--- a/packages/magicbell/src/listen.test.ts
+++ b/packages/magicbell/src/listen.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach } from 'vitest';
+
+import { setupMockServer } from '../test/mock-server';
+import { eventStream } from '../test/mock-sse';
+import { Client } from './client';
+import { createListener } from './listen';
+
+const server = setupMockServer();
+let listen;
+
+beforeEach(async () => {
+  server.intercept('all', (req) => {
+    if (req.url.pathname === '/config') return { ws: { channel: 'project:1:channel:2' } };
+    if (req.url.pathname === '/ws/auth') return { keyName: 'key', mac: 'random' };
+    if (req.url.pathname === '/keys/key/requestToken') return { token: 'token' };
+    if (req.url.pathname === '/sse') return { passThrough: true };
+  });
+
+  const { host } = await eventStream(function* () {
+    yield { type: 'notifications/new', data: { id: 1 } };
+    yield { type: 'notifications/new', data: { id: 2 } };
+    yield { type: 'notifications/new', data: { id: 3 } };
+  });
+
+  const client = new Client({ apiKey: 'my-api-key' });
+  listen = createListener(client, { sseHost: host });
+});
+
+test('can listen to realtime events using async iterator', async () => {
+  const events = [];
+  for await (const event of listen()) {
+    events.push(event);
+  }
+
+  expect(events).toHaveLength(3);
+  expect(events[0].data).toEqual({ id: 1 });
+  expect(events[1].data).toEqual({ id: 2 });
+  expect(events[2].data).toEqual({ id: 3 });
+});
+
+test('can listen to realtime events using forEach helper', async () => {
+  const events = [];
+  await listen().forEach((event) => {
+    events.push(event);
+  });
+
+  expect(events).toHaveLength(3);
+  expect(events[0].data).toEqual({ id: 1 });
+  expect(events[1].data).toEqual({ id: 2 });
+  expect(events[2].data).toEqual({ id: 3 });
+});
+
+test('break from iteration closes listener', async () => {
+  const events = [];
+  for await (const event of listen()) {
+    events.push(event);
+    if (events.length === 2) break;
+  }
+
+  expect(events).toHaveLength(2);
+  expect(events[0].data).toEqual({ id: 1 });
+  expect(events[1].data).toEqual({ id: 2 });
+});
+
+test('return false in forEach helper closes listener', async () => {
+  const events = [];
+  await listen().forEach((event, idx) => {
+    events.push(event);
+    return idx < 1;
+  });
+
+  expect(events).toHaveLength(2);
+  expect(events[0].data).toEqual({ id: 1 });
+  expect(events[1].data).toEqual({ id: 2 });
+});

--- a/packages/magicbell/src/listen.ts
+++ b/packages/magicbell/src/listen.ts
@@ -1,0 +1,157 @@
+import axios from 'axios';
+import EventSource from 'eventsource';
+
+import { Client } from './client';
+import { ASYNC_ITERATOR_SYMBOL, makeForEach } from './paginate';
+import { RequestOptions } from './types';
+
+type AuthResponse = {
+  keyName: string;
+  timestamp: number;
+  nonce: string;
+  ttl: number;
+  mac: string;
+};
+
+type TokenResponse = {
+  token: string;
+  keyName: string;
+  issued: number;
+  expires: number;
+  capability: string;
+  userClaims: string;
+};
+
+type Event = {
+  id: string;
+  timestamp: number;
+  encoding: string;
+  channel: string;
+} & (
+  | { name: 'notifications/new'; data: { id: string } }
+  | { name: 'notifications/read'; data: { id: string; client_id: string } }
+  | { name: 'notifications/read/all'; data: { client_id: string } }
+  | { name: 'notifications/seen/all'; data: { client_id: string } }
+  | { name: 'notifications/unread'; data: { id: string; client_id: string } }
+  | { name: 'notifications/delete'; data: { id: string; client_id: string | null } }
+);
+
+type IterableEventSource<TNode> = {
+  [Symbol.asyncIterator](): Iterator<TNode>;
+  forEach(cb: (node: TNode, index: number) => void | boolean | Promise<void | boolean>): Promise<void>;
+};
+
+export function createListener(client: InstanceType<typeof Client>) {
+  let eventSource: EventSource;
+  let channels: string;
+  let lastEvent: string;
+  let configPromise;
+
+  const messages: { value: Event; done: boolean }[] = [];
+  let resolve;
+
+  const pushMessage = (p) => {
+    messages.push(p);
+
+    if (resolve) {
+      resolve();
+      resolve = null;
+    }
+  };
+
+  // accept callback or yield
+  async function connect(options?: RequestOptions) {
+    // invoke optional config request in the background, as we only need it after the ably authentication
+    if (!channels && !configPromise) {
+      configPromise = client
+        .request({ method: 'GET', path: '/config' }, options)
+        .then((x) => (channels = x.ws.channel));
+    }
+
+    const auth = await client.request<AuthResponse>({ method: 'POST', path: '/ws/auth' }, options);
+
+    // authenticate against ably
+    const { token } = await axios
+      .post<TokenResponse>(`https://rest.ably.io/keys/${auth.keyName}/requestToken`, auth)
+      .then((x) => x.data);
+
+    // make sure that the optional config request has finished
+    await configPromise;
+
+    // establish a connection with that token
+    const url = new URL('https://realtime.ably.io/sse');
+    url.searchParams.append('v', '1.1');
+    url.searchParams.append('accessToken', token);
+    url.searchParams.append('channels', channels);
+    url.searchParams.append('heartbeats', 'true');
+
+    if (lastEvent) {
+      url.searchParams.append('lastEvent', lastEvent);
+    }
+
+    if (eventSource) {
+      eventSource.close();
+    }
+
+    eventSource = new EventSource(url.toString());
+
+    // handle incoming messages
+    eventSource.onmessage = (event) => {
+      if (event.origin !== 'https://realtime.ably.io') return;
+
+      lastEvent = event.lastEventId;
+      if (!('data' in event)) return;
+
+      const message = JSON.parse(event.data);
+      message.data = message.encoding === 'json' ? JSON.parse(message.data) : message.data;
+      pushMessage({ value: message, done: false });
+    };
+
+    // handle connection errors
+    eventSource.onerror = (msg) => {
+      const err = 'data' in msg ? JSON.parse((msg as any).data) : {};
+      const isTokenErr = err.code >= 40140 && err.code < 40150;
+      if (isTokenErr) {
+        eventSource.close();
+        connect(options);
+      } else if (/invalid channel id/i.test(err.message)) {
+        eventSource.close();
+        pushMessage({ value: null, done: true });
+      } else {
+        // eslint-disable-next-line no-console
+        console.log('err', err);
+      }
+    };
+  }
+
+  function listen(options: RequestOptions): IterableEventSource<Event> {
+    void connect(options);
+
+    const asyncIteratorNext = async () => {
+      if (!messages.length) await new Promise((r) => (resolve = r));
+      const event = messages.pop();
+      if (event.done && eventSource) eventSource.close();
+      return event;
+    };
+
+    const dispose = () => {
+      eventSource.close();
+      return { done: true, value: undefined };
+    };
+
+    const forEach = makeForEach(asyncIteratorNext, dispose);
+    const autoPaginationMethods = {
+      forEach,
+
+      next: asyncIteratorNext,
+      return: dispose,
+      [ASYNC_ITERATOR_SYMBOL]: () => {
+        return autoPaginationMethods;
+      },
+    };
+
+    return autoPaginationMethods;
+  }
+
+  return listen;
+}

--- a/packages/magicbell/src/paginate.ts
+++ b/packages/magicbell/src/paginate.ts
@@ -88,7 +88,7 @@ function memoizedPromise(promiseCache, cb) {
   return promiseCache.currentPromise;
 }
 
-function makeForEach(asyncIteratorNext) {
+export function makeForEach(asyncIteratorNext, onDoneCallback?: () => void) {
   return function forEach(onItem) {
     return new Promise<void>((resolve, reject) => {
       let idx = 0;
@@ -103,6 +103,7 @@ function makeForEach(asyncIteratorNext) {
           resolve(onItem(item, idx));
         }).then((shouldContinue) => {
           if (shouldContinue === false) {
+            onDoneCallback?.();
             return handleIteration({ done: true });
           } else {
             idx++;

--- a/packages/magicbell/test/mock-server.ts
+++ b/packages/magicbell/test/mock-server.ts
@@ -37,8 +37,23 @@ export function setupMockServer() {
 
       server.use(
         rest[method]('*', (req, res, ctx) => {
-          const { status, json, ...data } = cb?.(req, res, context) || {};
-          const response = res(ctx.status(status || 200), ctx.json(json || data || ''));
+          const {
+            status,
+            json,
+            contentType = 'application/json',
+            cacheControl = 'no-cache',
+            passThrough = false,
+            ...data
+          } = cb?.(req, res, context) || {};
+
+          if (passThrough) return req.passthrough();
+
+          const response = res(
+            ctx.status(status || 200),
+            ctx.set('Content-Type', contentType),
+            ctx.set('Cache-Control', cacheControl),
+            ctx.json(json || data || ''),
+          );
 
           context.handledRequests++;
           context.lastRequest = req;

--- a/packages/magicbell/test/mock-sse.ts
+++ b/packages/magicbell/test/mock-sse.ts
@@ -1,0 +1,58 @@
+import http from 'http';
+import portFinder from 'portfinder';
+
+export function eventStream(generatorFn: () => Generator<Record<string, unknown>, void, unknown>) {
+  let done = false;
+
+  const server = http.createServer(function (req, res) {
+    const url = new URL(req.url, 'http://localhost');
+
+    if (url.pathname === '/sse') {
+      const iterator = generatorFn();
+
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders();
+
+      res.write('retry: 10000\n\n');
+
+      let msg = 0;
+      while (true) {
+        const next = iterator.next();
+
+        if (next.value) {
+          setTimeout(() => {
+            res.write('data: ' + JSON.stringify(next.value) + '\n\n');
+          }, msg++ * 5);
+        }
+
+        if (next.done) {
+          setTimeout(() => {
+            res.write('data:' + JSON.stringify({ type: 'close' }) + '\n\n');
+          }, msg++ * 5);
+
+          break;
+        }
+      }
+
+      setTimeout(() => (done = true), msg++ * 5);
+    }
+  });
+
+  const interval = setInterval(() => {
+    if (!done) return;
+    clearInterval(interval);
+    clearTimeout(timeout);
+    server.close();
+  }, 5);
+
+  const timeout = setTimeout(() => clearInterval(interval), 30_000);
+
+  return new Promise<{ host: string; port: number }>((resolve) => {
+    portFinder.getPortPromise().then((port) => {
+      server.listen(port);
+      resolve({ port, host: `http://localhost:${port}` });
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7775,6 +7775,11 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,6 +4791,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 async@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -10699,7 +10706,7 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11251,7 +11258,7 @@ mixme@^0.5.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.5.4.tgz#8cb3bd0cd32a513c161bf1ca99d143f0bcf2eff3"
   integrity sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.3:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -12299,6 +12306,15 @@ popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
+portfinder@^1.0.32:
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
+  integrity sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==
+  dependencies:
+    async "^2.6.4"
+    debug "^3.2.7"
+    mkdirp "^0.5.6"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Added the `.listen` method. With this method you can listen to server sent events in realtime. For example, to do something when new notifications come in, or to trigger an event when a user marks a notification as read.

The following events are currently emitted and handled. Please also see the updated readme in this PR for more info:

| event.name               | description                                |
| ------------------------ | ------------------------------------------ |
| `notifications/new`      | a new notification has been created        |
| `notifications/read`     | a notification has been read               |
| `notifications/unread`   | a notification has been marked as unread   |
| `notifications/delete`   | a notification has been deleted            |
| `notifications/read/all` | all notifications have been marked as read |
| `notifications/seen/all` | all notifications have been marked as seen |


Events can be listened to via an async iterator:

```js
for await (const notification of magicbell.listen()) {
  console.log(notification.data.id);
  // break to abort and stop listening
  if (shouldStop()) break;
}
```

Or via a `forEach` helper:

```js
magicbell.listen().forEach((notification) => {
  console.log(notification.data.id);
  // return false to abort and stop listening
  if (shouldStop()) return false;
});
```
