### PR TITLE
feat: add type annotations to all resource methods

### DIFF
--- a/.changeset/rich-carpets-turn.md
+++ b/.changeset/rich-carpets-turn.md
@@ -1,0 +1,5 @@
+---
+'magicbell': minor
+---
+
+Add type annotations to all resource methods

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['plugin:prettier/recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'plugin:@typescript-eslint/recommended'],
-  plugins: ['eslint-plugin-simple-import-sort', 'cypress'],
+  plugins: ['eslint-plugin-simple-import-sort', 'import', 'cypress'],
   rules: {
     // we use jsx-runtime automatic
     "react/jsx-uses-react": "off",
@@ -12,6 +12,9 @@ module.exports = {
     'prefer-const': ['error', { destructuring: 'all' }],
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
+    'import/newline-after-import': 'error',
+    'import/first': 'error',
+    'import/no-duplicates': 'error',
     curly: ['error', 'multi-line', 'consistent'],
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.8",

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -2,10 +2,6 @@
 
 This package provides a convenient interface to query the [MagicBell](https://magicbell.com) API. Note that as some methods depend on your secret key, this SDK is not to be used in browsers.
 
-> **Note**
->
-> This package is in early release and is subject to change. TypeScript is supported, but api responses are untyped at the moment. We'll add types before we reach v1.0.0.
-
 ## Requirements
 
 Node 14 or higher.

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -63,6 +63,7 @@
     "axios": "^0.27.2",
     "axios-retry": "^3.3.1",
     "eventsource": "^2.0.2",
+    "json-schema-to-ts": "2.6.0",
     "qs": "^6.11.0",
     "tsx": "^3.9.0"
   }

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -136,6 +136,7 @@ export class Client {
       normalizeHeaders({
         'User-Agent': this.#userAgent,
         'Idempotency-Key': options.idempotencyKey || this.#getDefaultIdempotencyKey(method, options.maxRetries),
+        'Accept-Version': 'v2',
         'X-MAGICBELL-API-KEY': options.apiKey,
         'X-MAGICBELL-API-SECRET': options.apiSecret,
         'X-MAGICBELL-CLIENT-ID': this.#clientId,

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -146,6 +146,7 @@ export class Client {
         'X-MAGICBELL-USER-HMAC':
           options.userHmac || computeUserKey(options.apiSecret, options.userExternalId || options.userEmail),
       }),
+      true,
     );
   }
 

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -4,7 +4,7 @@ import { computeUserKey } from './lib/crypto';
 import { getClientId, getClientUserAgent, getUserAgent } from './lib/env';
 import { createError } from './lib/error';
 import { normalizeHeaders } from './lib/headers';
-import { Logger } from './lib/log';
+import { Logger, toCurl } from './lib/log';
 import { compact, hasOwn, joinAnd, sleep, uuid4 } from './lib/utils';
 import { createListener } from './listen';
 import { isOptionsHash } from './options';
@@ -104,6 +104,9 @@ export class Client {
           response = res;
         })
         .catch((e) => {
+          const curl = toCurl({ method, baseURL: requestOptions.host, url: path, data, params, headers });
+          this.#logger.error(`${e.message}: ${curl}`);
+
           error = e;
           response = e.response;
         });

--- a/packages/magicbell/src/lib/error.ts
+++ b/packages/magicbell/src/lib/error.ts
@@ -40,9 +40,9 @@ type ErrorConfig = {
 
 /**
  * BaseError is the base error from which all other more specific errors derive.
- * Specifically for errors returned from Stripe's REST API.
+ * Specifically for errors returned from REST API.
  */
-export class BaseError extends Error {
+class BaseError extends Error {
   name: string;
   message: string;
   type?: string;

--- a/packages/magicbell/src/lib/log.ts
+++ b/packages/magicbell/src/lib/log.ts
@@ -1,6 +1,9 @@
+import { AxiosRequestConfig } from 'axios';
+
 const colors = {
   reset: '\x1b[0m',
   magenta: '\x1b[35m',
+  red: '\x1b[31m',
 };
 
 export function emitWarning(message) {
@@ -20,4 +23,32 @@ export class Logger {
     // eslint-disable-next-line no-console
     console.log(`${colors.reset}${colors.magenta}magicbell:${colors.reset} ${message}`);
   }
+
+  error(message) {
+    if (!this.active) return;
+
+    // eslint-disable-next-line no-console
+    console.error(`${colors.reset}${colors.red}magicbell:${colors.reset} ${message}`);
+  }
+}
+
+function mask(str: string) {
+  if (__DEV__) return str;
+  return `${str.slice(0, 4)}…${str.slice(-4)}`;
+}
+
+const secrets = /secret|token|key|password/i;
+function isSecret(key: string) {
+  return secrets.test(key);
+}
+
+export function toCurl({ method, baseURL, url, data, headers }: AxiosRequestConfig) {
+  return [
+    `curl -X ${method.toUpperCase()}`,
+    `${baseURL}/${url.replace(/^\//, '')}`,
+    Object.entries(headers)
+      .map(([key, value]) => `-H '${key}: ${isSecret(key) ? mask(String(value)) : value}'`)
+      .join(' '),
+    data && `-d '${JSON.stringify(data)}'`,
+  ].join(' ');
 }

--- a/packages/magicbell/src/lib/utils.ts
+++ b/packages/magicbell/src/lib/utils.ts
@@ -27,7 +27,7 @@ export function isObject(value) {
   return value && typeof value === 'object';
 }
 
-export function compact(obj: Record<string, unknown>) {
+export function compact(obj: Record<string, unknown>, dropEmptyString = false) {
   if (typeof obj !== 'object') {
     throw new Error('Argument must be an object');
   }
@@ -35,6 +35,7 @@ export function compact(obj: Record<string, unknown>) {
   const result = {};
   for (const key of Object.keys(obj)) {
     if (obj[key] == null) continue;
+    if (dropEmptyString && obj[key] === '') continue;
     result[key] = obj[key];
   }
 

--- a/packages/magicbell/src/listen.ts
+++ b/packages/magicbell/src/listen.ts
@@ -41,7 +41,9 @@ type IterableEventSource<TNode> = {
   forEach(cb: (node: TNode, index: number) => void | boolean | Promise<void | boolean>): Promise<void>;
 };
 
-export function createListener(client: InstanceType<typeof Client>, args: { sseHost?: string } = {}) {
+export type Listener = (options?: RequestOptions) => IterableEventSource<Event>;
+
+export function createListener(client: InstanceType<typeof Client>, args: { sseHost?: string } = {}): Listener {
   let eventSource: EventSource;
   let channels: string;
   let lastEvent: string;

--- a/packages/magicbell/src/method.ts
+++ b/packages/magicbell/src/method.ts
@@ -107,7 +107,10 @@ export function normalizeArgs({
     );
   }
 
-  let dataInQuery = method === 'GET' || method === 'DELETE';
+  // Note, DELETE requests should have data in the params, but our `subscriptions.delete`
+  //   endpoint reads it from the body. Other delete requests don't have data, so this seems
+  //   to be the best solution for now.
+  let dataInQuery = method === 'GET'; // || method === 'DELETE';
 
   // We have a few POST methods using query data instead of body data.
   if (method === 'POST' && isForcedQueryParams(dataFromArgs)) {

--- a/packages/magicbell/src/method.ts
+++ b/packages/magicbell/src/method.ts
@@ -34,8 +34,10 @@ function isForcedQueryParams(object) {
   return true;
 }
 
-function getUrl(path: string, params: Record<string, string>) {
-  return path.replace(/{([\s\S]+?)}/g, ($0, $1) => encodeURIComponent(params[$1] || ''));
+function getUrl(path: string, params: Record<string, string>, options = { encode: true }) {
+  return path.replace(/{([\s\S]+?)}/g, ($0, $1) =>
+    options.encode ? encodeURIComponent(params[$1] || '') : params[$1] || '',
+  );
 }
 
 function extractUrlParams(path: string) {
@@ -93,7 +95,8 @@ export function normalizeArgs({
     return urlData;
   }, {});
 
-  const url = getUrl(path, urlData);
+  // We don't encode atm because the backend doesn't support that in PUT /users/email:user@domain.com
+  const url = getUrl(path, urlData, { encode: false });
   const dataFromArgs = getDataFromArgs(argsCopy);
   const options = getOptionsFromArgs(argsCopy);
 

--- a/packages/magicbell/src/resource.test.ts
+++ b/packages/magicbell/src/resource.test.ts
@@ -129,11 +129,12 @@ test('methods dont put categories and topics in query params if they hold object
   expect(spy.lastRequest.url.searchParams.get('topics[]')).toEqual(null);
 
   await fakeResource.post({ categories: ['comments'] });
-  expect(await spy.lastRequest.json()).toEqual({ fake: {} });
+
+  expect(await spy.lastRequest.text()).toEqual('');
   expect(spy.lastRequest.url.searchParams.get('categories[]')).toEqual('comments');
 
   await fakeResource.post({ topics: ['issue.3'] });
-  expect(await spy.lastRequest.json()).toEqual({ fake: {} });
+  expect(await spy.lastRequest.text()).toEqual('');
   expect(spy.lastRequest.url.searchParams.get('topics[]')).toEqual('issue.3');
 });
 

--- a/packages/magicbell/src/resource.ts
+++ b/packages/magicbell/src/resource.ts
@@ -1,4 +1,13 @@
 import { Client } from './client';
+import { joinUrlSegments } from './lib/utils';
+import { IterablePromise, normalizeArgs } from './method';
+import { autoPaginate } from './paginate';
+
+type ResourceRequestOptions = {
+  method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH';
+  path?: string;
+  paged?: boolean;
+};
 
 export class Resource {
   path: string;
@@ -8,5 +17,47 @@ export class Resource {
 
   constructor(client: InstanceType<typeof Client>) {
     this.client = client;
+  }
+
+  request<TData = any>(
+    options: ResourceRequestOptions & { paged: true },
+    ...args: (string | Record<string, unknown>)[]
+  ): IterablePromise<TData>;
+
+  request<TData = any>(
+    options: ResourceRequestOptions & { paged?: false | never },
+    ...args: (string | Record<string, unknown>)[]
+  ): Promise<TData>;
+
+  request({ method, paged, path: tplPath }: ResourceRequestOptions, ...args: (string | Record<string, unknown>)[]) {
+    const { path, data, params, options } = normalizeArgs({
+      path: joinUrlSegments(this.path, tplPath),
+      method,
+      args,
+    });
+
+    const makeRequest = ({ data, params }) => {
+      const entity = this.entity || this.path;
+      data = data ? { [entity]: data } : data;
+
+      return this.client
+        .request({ method, path, data, params }, options)
+        .then((response) => response[entity] || response);
+    };
+
+    if (paged) {
+      return autoPaginate(makeRequest, {
+        data,
+        params,
+      });
+    }
+
+    return makeRequest({ data, params });
+  }
+
+  assertFeatureFlag(flag: string) {
+    if (!this.client.hasFlag(flag)) {
+      throw new Error(`This is a beta feature, please enable it by providing the "${flag}" feature flag.`);
+    }
   }
 }

--- a/packages/magicbell/src/resources/imports.ts
+++ b/packages/magicbell/src/resources/imports.ts
@@ -18,16 +18,30 @@ export class Imports extends Resource {
    * Send a request to start the import of a list of users. The import allows the
    * creation of slack connections as well.
    *
+   * @param options - override client request options.
+   * @returns
+   **/
+  create(options?: RequestOptions): Promise<CreateImportsResponse>;
+
+  /**
+   * Send a request to start the import of a list of users. The import allows the
+   * creation of slack connections as well.
+   *
    * @param data
    * @param options - override client request options.
    * @returns
    **/
-  create(data: CreateImportsPayload, options?: RequestOptions): Promise<CreateImportsResponse> {
+  create(data: CreateImportsPayload, options?: RequestOptions): Promise<CreateImportsResponse>;
+
+  create(
+    dataOrOptions: CreateImportsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<CreateImportsResponse> {
     return this.request(
       {
         method: 'POST',
       },
-      data,
+      dataOrOptions,
       options,
     );
   }

--- a/packages/magicbell/src/resources/imports.ts
+++ b/packages/magicbell/src/resources/imports.ts
@@ -1,25 +1,53 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
 import { Resource } from '../resource';
+import * as schemas from '../schemas/imports';
+import { type RequestOptions } from '../types';
+
+type CreateImportsResponse = FromSchema<typeof schemas.CreateImportsResponseSchema>;
+type CreateImportsPayload = FromSchema<typeof schemas.CreateImportsPayloadSchema>;
+type GetImportsResponse = FromSchema<typeof schemas.GetImportsResponseSchema>;
 
 export class Imports extends Resource {
   path = 'imports';
   entity = 'import';
 
   /**
-   * Create a user import
+   * Send a request to start the import of a list of users. The import allows the
+   * creation of slack connections as well.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  create = createMethod({
-    id: 'imports-create',
-    method: 'POST',
-  });
+  create(data: CreateImportsPayload, options?: RequestOptions): Promise<CreateImportsResponse> {
+    return this.request(
+      {
+        method: 'POST',
+      },
+      data,
+      options,
+    );
+  }
 
   /**
-   * Get a user import
+   * Send a request to query the status & errors of the import.
+   *
+   * @param importId - ID of the import.
+   *   The ID of the import is returned when the import is created.
+   * @param options - override client request options.
+   * @returns
    **/
-  get = createMethod({
-    id: 'imports-get',
-    method: 'GET',
-    path: '{import_id}',
-  });
+  get(importId: string, options?: RequestOptions): Promise<GetImportsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        path: '{import_id}',
+      },
+      importId,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/notification-preferences.ts
+++ b/packages/magicbell/src/resources/notification-preferences.ts
@@ -35,6 +35,15 @@ export class NotificationPreferences extends Resource {
    * Update a user's notification preferences. These preferences will be applied only
    * to channels you enabled for your project.
    *
+   * @param options - override client request options.
+   * @returns
+   **/
+  update(options?: RequestOptions): Promise<UpdateNotificationPreferencesResponse>;
+
+  /**
+   * Update a user's notification preferences. These preferences will be applied only
+   * to channels you enabled for your project.
+   *
    * @param data
    * @param options - override client request options.
    * @returns
@@ -42,12 +51,17 @@ export class NotificationPreferences extends Resource {
   update(
     data: UpdateNotificationPreferencesPayload,
     options?: RequestOptions,
+  ): Promise<UpdateNotificationPreferencesResponse>;
+
+  update(
+    dataOrOptions: UpdateNotificationPreferencesPayload | RequestOptions,
+    options?: RequestOptions,
   ): Promise<UpdateNotificationPreferencesResponse> {
     return this.request(
       {
         method: 'PUT',
       },
-      data,
+      dataOrOptions,
       options,
     );
   }

--- a/packages/magicbell/src/resources/notification-preferences.ts
+++ b/packages/magicbell/src/resources/notification-preferences.ts
@@ -1,24 +1,54 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
 import { Resource } from '../resource';
+import * as schemas from '../schemas/notification-preferences';
+import { type RequestOptions } from '../types';
+
+type GetNotificationPreferencesResponse = FromSchema<typeof schemas.GetNotificationPreferencesResponseSchema>;
+type UpdateNotificationPreferencesResponse = FromSchema<typeof schemas.UpdateNotificationPreferencesResponseSchema>;
+type UpdateNotificationPreferencesPayload = FromSchema<typeof schemas.UpdateNotificationPreferencesPayloadSchema>;
 
 export class NotificationPreferences extends Resource {
   path = 'notification_preferences';
   entity = 'notification_preferences';
 
   /**
-   * Fetch user notification preferences
+   * Fetch a user's notification preferences. If a user does not disable a channel
+   * explicitly, we would send notifications through that channel as long as your
+   * project is enabled.
+   *
+   * @param options - override client request options.
+   * @returns
    **/
-  get = createMethod({
-    id: 'notification-preferences-get',
-    method: 'GET',
-  });
+  get(options?: RequestOptions): Promise<GetNotificationPreferencesResponse> {
+    return this.request(
+      {
+        method: 'GET',
+      },
+      options,
+    );
+  }
 
   /**
-   * Update user notification preferences
+   * Update a user's notification preferences. These preferences will be applied only
+   * to channels you enabled for your project.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  update = createMethod({
-    id: 'notification-preferences-update',
-    method: 'PUT',
-  });
+  update(
+    data: UpdateNotificationPreferencesPayload,
+    options?: RequestOptions,
+  ): Promise<UpdateNotificationPreferencesResponse> {
+    return this.request(
+      {
+        method: 'PUT',
+      },
+      data,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/notifications.ts
+++ b/packages/magicbell/src/resources/notifications.ts
@@ -1,97 +1,276 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { type IterablePromise } from '../method';
 import { Resource } from '../resource';
+import * as schemas from '../schemas/notifications';
+import { type RequestOptions } from '../types';
+
+type CreateNotificationsResponse = FromSchema<typeof schemas.CreateNotificationsResponseSchema>;
+type CreateNotificationsPayload = FromSchema<typeof schemas.CreateNotificationsPayloadSchema>;
+type ListNotificationsResponse = FromSchema<typeof schemas.ListNotificationsResponseSchema>;
+type ListNotificationsPayload = FromSchema<typeof schemas.ListNotificationsPayloadSchema>;
+type GetNotificationsResponse = FromSchema<typeof schemas.GetNotificationsResponseSchema>;
+type MarkAllReadNotificationsPayload = FromSchema<typeof schemas.MarkAllReadNotificationsPayloadSchema>;
+type MarkAllSeenNotificationsPayload = FromSchema<typeof schemas.MarkAllSeenNotificationsPayloadSchema>;
 
 export class Notifications extends Resource {
   path = 'notifications';
   entity = 'notification';
 
   /**
-   * Create notifications
+   * Send a notification to one or multiple users. You can identify users by their
+   * email address or by an external_id.
+   *
+   * You don't have to import your users into MagicBell. If a user does not exist
+   * we'll create it automatically.
+   *
+   * You can send user attributes like first_name, custom_attributes, and more when
+   * creating a notification.
+   *
+   * The new notification will be shown in the notification inbox of each recipient
+   * in real-time. It will also be delivered to each recipient through all channels
+   * you have enabled for your MagicBell project.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  create = createMethod({
-    id: 'notifications-create',
-    method: 'POST',
-  });
+  create(data: CreateNotificationsPayload, options?: RequestOptions): Promise<CreateNotificationsResponse> {
+    return this.request(
+      {
+        method: 'POST',
+      },
+      data,
+      options,
+    );
+  }
 
   /**
-   * Fetch notifications
+   * Fetch a user's notifications. Notifications are sorted in descendent order by
+   * the sent_at timestamp.
+   *
+   * @param options - override client request options.
+   * @returns
    **/
-  list = createMethod({
-    id: 'notifications-list',
-    method: 'GET',
-    type: 'list',
-  });
+  list(options?: RequestOptions): IterablePromise<ListNotificationsResponse>;
 
   /**
-   * Fetch a notification
+   * Fetch a user's notifications. Notifications are sorted in descendent order by
+   * the sent_at timestamp.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  get = createMethod({
-    id: 'notifications-get',
-    method: 'GET',
-    path: '{notification_id}',
-  });
+  list(data: ListNotificationsPayload, options?: RequestOptions): IterablePromise<ListNotificationsResponse>;
+
+  list(
+    dataOrOptions: ListNotificationsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): IterablePromise<ListNotificationsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        paged: true,
+      },
+      dataOrOptions,
+      options,
+    );
+  }
 
   /**
-   * Delete a notification
+   * Fetch a user's notification by its ID.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
+   * @returns
    **/
-  delete = createMethod({
-    id: 'notifications-delete',
-    method: 'DELETE',
-    path: '{notification_id}',
-  });
+  get(notificationId: string, options?: RequestOptions): Promise<GetNotificationsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        path: '{notification_id}',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Mark a notification as read
+   * Delete a user's notification by its ID. The notification is deleted immediately
+   * and removed from the user's notification inbox in real-time.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
    **/
-  markAsRead = createMethod({
-    id: 'notifications-mark-as-read',
-    method: 'POST',
-    path: '{notification_id}/read',
-  });
+  delete(notificationId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: '{notification_id}',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Mark a notification as unread
+   * Mark a user notification as read. The notification will be automatically marked
+   * as seen, too.
+   *
+   * The new state will be reflected in the user's notification inbox in real-time.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
    **/
-  markAsUnread = createMethod({
-    id: 'notifications-mark-as-unread',
-    method: 'POST',
-    path: '{notification_id}/unread',
-  });
+  markAsRead(notificationId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'POST',
+        path: '{notification_id}/read',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Archive a notification
+   * Mark a user notification as unread. The new state will be reflected in the
+   * user's notification inbox in real-time.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
    **/
-  archive = createMethod({
-    id: 'notifications-archive',
-    method: 'POST',
-    path: '{notification_id}/archive',
-  });
+  markAsUnread(notificationId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'POST',
+        path: '{notification_id}/unread',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Unarchive a notification
+   * Mark a user notification as archived.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
    **/
-  unarchive = createMethod({
-    id: 'notifications-unarchive',
-    method: 'DELETE',
-    path: '{notification_id}/archive',
-  });
+  archive(notificationId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'POST',
+        path: '{notification_id}/archive',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Mark all notifications as read
+   * Mark a user notification as unarchived.
+   *
+   * @param notificationId - ID of the user notification.
+   *   The ID of a user notification can be obtained from the "Fetch user
+   *   notifications" API endpoint or from push events sent to the MagicBell React
+   *   library.
+   *
+   * @param options - override client request options.
    **/
-  markAllRead = createMethod({
-    id: 'notifications-mark-all-read',
-    method: 'POST',
-    path: 'read',
-  });
+  unarchive(notificationId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: '{notification_id}/archive',
+      },
+      notificationId,
+      options,
+    );
+  }
 
   /**
-   * Mark all notifications as seen
+   * Mark all notifications of a user as read. When you call this endpoint, the
+   * notification inboxes of this user will be updated in real-time.
+   *
+   * @param options - override client request options.
    **/
-  markAllSeen = createMethod({
-    id: 'notifications-mark-all-seen',
-    method: 'POST',
-    path: 'seen',
-  });
+  markAllRead(options?: RequestOptions): Promise<void>;
+
+  /**
+   * Mark all notifications of a user as read. When you call this endpoint, the
+   * notification inboxes of this user will be updated in real-time.
+   *
+   * @param data
+   * @param options - override client request options.
+   **/
+  markAllRead(data: MarkAllReadNotificationsPayload, options?: RequestOptions): Promise<void>;
+
+  markAllRead(
+    dataOrOptions: MarkAllReadNotificationsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<void> {
+    return this.request(
+      {
+        method: 'POST',
+        path: 'read',
+      },
+      dataOrOptions,
+      options,
+    );
+  }
+
+  /**
+   * Mark all notifications of a user as seen. When you call this endpoint, the
+   * notification inboxes of this user will be updated in real-time.
+   *
+   * @param options - override client request options.
+   **/
+  markAllSeen(options?: RequestOptions): Promise<void>;
+
+  /**
+   * Mark all notifications of a user as seen. When you call this endpoint, the
+   * notification inboxes of this user will be updated in real-time.
+   *
+   * @param data
+   * @param options - override client request options.
+   **/
+  markAllSeen(data: MarkAllSeenNotificationsPayload, options?: RequestOptions): Promise<void>;
+
+  markAllSeen(
+    dataOrOptions: MarkAllSeenNotificationsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<void> {
+    return this.request(
+      {
+        method: 'POST',
+        path: 'seen',
+      },
+      dataOrOptions,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/push-subscriptions.ts
+++ b/packages/magicbell/src/resources/push-subscriptions.ts
@@ -1,27 +1,61 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
 import { Resource } from '../resource';
+import * as schemas from '../schemas/push-subscriptions';
+import { type RequestOptions } from '../types';
+
+type CreatePushSubscriptionsResponse = FromSchema<typeof schemas.CreatePushSubscriptionsResponseSchema>;
+type CreatePushSubscriptionsPayload = FromSchema<typeof schemas.CreatePushSubscriptionsPayloadSchema>;
 
 export class PushSubscriptions extends Resource {
   path = 'push_subscriptions';
   entity = 'push_subscription';
 
   /**
-   * Register a device
+   * Register a device token for push notifications.
+   *
+   * Please keep in mind that mobile push notifications will be delivered to this
+   * device only if the channel is configured and enabled.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
    **/
-  create = createMethod({
-    id: 'push-subscriptions-create',
-    method: 'POST',
-    beta: true,
-  });
+  create(data: CreatePushSubscriptionsPayload, options?: RequestOptions): Promise<CreatePushSubscriptionsResponse> {
+    this.assertFeatureFlag('push-subscriptions-create');
+
+    return this.request(
+      {
+        method: 'POST',
+      },
+      data,
+      options,
+    );
+  }
 
   /**
-   * Unregister a device
+   * Remove the subscription of a device to mobile push notifications. The device
+   * will be discarded immediately.
+   *
+   * @param deviceToken - Token of the device you want to remove
+   * @param options - override client request options.
+   *
+   * @beta
    **/
-  delete = createMethod({
-    id: 'push-subscriptions-delete',
-    method: 'DELETE',
-    path: '{device_token}',
-    beta: true,
-  });
+  delete(deviceToken: string, options?: RequestOptions): Promise<void> {
+    this.assertFeatureFlag('push-subscriptions-delete');
+
+    return this.request(
+      {
+        method: 'DELETE',
+        path: '{device_token}',
+      },
+      deviceToken,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/subscriptions.ts
+++ b/packages/magicbell/src/resources/subscriptions.ts
@@ -13,7 +13,6 @@ type CreateSubscriptionsPayload = FromSchema<typeof schemas.CreateSubscriptionsP
 type UnsubscribeSubscriptionsResponse = FromSchema<typeof schemas.UnsubscribeSubscriptionsResponseSchema>;
 type UnsubscribeSubscriptionsPayload = FromSchema<typeof schemas.UnsubscribeSubscriptionsPayloadSchema>;
 type GetSubscriptionsResponse = FromSchema<typeof schemas.GetSubscriptionsResponseSchema>;
-type GetSubscriptionsPayload = FromSchema<typeof schemas.GetSubscriptionsPayloadSchema>;
 type DeleteSubscriptionsPayload = FromSchema<typeof schemas.DeleteSubscriptionsPayloadSchema>;
 
 export class Subscriptions extends Resource {
@@ -58,16 +57,7 @@ export class Subscriptions extends Resource {
   /**
    * Unusbscribe a user from a particular topic (and optional categories).
    *
-   * @param topic
-   * @param options - override client request options.
-   * @returns
-   **/
-  unsubscribe(topic: string, options?: RequestOptions): Promise<UnsubscribeSubscriptionsResponse>;
-
-  /**
-   * Unusbscribe a user from a particular topic (and optional categories).
-   *
-   * @param topic
+   * @param topic - The topic for which we'd like to filter topic subscriptions.
    * @param data
    * @param options - override client request options.
    * @returns
@@ -76,12 +66,6 @@ export class Subscriptions extends Resource {
     topic: string,
     data: UnsubscribeSubscriptionsPayload,
     options?: RequestOptions,
-  ): Promise<UnsubscribeSubscriptionsResponse>;
-
-  unsubscribe(
-    topic: string,
-    dataOrOptions: UnsubscribeSubscriptionsPayload | RequestOptions,
-    options?: RequestOptions,
   ): Promise<UnsubscribeSubscriptionsResponse> {
     return this.request(
       {
@@ -89,7 +73,7 @@ export class Subscriptions extends Resource {
         path: '{topic}/unsubscribe',
       },
       topic,
-      dataOrOptions,
+      data,
       options,
     );
   }
@@ -97,34 +81,17 @@ export class Subscriptions extends Resource {
   /**
    * Show a user's subscription status for a particular topic and categories.
    *
-   * @param topic
+   * @param topic - The topic for which we'd like to filter topic subscriptions.
    * @param options - override client request options.
    * @returns
    **/
-  get(topic: string, options?: RequestOptions): Promise<GetSubscriptionsResponse>;
-
-  /**
-   * Show a user's subscription status for a particular topic and categories.
-   *
-   * @param topic
-   * @param data
-   * @param options - override client request options.
-   * @returns
-   **/
-  get(topic: string, data: GetSubscriptionsPayload, options?: RequestOptions): Promise<GetSubscriptionsResponse>;
-
-  get(
-    topic: string,
-    dataOrOptions: GetSubscriptionsPayload | RequestOptions,
-    options?: RequestOptions,
-  ): Promise<GetSubscriptionsResponse> {
+  get(topic: string, options?: RequestOptions): Promise<GetSubscriptionsResponse> {
     return this.request(
       {
         method: 'GET',
         path: '{topic}',
       },
       topic,
-      dataOrOptions,
       options,
     );
   }
@@ -132,7 +99,7 @@ export class Subscriptions extends Resource {
   /**
    * Delete topic subscription(s)
    *
-   * @param topic
+   * @param topic - The topic for which we'd like to filter topic subscriptions.
    * @param options - override client request options.
    **/
   delete(topic: string, options?: RequestOptions): Promise<void>;
@@ -140,7 +107,7 @@ export class Subscriptions extends Resource {
   /**
    * Delete topic subscription(s)
    *
-   * @param topic
+   * @param topic - The topic for which we'd like to filter topic subscriptions.
    * @param data
    * @param options - override client request options.
    **/

--- a/packages/magicbell/src/resources/subscriptions.ts
+++ b/packages/magicbell/src/resources/subscriptions.ts
@@ -1,52 +1,164 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { type IterablePromise } from '../method';
 import { Resource } from '../resource';
+import * as schemas from '../schemas/subscriptions';
+import { type RequestOptions } from '../types';
+
+type ListSubscriptionsResponse = FromSchema<typeof schemas.ListSubscriptionsResponseSchema>;
+type CreateSubscriptionsResponse = FromSchema<typeof schemas.CreateSubscriptionsResponseSchema>;
+type CreateSubscriptionsPayload = FromSchema<typeof schemas.CreateSubscriptionsPayloadSchema>;
+type UnsubscribeSubscriptionsResponse = FromSchema<typeof schemas.UnsubscribeSubscriptionsResponseSchema>;
+type UnsubscribeSubscriptionsPayload = FromSchema<typeof schemas.UnsubscribeSubscriptionsPayloadSchema>;
+type GetSubscriptionsResponse = FromSchema<typeof schemas.GetSubscriptionsResponseSchema>;
+type GetSubscriptionsPayload = FromSchema<typeof schemas.GetSubscriptionsPayloadSchema>;
+type DeleteSubscriptionsPayload = FromSchema<typeof schemas.DeleteSubscriptionsPayloadSchema>;
 
 export class Subscriptions extends Resource {
   path = 'subscriptions';
   entity = 'subscription';
 
   /**
-   * List subscriptions
+   * List a user's subscriptions status for all topics and categories.
+   *
+   * @param options - override client request options.
+   * @returns
    **/
-  list = createMethod({
-    id: 'subscriptions-list',
-    method: 'GET',
-    type: 'list',
-  });
+  list(options?: RequestOptions): IterablePromise<ListSubscriptionsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        paged: true,
+      },
+      options,
+    );
+  }
 
   /**
-   * Create a topic subscription
+   * Set a user's subscription status to subscribed for a particular topic (and
+   * optional categories). If the user previously unsubscribed, the user will be
+   * resubscribed.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  create = createMethod({
-    id: 'subscriptions-create',
-    method: 'POST',
-  });
+  create(data: CreateSubscriptionsPayload, options?: RequestOptions): Promise<CreateSubscriptionsResponse> {
+    return this.request(
+      {
+        method: 'POST',
+      },
+      data,
+      options,
+    );
+  }
 
   /**
-   * Unsubscribe from a topic
+   * Unusbscribe a user from a particular topic (and optional categories).
+   *
+   * @param topic
+   * @param options - override client request options.
+   * @returns
    **/
-  unsubscribe = createMethod({
-    id: 'subscriptions-unsubscribe',
-    method: 'POST',
-    path: '{topic}/unsubscribe',
-  });
+  unsubscribe(topic: string, options?: RequestOptions): Promise<UnsubscribeSubscriptionsResponse>;
 
   /**
-   * Show a topic subscription
+   * Unusbscribe a user from a particular topic (and optional categories).
+   *
+   * @param topic
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  get = createMethod({
-    id: 'subscriptions-get',
-    method: 'GET',
-    path: '{topic}',
-  });
+  unsubscribe(
+    topic: string,
+    data: UnsubscribeSubscriptionsPayload,
+    options?: RequestOptions,
+  ): Promise<UnsubscribeSubscriptionsResponse>;
+
+  unsubscribe(
+    topic: string,
+    dataOrOptions: UnsubscribeSubscriptionsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<UnsubscribeSubscriptionsResponse> {
+    return this.request(
+      {
+        method: 'POST',
+        path: '{topic}/unsubscribe',
+      },
+      topic,
+      dataOrOptions,
+      options,
+    );
+  }
+
+  /**
+   * Show a user's subscription status for a particular topic and categories.
+   *
+   * @param topic
+   * @param options - override client request options.
+   * @returns
+   **/
+  get(topic: string, options?: RequestOptions): Promise<GetSubscriptionsResponse>;
+
+  /**
+   * Show a user's subscription status for a particular topic and categories.
+   *
+   * @param topic
+   * @param data
+   * @param options - override client request options.
+   * @returns
+   **/
+  get(topic: string, data: GetSubscriptionsPayload, options?: RequestOptions): Promise<GetSubscriptionsResponse>;
+
+  get(
+    topic: string,
+    dataOrOptions: GetSubscriptionsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<GetSubscriptionsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        path: '{topic}',
+      },
+      topic,
+      dataOrOptions,
+      options,
+    );
+  }
 
   /**
    * Delete topic subscription(s)
+   *
+   * @param topic
+   * @param options - override client request options.
    **/
-  delete = createMethod({
-    id: 'subscriptions-delete',
-    method: 'DELETE',
-    path: '{topic}',
-  });
+  delete(topic: string, options?: RequestOptions): Promise<void>;
+
+  /**
+   * Delete topic subscription(s)
+   *
+   * @param topic
+   * @param data
+   * @param options - override client request options.
+   **/
+  delete(topic: string, data: DeleteSubscriptionsPayload, options?: RequestOptions): Promise<void>;
+
+  delete(
+    topic: string,
+    dataOrOptions: DeleteSubscriptionsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: '{topic}',
+      },
+      topic,
+      dataOrOptions,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/users.ts
+++ b/packages/magicbell/src/resources/users.ts
@@ -1,70 +1,167 @@
 // This file is generated. Do not update manually!
-import { createMethod } from '../method';
+
+import { type FromSchema } from 'json-schema-to-ts';
+
 import { Resource } from '../resource';
+import * as schemas from '../schemas/users';
+import { type RequestOptions } from '../types';
+
+type CreateUsersResponse = FromSchema<typeof schemas.CreateUsersResponseSchema>;
+type CreateUsersPayload = FromSchema<typeof schemas.CreateUsersPayloadSchema>;
+type UpdateUsersResponse = FromSchema<typeof schemas.UpdateUsersResponseSchema>;
+type UpdateUsersPayload = FromSchema<typeof schemas.UpdateUsersPayloadSchema>;
+type UpdateByEmailUsersResponse = FromSchema<typeof schemas.UpdateByEmailUsersResponseSchema>;
+type UpdateByEmailUsersPayload = FromSchema<typeof schemas.UpdateByEmailUsersPayloadSchema>;
+type UpdateByExternalIdUsersResponse = FromSchema<typeof schemas.UpdateByExternalIdUsersResponseSchema>;
+type UpdateByExternalIdUsersPayload = FromSchema<typeof schemas.UpdateByExternalIdUsersPayloadSchema>;
 
 export class Users extends Resource {
   path = 'users';
   entity = 'user';
 
   /**
-   * Create a user
+   * Create a user. Please note that you must provide the user's email or the
+   * external id so MagicBell can uniquely identify the user.
+   *
+   * The external id, if provided, must be unique to the user.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  create = createMethod({
-    id: 'users-create',
-    method: 'POST',
-  });
+  create(data: CreateUsersPayload, options?: RequestOptions): Promise<CreateUsersResponse> {
+    return this.request(
+      {
+        method: 'POST',
+      },
+      data,
+      options,
+    );
+  }
 
   /**
-   * Update a user
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param userId - The user id is the MagicBell user id. Alternatively, provide an
+   *   id like `email:theusersemail@example.com` or `external_id:theusersexternalid` as
+   *   the user id.
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  update = createMethod({
-    id: 'users-update',
-    method: 'PUT',
-    path: '{user_id}',
-  });
+  update(userId: string, data: UpdateUsersPayload, options?: RequestOptions): Promise<UpdateUsersResponse> {
+    return this.request(
+      {
+        method: 'PUT',
+        path: '{user_id}',
+      },
+      userId,
+      data,
+      options,
+    );
+  }
 
   /**
-   * Delete a user
+   * Immediately deletes a user.
+   *
+   * @param userId - The user id is the MagicBell user id. Alternatively, provide an
+   *   id like `email:theusersemail@example.com` or `external_id:theusersexternalid` as
+   *   the user id.
+   * @param options - override client request options.
    **/
-  delete = createMethod({
-    id: 'users-delete',
-    method: 'DELETE',
-    path: '{user_id}',
-  });
+  delete(userId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: '{user_id}',
+      },
+      userId,
+      options,
+    );
+  }
 
   /**
-   * Update a user by email
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param userEmail
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  updateByEmail = createMethod({
-    id: 'users-update-by-email',
-    method: 'PUT',
-    path: 'email:{user_email}',
-  });
+  updateByEmail(
+    userEmail: string,
+    data: UpdateByEmailUsersPayload,
+    options?: RequestOptions,
+  ): Promise<UpdateByEmailUsersResponse> {
+    return this.request(
+      {
+        method: 'PUT',
+        path: 'email:{user_email}',
+      },
+      userEmail,
+      data,
+      options,
+    );
+  }
 
   /**
-   * Delete a user by email
+   * Immediately deletes a user.
+   *
+   * @param userEmail
+   * @param options - override client request options.
    **/
-  deleteByEmail = createMethod({
-    id: 'users-delete-by-email',
-    method: 'DELETE',
-    path: 'email:{user_email}',
-  });
+  deleteByEmail(userEmail: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: 'email:{user_email}',
+      },
+      userEmail,
+      options,
+    );
+  }
 
   /**
-   * Update a user by external ID
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param externalId
+   * @param data
+   * @param options - override client request options.
+   * @returns
    **/
-  updateByExternalId = createMethod({
-    id: 'users-update-by-external-id',
-    method: 'PUT',
-    path: 'external_id:{external_id}',
-  });
+  updateByExternalId(
+    externalId: string,
+    data: UpdateByExternalIdUsersPayload,
+    options?: RequestOptions,
+  ): Promise<UpdateByExternalIdUsersResponse> {
+    return this.request(
+      {
+        method: 'PUT',
+        path: 'external_id:{external_id}',
+      },
+      externalId,
+      data,
+      options,
+    );
+  }
 
   /**
-   * Delete a user by external ID
+   * Immediately deletes a user.
+   *
+   * @param externalId
+   * @param options - override client request options.
    **/
-  deleteByExternalId = createMethod({
-    id: 'users-delete-by-external-id',
-    method: 'DELETE',
-    path: 'external_id:{external_id}',
-  });
+  deleteByExternalId(externalId: string, options?: RequestOptions): Promise<void> {
+    return this.request(
+      {
+        method: 'DELETE',
+        path: 'external_id:{external_id}',
+      },
+      externalId,
+      options,
+    );
+  }
 }

--- a/packages/magicbell/src/resources/users.ts
+++ b/packages/magicbell/src/resources/users.ts
@@ -25,19 +25,44 @@ export class Users extends Resource {
    *
    * The external id, if provided, must be unique to the user.
    *
+   * @param options - override client request options.
+   * @returns
+   **/
+  create(options?: RequestOptions): Promise<CreateUsersResponse>;
+
+  /**
+   * Create a user. Please note that you must provide the user's email or the
+   * external id so MagicBell can uniquely identify the user.
+   *
+   * The external id, if provided, must be unique to the user.
+   *
    * @param data
    * @param options - override client request options.
    * @returns
    **/
-  create(data: CreateUsersPayload, options?: RequestOptions): Promise<CreateUsersResponse> {
+  create(data: CreateUsersPayload, options?: RequestOptions): Promise<CreateUsersResponse>;
+
+  create(dataOrOptions: CreateUsersPayload | RequestOptions, options?: RequestOptions): Promise<CreateUsersResponse> {
     return this.request(
       {
         method: 'POST',
       },
-      data,
+      dataOrOptions,
       options,
     );
   }
+
+  /**
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param userId - The user id is the MagicBell user id. Alternatively, provide an
+   *   id like `email:theusersemail@example.com` or `external_id:theusersexternalid` as
+   *   the user id.
+   * @param options - override client request options.
+   * @returns
+   **/
+  update(userId: string, options?: RequestOptions): Promise<UpdateUsersResponse>;
 
   /**
    * Update a user's data. If you identify users by their email addresses, you need
@@ -50,14 +75,20 @@ export class Users extends Resource {
    * @param options - override client request options.
    * @returns
    **/
-  update(userId: string, data: UpdateUsersPayload, options?: RequestOptions): Promise<UpdateUsersResponse> {
+  update(userId: string, data: UpdateUsersPayload, options?: RequestOptions): Promise<UpdateUsersResponse>;
+
+  update(
+    userId: string,
+    dataOrOptions: UpdateUsersPayload | RequestOptions,
+    options?: RequestOptions,
+  ): Promise<UpdateUsersResponse> {
     return this.request(
       {
         method: 'PUT',
         path: '{user_id}',
       },
       userId,
-      data,
+      dataOrOptions,
       options,
     );
   }
@@ -86,6 +117,16 @@ export class Users extends Resource {
    * to update the MagicBell data, so this user can still access their notifications.
    *
    * @param userEmail
+   * @param options - override client request options.
+   * @returns
+   **/
+  updateByEmail(userEmail: string, options?: RequestOptions): Promise<UpdateByEmailUsersResponse>;
+
+  /**
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param userEmail
    * @param data
    * @param options - override client request options.
    * @returns
@@ -94,6 +135,12 @@ export class Users extends Resource {
     userEmail: string,
     data: UpdateByEmailUsersPayload,
     options?: RequestOptions,
+  ): Promise<UpdateByEmailUsersResponse>;
+
+  updateByEmail(
+    userEmail: string,
+    dataOrOptions: UpdateByEmailUsersPayload | RequestOptions,
+    options?: RequestOptions,
   ): Promise<UpdateByEmailUsersResponse> {
     return this.request(
       {
@@ -101,7 +148,7 @@ export class Users extends Resource {
         path: 'email:{user_email}',
       },
       userEmail,
-      data,
+      dataOrOptions,
       options,
     );
   }
@@ -128,6 +175,16 @@ export class Users extends Resource {
    * to update the MagicBell data, so this user can still access their notifications.
    *
    * @param externalId
+   * @param options - override client request options.
+   * @returns
+   **/
+  updateByExternalId(externalId: string, options?: RequestOptions): Promise<UpdateByExternalIdUsersResponse>;
+
+  /**
+   * Update a user's data. If you identify users by their email addresses, you need
+   * to update the MagicBell data, so this user can still access their notifications.
+   *
+   * @param externalId
    * @param data
    * @param options - override client request options.
    * @returns
@@ -136,6 +193,12 @@ export class Users extends Resource {
     externalId: string,
     data: UpdateByExternalIdUsersPayload,
     options?: RequestOptions,
+  ): Promise<UpdateByExternalIdUsersResponse>;
+
+  updateByExternalId(
+    externalId: string,
+    dataOrOptions: UpdateByExternalIdUsersPayload | RequestOptions,
+    options?: RequestOptions,
   ): Promise<UpdateByExternalIdUsersResponse> {
     return this.request(
       {
@@ -143,7 +206,7 @@ export class Users extends Resource {
         path: 'external_id:{external_id}',
       },
       externalId,
-      data,
+      dataOrOptions,
       options,
     );
   }

--- a/packages/magicbell/src/schemas/README.md
+++ b/packages/magicbell/src/schemas/README.md
@@ -1,0 +1,1 @@
+Files in this directory are auto generated. Do not make any manual changes within this directory.

--- a/packages/magicbell/src/schemas/imports.ts
+++ b/packages/magicbell/src/schemas/imports.ts
@@ -5,56 +5,63 @@ export const CreateImportsResponseSchema = {
   additionalProperties: false,
 
   properties: {
-    id: {
-      type: 'string',
-      description: 'ID of the import. This is used to query the status of the import.',
-    },
-
-    status: {
-      type: 'string',
-      enum: ['processing'],
-    },
-
-    summary: {
+    notification: {
       type: 'object',
       additionalProperties: false,
 
       properties: {
-        total: {
-          type: 'integer',
-          description: 'The total number of records processed.',
+        id: {
+          type: 'string',
+          description: 'ID of the import. This is used to query the status of the import.',
         },
 
-        failures: {
-          type: 'integer',
-          description: 'The total number of failed records.',
+        status: {
+          type: 'string',
+          enum: ['processing'],
         },
-      },
-    },
 
-    errors: {
-      type: 'array',
+        summary: {
+          type: 'object',
+          additionalProperties: false,
 
-      items: {
-        type: 'object',
-        additionalProperties: false,
+          properties: {
+            total: {
+              type: 'integer',
+              description: 'The total number of records processed.',
+            },
 
-        properties: {
-          email: {
-            type: 'string',
-            description:
-              "The identifying email of the user. If the user's external_id is used as identifier, the email key will not be present",
+            failures: {
+              type: 'integer',
+              description: 'The total number of failed records.',
+            },
           },
+        },
 
-          external_id: {
-            type: 'string',
-            description:
-              "The identifying external_id of the user. If the user's email is used as identifier, the external_id key will not be present",
-          },
+        errors: {
+          type: 'array',
 
-          message: {
-            type: 'string',
-            description: 'The error message indicating why importing the user failed',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+
+            properties: {
+              email: {
+                type: 'string',
+                description:
+                  "The identifying email of the user. If the user's external_id is used as identifier, the email key will not be present",
+              },
+
+              external_id: {
+                type: 'string',
+                description:
+                  "The identifying external_id of the user. If the user's email is used as identifier, the external_id key will not be present",
+              },
+
+              message: {
+                type: 'string',
+                description: 'The error message indicating why importing the user failed',
+              },
+            },
           },
         },
       },
@@ -110,6 +117,11 @@ export const CreateImportsPayloadSchema = {
           phone_numbers: {
             type: 'array',
             description: 'An array of phone numbers to use for sending SMS notifications.',
+
+            items: {
+              type: 'string',
+            },
+
             maxItems: 50,
           },
 

--- a/packages/magicbell/src/schemas/imports.ts
+++ b/packages/magicbell/src/schemas/imports.ts
@@ -1,0 +1,187 @@
+// This file is generated. Do not update manually!
+export const CreateImportsResponseSchema = {
+  title: 'CreateImportsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    id: {
+      type: 'string',
+      description: 'ID of the import. This is used to query the status of the import.',
+    },
+
+    status: {
+      type: 'string',
+      enum: ['processing'],
+    },
+
+    summary: {
+      type: 'object',
+      additionalProperties: false,
+
+      properties: {
+        total: {
+          type: 'integer',
+          description: 'The total number of records processed.',
+        },
+
+        failures: {
+          type: 'integer',
+          description: 'The total number of failed records.',
+        },
+      },
+    },
+
+    errors: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          email: {
+            type: 'string',
+            description:
+              "The identifying email of the user. If the user's external_id is used as identifier, the email key will not be present",
+          },
+
+          external_id: {
+            type: 'string',
+            description:
+              "The identifying external_id of the user. If the user's email is used as identifier, the external_id key will not be present",
+          },
+
+          message: {
+            type: 'string',
+            description: 'The error message indicating why importing the user failed',
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const CreateImportsPayloadSchema = {
+  title: 'CreateImportsPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    users: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+
+        properties: {
+          external_id: {
+            type: 'string',
+            description:
+              "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+            maxLength: 255,
+          },
+
+          email: {
+            type: 'string',
+            description: "The user's email.",
+            maxLength: 255,
+          },
+
+          first_name: {
+            type: 'string',
+            description: "The user's first name.",
+            maxLength: 50,
+          },
+
+          last_name: {
+            type: 'string',
+            description: "The user's last name.",
+            maxLength: 50,
+          },
+
+          custom_attributes: {
+            type: 'object',
+            description:
+              "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+            additionalProperties: true,
+          },
+
+          phone_numbers: {
+            type: 'array',
+            description: 'An array of phone numbers to use for sending SMS notifications.',
+            maxItems: 50,
+          },
+
+          channels: {
+            type: 'object',
+            additionalProperties: true,
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const GetImportsResponseSchema = {
+  title: 'GetImportsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    id: {
+      type: 'string',
+      description: 'ID of the import. This is used to query the status of the import.',
+    },
+
+    status: {
+      type: 'string',
+      enum: ['processing'],
+    },
+
+    summary: {
+      type: 'object',
+      additionalProperties: false,
+
+      properties: {
+        total: {
+          type: 'integer',
+          description: 'The total number of records processed.',
+        },
+
+        failures: {
+          type: 'integer',
+          description: 'The total number of failed records.',
+        },
+      },
+    },
+
+    errors: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          email: {
+            type: 'string',
+            description:
+              "The identifying email of the user. If the user's external_id is used as identifier, the email key will not be present",
+          },
+
+          external_id: {
+            type: 'string',
+            description:
+              "The identifying external_id of the user. If the user's email is used as identifier, the external_id key will not be present",
+          },
+
+          message: {
+            type: 'string',
+            description: 'The error message indicating why importing the user failed',
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/schemas/notification-preferences.ts
+++ b/packages/magicbell/src/schemas/notification-preferences.ts
@@ -1,0 +1,168 @@
+// This file is generated. Do not update manually!
+export const GetNotificationPreferencesResponseSchema = {
+  title: 'GetNotificationPreferencesResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    categories: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          label: {
+            type: 'string',
+            description: 'The label of the category',
+          },
+
+          slug: {
+            type: 'string',
+            description: 'The slug of the category.',
+          },
+
+          channels: {
+            description: 'Preferences for each channel for this category.',
+            type: 'array',
+
+            items: {
+              type: 'object',
+              additionalProperties: false,
+
+              properties: {
+                label: {
+                  type: 'string',
+                  description: 'The label of the channel',
+                },
+
+                slug: {
+                  type: 'string',
+                  description: 'The slug of the channel.',
+                },
+
+                enabled: {
+                  type: 'boolean',
+                  description: 'The current state of the channel.',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const UpdateNotificationPreferencesResponseSchema = {
+  title: 'UpdateNotificationPreferencesResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    categories: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          label: {
+            type: 'string',
+            description: 'The label of the category',
+          },
+
+          slug: {
+            type: 'string',
+            description: 'The slug of the category.',
+          },
+
+          channels: {
+            description: 'Preferences for each channel for this category.',
+            type: 'array',
+
+            items: {
+              type: 'object',
+              additionalProperties: false,
+
+              properties: {
+                label: {
+                  type: 'string',
+                  description: 'The label of the channel',
+                },
+
+                slug: {
+                  type: 'string',
+                  description: 'The slug of the channel.',
+                },
+
+                enabled: {
+                  type: 'boolean',
+                  description: 'The current state of the channel.',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const UpdateNotificationPreferencesPayloadSchema = {
+  title: 'UpdateNotificationPreferencesPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    categories: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          label: {
+            type: 'string',
+            description: 'The label of the category',
+          },
+
+          slug: {
+            type: 'string',
+            description: 'The slug of the category.',
+          },
+
+          channels: {
+            description: 'Preferences for each channel for this category.',
+            type: 'array',
+
+            items: {
+              type: 'object',
+              additionalProperties: false,
+
+              properties: {
+                label: {
+                  type: 'string',
+                  description: 'The label of the channel',
+                },
+
+                slug: {
+                  type: 'string',
+                  description: 'The slug of the channel.',
+                },
+
+                enabled: {
+                  type: 'boolean',
+                  description: 'The current state of the channel.',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/schemas/notifications.ts
+++ b/packages/magicbell/src/schemas/notifications.ts
@@ -8,7 +8,57 @@ export const CreateNotificationsResponseSchema = {
     id: {
       type: 'string',
     },
+
+    title: {
+      type: 'string',
+      description: 'Title of the notification.',
+      nullable: false,
+      maxLength: 255,
+    },
+
+    content: {
+      type: 'string',
+      description:
+        'Content of the notification. If you provide HTML content, the notification inbox will render it correctly. It should not exceed 4MB.',
+      nullable: true,
+    },
+
+    action_url: {
+      type: 'string',
+      format: 'uri',
+      description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+      nullable: true,
+      maxLength: 2048,
+    },
+
+    category: {
+      type: 'string',
+      description: 'Category the notification belongs to. This is useful to allow users to set their preferences.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    topic: {
+      type: 'string',
+      description: 'Topic the notification belongs to. This is useful to create threads.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+      nullable: true,
+      additionalProperties: true,
+    },
+
+    sent_at: {
+      type: 'number',
+    },
   },
+
+  required: ['id', 'title', 'sent_at'],
 } as const;
 
 export const CreateNotificationsPayloadSchema = {
@@ -291,6 +341,10 @@ export const ListNotificationsResponseSchema = {
         additionalProperties: false,
 
         properties: {
+          id: {
+            type: 'string',
+          },
+
           title: {
             type: 'string',
             description: 'Title of the notification.',
@@ -313,47 +367,6 @@ export const ListNotificationsResponseSchema = {
             maxLength: 2048,
           },
 
-          recipients: {
-            description:
-              'Users to send the notification to. You can specify up to 1000 users at once. Use matches to send a notification to everyone.',
-            nullable: false,
-            minItems: 1,
-            maxItems: 1000,
-            type: 'array',
-
-            items: {
-              type: 'object',
-              additionalProperties: true,
-
-              properties: {
-                email: {
-                  type: 'string',
-                  description: "The user's email",
-                },
-
-                external_id: {
-                  type: 'string',
-                  description:
-                    "A unique string that MagicBell can utilize to uniquely identify the user. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
-                },
-
-                matches: {
-                  type: 'string',
-                  description:
-                    'An SQL-like expression to match users by their stored attributes. Set it to "*" to send a notification to all users.',
-                },
-              },
-            },
-          },
-
-          custom_attributes: {
-            type: 'object',
-            description:
-              'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
-            nullable: true,
-            additionalProperties: true,
-          },
-
           category: {
             type: 'string',
             description:
@@ -369,144 +382,82 @@ export const ListNotificationsResponseSchema = {
             maxLength: 100,
           },
 
-          overrides: {
+          custom_attributes: {
             type: 'object',
-            description: 'Optional overrides to configure notifications per target destination.',
+            description:
+              'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
             nullable: true,
+            additionalProperties: true,
+          },
+
+          sent_at: {
+            type: 'number',
+          },
+
+          seen_at: {
+            type: 'number',
+          },
+
+          read_at: {
+            type: 'number',
+          },
+
+          archived_at: {
+            type: 'number',
+          },
+
+          recipient: {
+            type: 'object',
+            additionalProperties: false,
 
             properties: {
-              channels: {
-                type: 'object',
-                description: 'Overrides for specific channels',
-
-                properties: {
-                  in_app: {
-                    type: 'object',
-
-                    properties: {
-                      title: {
-                        type: 'string',
-                        description: 'Overriden title for this channel',
-                      },
-
-                      content: {
-                        type: 'string',
-                        description: 'Overriden content for this channel',
-                      },
-
-                      action_url: {
-                        type: 'string',
-                        description: 'Overriden action_url for this channel',
-                      },
-                    },
-                  },
-
-                  email: {
-                    type: 'object',
-
-                    properties: {
-                      title: {
-                        type: 'string',
-                        description: 'Overriden title for this channel',
-                      },
-
-                      content: {
-                        type: 'string',
-                        description: 'Overriden content for this channel',
-                      },
-
-                      action_url: {
-                        type: 'string',
-                        description: 'Overriden action_url for this channel',
-                      },
-                    },
-                  },
-
-                  web_push: {
-                    type: 'object',
-
-                    properties: {
-                      title: {
-                        type: 'string',
-                        description: 'Overriden title for this channel',
-                      },
-
-                      content: {
-                        type: 'string',
-                        description: 'Overriden content for this channel',
-                      },
-
-                      action_url: {
-                        type: 'string',
-                        description: 'Overriden action_url for this channel',
-                      },
-                    },
-                  },
-
-                  mobile_push: {
-                    type: 'object',
-
-                    properties: {
-                      title: {
-                        type: 'string',
-                        description: 'Overriden title for this channel',
-                      },
-
-                      content: {
-                        type: 'string',
-                        description: 'Overriden content for this channel',
-                      },
-
-                      action_url: {
-                        type: 'string',
-                        description: 'Overriden action_url for this channel',
-                      },
-                    },
-                  },
-                },
+              external_id: {
+                type: 'string',
+                description:
+                  "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+                maxLength: 255,
               },
 
-              providers: {
+              email: {
+                type: 'string',
+                description: "The user's email.",
+                maxLength: 255,
+              },
+
+              first_name: {
+                type: 'string',
+                description: "The user's first name.",
+                maxLength: 50,
+              },
+
+              last_name: {
+                type: 'string',
+                description: "The user's last name.",
+                maxLength: 50,
+              },
+
+              custom_attributes: {
                 type: 'object',
-                description: 'Overrides for specific providers (Sendgrid, Postmark, APNs, etc)',
+                description:
+                  "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+                additionalProperties: true,
+              },
 
-                properties: {
-                  sendgrid: {
-                    type: 'object',
-                    description:
-                      'Set of key-value pairs that you can pass on to Sendgrid. Applied only if it is configured for your project.',
-                  },
+              phone_numbers: {
+                type: 'array',
+                description: 'An array of phone numbers to use for sending SMS notifications.',
 
-                  mailgun: {
-                    type: 'object',
-                    description:
-                      'Set of key-value pairs that you can pass on to Mailgun. Applied only if it is configured for your project.',
-                  },
-
-                  postmark: {
-                    type: 'object',
-                    description:
-                      'Set of key-value pairs that you can pass on to Postmark. Applied only if it is configured for your project.',
-                  },
-
-                  ios: {
-                    type: 'object',
-                    description:
-                      'Set of key-value pairs that you can pass on to APNs. Applied only if it is configured for your project.',
-                  },
-
-                  android: {
-                    type: 'object',
-                    description:
-                      'Set of key-value pairs that you can pass on to FCM. Applied only if it is configured for your project.',
-                  },
+                items: {
+                  type: 'string',
                 },
+
+                maxItems: 50,
               },
             },
           },
         },
 
-        required: ['title', 'recipients'],
+        required: ['id', 'title', 'sent_at'],
       },
     },
   },

--- a/packages/magicbell/src/schemas/notifications.ts
+++ b/packages/magicbell/src/schemas/notifications.ts
@@ -1,0 +1,905 @@
+// This file is generated. Do not update manually!
+export const CreateNotificationsResponseSchema = {
+  title: 'CreateNotificationsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    id: {
+      type: 'string',
+    },
+  },
+} as const;
+
+export const CreateNotificationsPayloadSchema = {
+  title: 'CreateNotificationsPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    title: {
+      type: 'string',
+      description: 'Title of the notification.',
+      nullable: false,
+      maxLength: 255,
+    },
+
+    content: {
+      type: 'string',
+      description:
+        'Content of the notification. If you provide HTML content, the notification inbox will render it correctly. It should not exceed 4MB.',
+      nullable: true,
+    },
+
+    action_url: {
+      type: 'string',
+      format: 'uri',
+      description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+      nullable: true,
+      maxLength: 2048,
+    },
+
+    recipients: {
+      description:
+        'Users to send the notification to. You can specify up to 1000 users at once. Use matches to send a notification to everyone.',
+      nullable: false,
+      minItems: 1,
+      maxItems: 1000,
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: true,
+
+        properties: {
+          email: {
+            type: 'string',
+            description: "The user's email",
+          },
+
+          external_id: {
+            type: 'string',
+            description:
+              "A unique string that MagicBell can utilize to uniquely identify the user. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+          },
+
+          matches: {
+            type: 'string',
+            description:
+              'An SQL-like expression to match users by their stored attributes. Set it to "*" to send a notification to all users.',
+          },
+        },
+      },
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+      nullable: true,
+      additionalProperties: true,
+    },
+
+    category: {
+      type: 'string',
+      description: 'Category the notification belongs to. This is useful to allow users to set their preferences.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    topic: {
+      type: 'string',
+      description: 'Topic the notification belongs to. This is useful to create threads.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    overrides: {
+      type: 'object',
+      description: 'Optional overrides to configure notifications per target destination.',
+      nullable: true,
+
+      properties: {
+        channels: {
+          type: 'object',
+          description: 'Overrides for specific channels',
+
+          properties: {
+            in_app: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            email: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            web_push: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            mobile_push: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+          },
+        },
+
+        providers: {
+          type: 'object',
+          description: 'Overrides for specific providers (Sendgrid, Postmark, APNs, etc)',
+
+          properties: {
+            sendgrid: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Sendgrid. Applied only if it is configured for your project.',
+            },
+
+            mailgun: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Mailgun. Applied only if it is configured for your project.',
+            },
+
+            postmark: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Postmark. Applied only if it is configured for your project.',
+            },
+
+            ios: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to APNs. Applied only if it is configured for your project.',
+            },
+
+            android: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to FCM. Applied only if it is configured for your project.',
+            },
+          },
+        },
+      },
+    },
+  },
+
+  required: ['title', 'recipients'],
+} as const;
+
+export const ListNotificationsResponseSchema = {
+  title: 'ListNotificationsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    project_id: {
+      type: 'integer',
+      description: 'ID of the MagicBell project these notifications belong to.',
+      readOnly: true,
+    },
+
+    total: {
+      type: 'integer',
+      description: 'Total number of notifications for this user.',
+      readOnly: true,
+    },
+
+    per_page: {
+      type: 'integer',
+      description: 'Number of notifications per page.',
+      readOnly: true,
+    },
+
+    total_pages: {
+      type: 'integer',
+      description: 'Total number of pages.',
+      readOnly: true,
+    },
+
+    current_page: {
+      type: 'integer',
+      description: 'Number of the page returned.',
+      readOnly: true,
+    },
+
+    unseen_count: {
+      type: 'integer',
+      description: 'Number of unseen notifications. Any filters applied affect this number.',
+      readOnly: true,
+    },
+
+    unread_count: {
+      type: 'integer',
+      description: 'Number of unread notifications. Any filters applied affect this number.',
+      readOnly: true,
+    },
+
+    notifications: {
+      type: 'array',
+      description: 'List of all notifications in the current page',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Title of the notification.',
+            nullable: false,
+            maxLength: 255,
+          },
+
+          content: {
+            type: 'string',
+            description:
+              'Content of the notification. If you provide HTML content, the notification inbox will render it correctly. It should not exceed 4MB.',
+            nullable: true,
+          },
+
+          action_url: {
+            type: 'string',
+            format: 'uri',
+            description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+            nullable: true,
+            maxLength: 2048,
+          },
+
+          recipients: {
+            description:
+              'Users to send the notification to. You can specify up to 1000 users at once. Use matches to send a notification to everyone.',
+            nullable: false,
+            minItems: 1,
+            maxItems: 1000,
+            type: 'array',
+
+            items: {
+              type: 'object',
+              additionalProperties: true,
+
+              properties: {
+                email: {
+                  type: 'string',
+                  description: "The user's email",
+                },
+
+                external_id: {
+                  type: 'string',
+                  description:
+                    "A unique string that MagicBell can utilize to uniquely identify the user. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+                },
+
+                matches: {
+                  type: 'string',
+                  description:
+                    'An SQL-like expression to match users by their stored attributes. Set it to "*" to send a notification to all users.',
+                },
+              },
+            },
+          },
+
+          custom_attributes: {
+            type: 'object',
+            description:
+              'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+            nullable: true,
+            additionalProperties: true,
+          },
+
+          category: {
+            type: 'string',
+            description:
+              'Category the notification belongs to. This is useful to allow users to set their preferences.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          topic: {
+            type: 'string',
+            description: 'Topic the notification belongs to. This is useful to create threads.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          overrides: {
+            type: 'object',
+            description: 'Optional overrides to configure notifications per target destination.',
+            nullable: true,
+
+            properties: {
+              channels: {
+                type: 'object',
+                description: 'Overrides for specific channels',
+
+                properties: {
+                  in_app: {
+                    type: 'object',
+
+                    properties: {
+                      title: {
+                        type: 'string',
+                        description: 'Overriden title for this channel',
+                      },
+
+                      content: {
+                        type: 'string',
+                        description: 'Overriden content for this channel',
+                      },
+
+                      action_url: {
+                        type: 'string',
+                        description: 'Overriden action_url for this channel',
+                      },
+                    },
+                  },
+
+                  email: {
+                    type: 'object',
+
+                    properties: {
+                      title: {
+                        type: 'string',
+                        description: 'Overriden title for this channel',
+                      },
+
+                      content: {
+                        type: 'string',
+                        description: 'Overriden content for this channel',
+                      },
+
+                      action_url: {
+                        type: 'string',
+                        description: 'Overriden action_url for this channel',
+                      },
+                    },
+                  },
+
+                  web_push: {
+                    type: 'object',
+
+                    properties: {
+                      title: {
+                        type: 'string',
+                        description: 'Overriden title for this channel',
+                      },
+
+                      content: {
+                        type: 'string',
+                        description: 'Overriden content for this channel',
+                      },
+
+                      action_url: {
+                        type: 'string',
+                        description: 'Overriden action_url for this channel',
+                      },
+                    },
+                  },
+
+                  mobile_push: {
+                    type: 'object',
+
+                    properties: {
+                      title: {
+                        type: 'string',
+                        description: 'Overriden title for this channel',
+                      },
+
+                      content: {
+                        type: 'string',
+                        description: 'Overriden content for this channel',
+                      },
+
+                      action_url: {
+                        type: 'string',
+                        description: 'Overriden action_url for this channel',
+                      },
+                    },
+                  },
+                },
+              },
+
+              providers: {
+                type: 'object',
+                description: 'Overrides for specific providers (Sendgrid, Postmark, APNs, etc)',
+
+                properties: {
+                  sendgrid: {
+                    type: 'object',
+                    description:
+                      'Set of key-value pairs that you can pass on to Sendgrid. Applied only if it is configured for your project.',
+                  },
+
+                  mailgun: {
+                    type: 'object',
+                    description:
+                      'Set of key-value pairs that you can pass on to Mailgun. Applied only if it is configured for your project.',
+                  },
+
+                  postmark: {
+                    type: 'object',
+                    description:
+                      'Set of key-value pairs that you can pass on to Postmark. Applied only if it is configured for your project.',
+                  },
+
+                  ios: {
+                    type: 'object',
+                    description:
+                      'Set of key-value pairs that you can pass on to APNs. Applied only if it is configured for your project.',
+                  },
+
+                  android: {
+                    type: 'object',
+                    description:
+                      'Set of key-value pairs that you can pass on to FCM. Applied only if it is configured for your project.',
+                  },
+                },
+              },
+            },
+          },
+        },
+
+        required: ['title', 'recipients'],
+      },
+    },
+  },
+} as const;
+
+export const ListNotificationsPayloadSchema = {
+  title: 'ListNotificationsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    perPage: {
+      title: 'perPage',
+      description:
+        'A limit on the number of notifications to be returned. It can range between 1 and 100, and the default is 15.',
+      type: 'integer',
+    },
+
+    page: {
+      title: 'page',
+      description: 'A parameter for use in pagination. Defaults to 1.',
+      type: 'integer',
+    },
+
+    read: {
+      title: 'read',
+      description:
+        'A filter on the notifications based on the read state. If false, only unread notifications will be returned. Defaults to null.',
+      type: 'boolean',
+    },
+
+    seen: {
+      title: 'seen',
+      description:
+        'A filter on the notifications based on the seen state. If false, only unseen notifications will be returned. Defaults to null.',
+      type: 'boolean',
+    },
+
+    archived: {
+      title: 'archived',
+      description:
+        'A filter on the notifications based on the archived state. If false, only unarchived notifications will be returned. Defaults to null.',
+      type: 'boolean',
+    },
+
+    categories: {
+      title: 'categories',
+      description:
+        'A filter on the notifications based on the category. If you want to get uncategorized notifications, use the "uncategorized" value.\nThe value can be either an array of strings or a comma-separated string.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    topics: {
+      title: 'topics',
+      description: 'A filter on the notifications based on the topic.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;
+
+export const GetNotificationsResponseSchema = {
+  title: 'GetNotificationsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    title: {
+      type: 'string',
+      description: 'Title of the notification.',
+      nullable: false,
+      maxLength: 255,
+    },
+
+    content: {
+      type: 'string',
+      description:
+        'Content of the notification. If you provide HTML content, the notification inbox will render it correctly. It should not exceed 4MB.',
+      nullable: true,
+    },
+
+    action_url: {
+      type: 'string',
+      format: 'uri',
+      description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+      nullable: true,
+      maxLength: 2048,
+    },
+
+    recipients: {
+      description:
+        'Users to send the notification to. You can specify up to 1000 users at once. Use matches to send a notification to everyone.',
+      nullable: false,
+      minItems: 1,
+      maxItems: 1000,
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: true,
+
+        properties: {
+          email: {
+            type: 'string',
+            description: "The user's email",
+          },
+
+          external_id: {
+            type: 'string',
+            description:
+              "A unique string that MagicBell can utilize to uniquely identify the user. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+          },
+
+          matches: {
+            type: 'string',
+            description:
+              'An SQL-like expression to match users by their stored attributes. Set it to "*" to send a notification to all users.',
+          },
+        },
+      },
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+      nullable: true,
+      additionalProperties: true,
+    },
+
+    category: {
+      type: 'string',
+      description: 'Category the notification belongs to. This is useful to allow users to set their preferences.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    topic: {
+      type: 'string',
+      description: 'Topic the notification belongs to. This is useful to create threads.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    overrides: {
+      type: 'object',
+      description: 'Optional overrides to configure notifications per target destination.',
+      nullable: true,
+
+      properties: {
+        channels: {
+          type: 'object',
+          description: 'Overrides for specific channels',
+
+          properties: {
+            in_app: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            email: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            web_push: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+
+            mobile_push: {
+              type: 'object',
+
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Overriden title for this channel',
+                },
+
+                content: {
+                  type: 'string',
+                  description: 'Overriden content for this channel',
+                },
+
+                action_url: {
+                  type: 'string',
+                  description: 'Overriden action_url for this channel',
+                },
+              },
+            },
+          },
+        },
+
+        providers: {
+          type: 'object',
+          description: 'Overrides for specific providers (Sendgrid, Postmark, APNs, etc)',
+
+          properties: {
+            sendgrid: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Sendgrid. Applied only if it is configured for your project.',
+            },
+
+            mailgun: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Mailgun. Applied only if it is configured for your project.',
+            },
+
+            postmark: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to Postmark. Applied only if it is configured for your project.',
+            },
+
+            ios: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to APNs. Applied only if it is configured for your project.',
+            },
+
+            android: {
+              type: 'object',
+              description:
+                'Set of key-value pairs that you can pass on to FCM. Applied only if it is configured for your project.',
+            },
+          },
+        },
+      },
+    },
+  },
+
+  required: ['title', 'recipients'],
+} as const;
+
+export const MarkAllReadNotificationsPayloadSchema = {
+  title: 'MarkAllReadNotificationsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    archived: {
+      title: 'archived',
+      description:
+        'A filter on the notifications based on the archived state. Specify false to select unarchived notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    read: {
+      title: 'read',
+      description:
+        'A filter on the notifications based on the read state. Specify false to select unread notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    seen: {
+      title: 'seen',
+      description:
+        'A filter on the notifications based on the seen state. Specify false to select unseen notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    categories: {
+      title: 'categories',
+      description:
+        'A filter on the notifications based on the category. If you want to get uncategorized notifications, use the "uncategorized" value.\nThe value can be either an array of strings or a comma-separated string.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    topics: {
+      title: 'topics',
+      description: 'A filter on the notifications based on the topic.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;
+
+export const MarkAllSeenNotificationsPayloadSchema = {
+  title: 'MarkAllSeenNotificationsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    archived: {
+      title: 'archived',
+      description:
+        'A filter on the notifications based on the archived state. Specify false to select unarchived notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    read: {
+      title: 'read',
+      description:
+        'A filter on the notifications based on the read state. Specify false to select unread notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    seen: {
+      title: 'seen',
+      description:
+        'A filter on the notifications based on the seen state. Specify false to select unseen notifications. Defaults to null.',
+      type: 'boolean',
+    },
+
+    categories: {
+      title: 'categories',
+      description:
+        'A filter on the notifications based on the category. If you want to get uncategorized notifications, use the "uncategorized" value.\nThe value can be either an array of strings or a comma-separated string.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    topics: {
+      title: 'topics',
+      description: 'A filter on the notifications based on the topic.',
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;

--- a/packages/magicbell/src/schemas/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/push-subscriptions.ts
@@ -16,6 +16,10 @@ export const CreatePushSubscriptionsResponseSchema = {
     platform: {
       type: 'string',
     },
+
+    app_bundle_id: {
+      type: 'string',
+    },
   },
 } as const;
 

--- a/packages/magicbell/src/schemas/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/push-subscriptions.ts
@@ -1,0 +1,51 @@
+// This file is generated. Do not update manually!
+export const CreatePushSubscriptionsResponseSchema = {
+  title: 'CreatePushSubscriptionsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    id: {
+      type: 'string',
+    },
+
+    device_token: {
+      type: 'string',
+    },
+
+    platform: {
+      type: 'string',
+    },
+  },
+} as const;
+
+export const CreatePushSubscriptionsPayloadSchema = {
+  title: 'CreatePushSubscriptionsPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    device_token: {
+      type: 'string',
+      description:
+        'Token that identifies the device. This is usually generated automatically by your app once installed.',
+      maxLength: 255,
+    },
+
+    platform: {
+      type: 'string',
+      description:
+        "The platform where the device token was generated from. This value is used to determine the delivery mechanism for mobile push notifications. Either 'ios', 'android' or 'safari'.",
+      minLength: 3,
+    },
+
+    app_bundle_id: {
+      type: 'string',
+      description:
+        'The bundle ID of your app. This value is used to determine the delivery mechanism for mobile push notifications based on your workflow so that you can link several mobile applications to one project.',
+      maxLength: 155,
+    },
+  },
+
+  required: ['device_token', 'platform'],
+} as const;

--- a/packages/magicbell/src/schemas/subscriptions.ts
+++ b/packages/magicbell/src/schemas/subscriptions.ts
@@ -1,0 +1,265 @@
+// This file is generated. Do not update manually!
+export const ListSubscriptionsResponseSchema = {
+  title: 'ListSubscriptionsResponseSchema',
+  type: 'array',
+
+  items: {
+    type: 'object',
+    additionalProperties: false,
+
+    properties: {
+      categories: {
+        type: 'array',
+        description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+        items: {
+          type: 'object',
+          additionalProperties: false,
+
+          properties: {
+            slug: {
+              type: 'string',
+              description:
+                'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+            },
+
+            reason: {
+              type: 'string',
+              description: 'The reason for the subscription',
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const CreateSubscriptionsResponseSchema = {
+  title: 'CreateSubscriptionsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    subscription: {
+      type: 'object',
+      additionalProperties: false,
+
+      properties: {
+        categories: {
+          type: 'array',
+          description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+          items: {
+            type: 'object',
+            additionalProperties: false,
+
+            properties: {
+              slug: {
+                type: 'string',
+                description:
+                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+              },
+
+              reason: {
+                type: 'string',
+                description: 'The reason for the subscription',
+              },
+
+              status: {
+                type: 'string',
+                description: 'The status of the topic subscription',
+              },
+            },
+          },
+        },
+
+        topic: {
+          type: 'string',
+          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
+        },
+      },
+    },
+  },
+} as const;
+
+export const CreateSubscriptionsPayloadSchema = {
+  title: 'CreateSubscriptionsPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    categories: {
+      type: 'array',
+      description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+          },
+
+          reason: {
+            type: 'string',
+            description: 'The reason for the subscription',
+          },
+        },
+      },
+    },
+
+    topic: {
+      type: 'string',
+      description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
+    },
+  },
+
+  required: ['categories', 'topic'],
+} as const;
+
+export const UnsubscribeSubscriptionsResponseSchema = {
+  title: 'UnsubscribeSubscriptionsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    subscription: {
+      type: 'object',
+      additionalProperties: false,
+
+      properties: {
+        categories: {
+          type: 'array',
+          description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+          items: {
+            type: 'object',
+            additionalProperties: false,
+
+            properties: {
+              slug: {
+                type: 'string',
+                description:
+                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+              },
+
+              reason: {
+                type: 'string',
+                description: 'The reason for the subscription',
+              },
+
+              status: {
+                type: 'string',
+                description: 'The status of the topic subscription',
+              },
+            },
+          },
+        },
+
+        topic: {
+          type: 'string',
+          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
+        },
+      },
+    },
+  },
+} as const;
+
+export const UnsubscribeSubscriptionsPayloadSchema = {
+  title: 'UnsubscribeSubscriptionsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    topic: {
+      title: 'topic',
+      description: "The topic for which we'd like to filter topic subscriptions.",
+      type: 'string',
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;
+
+export const GetSubscriptionsResponseSchema = {
+  title: 'GetSubscriptionsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    subscription: {
+      type: 'object',
+      additionalProperties: false,
+
+      properties: {
+        categories: {
+          type: 'array',
+          description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+          items: {
+            type: 'object',
+            additionalProperties: false,
+
+            properties: {
+              slug: {
+                type: 'string',
+                description:
+                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+              },
+
+              reason: {
+                type: 'string',
+                description: 'The reason for the subscription',
+              },
+
+              status: {
+                type: 'string',
+                description: 'The status of the topic subscription',
+              },
+            },
+          },
+        },
+
+        topic: {
+          type: 'string',
+          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
+        },
+      },
+    },
+  },
+} as const;
+
+export const GetSubscriptionsPayloadSchema = {
+  title: 'GetSubscriptionsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    topic: {
+      title: 'topic',
+      description: "The topic for which we'd like to filter topic subscriptions.",
+      type: 'string',
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;
+
+export const DeleteSubscriptionsPayloadSchema = {
+  title: 'DeleteSubscriptionsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    topic: {
+      title: 'topic',
+      description: "The topic for which we'd like to filter topic subscriptions.",
+      type: 'string',
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;

--- a/packages/magicbell/src/schemas/subscriptions.ts
+++ b/packages/magicbell/src/schemas/subscriptions.ts
@@ -1,31 +1,47 @@
 // This file is generated. Do not update manually!
 export const ListSubscriptionsResponseSchema = {
   title: 'ListSubscriptionsResponseSchema',
-  type: 'array',
+  type: 'object',
+  additionalProperties: false,
 
-  items: {
-    type: 'object',
-    additionalProperties: false,
+  properties: {
+    subscriptions: {
+      type: 'array',
 
-    properties: {
-      categories: {
-        type: 'array',
-        description: 'A list of hashes containing the category slug and the reason for the subscription',
+      items: {
+        type: 'object',
+        additionalProperties: false,
 
-        items: {
-          type: 'object',
-          additionalProperties: false,
+        properties: {
+          topic: {
+            type: 'string',
+          },
 
-          properties: {
-            slug: {
-              type: 'string',
-              description:
-                'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
-            },
+          categories: {
+            type: 'array',
+            description: 'A list of hashes containing the category slug and the reason for the subscription',
 
-            reason: {
-              type: 'string',
-              description: 'The reason for the subscription',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+
+              properties: {
+                slug: {
+                  type: 'string',
+                  description:
+                    'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+                },
+
+                reason: {
+                  type: 'string',
+                  description: 'The reason for the subscription',
+                },
+
+                status: {
+                  type: 'string',
+                  enum: ['subscribed', 'unsubscribed'],
+                },
+              },
             },
           },
         },
@@ -40,44 +56,38 @@ export const CreateSubscriptionsResponseSchema = {
   additionalProperties: false,
 
   properties: {
-    subscription: {
-      type: 'object',
-      additionalProperties: false,
+    categories: {
+      type: 'array',
+      description: 'A list of hashes containing the category slug and the reason for the subscription',
 
-      properties: {
-        categories: {
-          type: 'array',
-          description: 'A list of hashes containing the category slug and the reason for the subscription',
+      items: {
+        type: 'object',
+        additionalProperties: false,
 
-          items: {
-            type: 'object',
-            additionalProperties: false,
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+          },
 
-            properties: {
-              slug: {
-                type: 'string',
-                description:
-                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
-              },
+          reason: {
+            type: 'string',
+            description: 'The reason for the subscription',
+          },
 
-              reason: {
-                type: 'string',
-                description: 'The reason for the subscription',
-              },
-
-              status: {
-                type: 'string',
-                description: 'The status of the topic subscription',
-              },
-            },
+          status: {
+            type: 'string',
+            description: 'The status of the topic subscription',
+            enum: ['subscribed', 'unsubscribed'],
           },
         },
-
-        topic: {
-          type: 'string',
-          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
-        },
       },
+    },
+
+    topic: {
+      type: 'string',
+      description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
     },
   },
 } as const;
@@ -126,44 +136,38 @@ export const UnsubscribeSubscriptionsResponseSchema = {
   additionalProperties: false,
 
   properties: {
-    subscription: {
-      type: 'object',
-      additionalProperties: false,
+    categories: {
+      type: 'array',
+      description: 'A list of hashes containing the category slug and the reason for the subscription',
 
-      properties: {
-        categories: {
-          type: 'array',
-          description: 'A list of hashes containing the category slug and the reason for the subscription',
+      items: {
+        type: 'object',
+        additionalProperties: false,
 
-          items: {
-            type: 'object',
-            additionalProperties: false,
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+          },
 
-            properties: {
-              slug: {
-                type: 'string',
-                description:
-                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
-              },
+          reason: {
+            type: 'string',
+            description: 'The reason for the subscription',
+          },
 
-              reason: {
-                type: 'string',
-                description: 'The reason for the subscription',
-              },
-
-              status: {
-                type: 'string',
-                description: 'The status of the topic subscription',
-              },
-            },
+          status: {
+            type: 'string',
+            description: 'The status of the topic subscription',
+            enum: ['subscribed', 'unsubscribed'],
           },
         },
-
-        topic: {
-          type: 'string',
-          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
-        },
       },
+    },
+
+    topic: {
+      type: 'string',
+      description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
     },
   },
 } as const;
@@ -171,17 +175,34 @@ export const UnsubscribeSubscriptionsResponseSchema = {
 export const UnsubscribeSubscriptionsPayloadSchema = {
   title: 'UnsubscribeSubscriptionsPayloadSchema',
   type: 'object',
+  additionalProperties: false,
 
   properties: {
-    topic: {
-      title: 'topic',
-      description: "The topic for which we'd like to filter topic subscriptions.",
-      type: 'string',
+    categories: {
+      type: 'array',
+      description: 'A list of hashes containing the category slug and the reason for the subscription',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+          },
+
+          reason: {
+            type: 'string',
+            description: 'The reason for the subscription',
+          },
+        },
+      },
     },
   },
 
-  additionalProperties: false,
-  required: [],
+  required: ['categories'],
 } as const;
 
 export const GetSubscriptionsResponseSchema = {
@@ -190,62 +211,40 @@ export const GetSubscriptionsResponseSchema = {
   additionalProperties: false,
 
   properties: {
-    subscription: {
-      type: 'object',
-      additionalProperties: false,
+    categories: {
+      type: 'array',
+      description: 'A list of hashes containing the category slug and the reason for the subscription',
 
-      properties: {
-        categories: {
-          type: 'array',
-          description: 'A list of hashes containing the category slug and the reason for the subscription',
+      items: {
+        type: 'object',
+        additionalProperties: false,
 
-          items: {
-            type: 'object',
-            additionalProperties: false,
-
-            properties: {
-              slug: {
-                type: 'string',
-                description:
-                  'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
-              },
-
-              reason: {
-                type: 'string',
-                description: 'The reason for the subscription',
-              },
-
-              status: {
-                type: 'string',
-                description: 'The status of the topic subscription',
-              },
-            },
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
           },
-        },
 
-        topic: {
-          type: 'string',
-          description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
+          reason: {
+            type: 'string',
+            description: 'The reason for the subscription',
+          },
+
+          status: {
+            type: 'string',
+            description: 'The status of the topic subscription',
+            enum: ['subscribed', 'unsubscribed'],
+          },
         },
       },
     },
-  },
-} as const;
 
-export const GetSubscriptionsPayloadSchema = {
-  title: 'GetSubscriptionsPayloadSchema',
-  type: 'object',
-
-  properties: {
     topic: {
-      title: 'topic',
-      description: "The topic for which we'd like to filter topic subscriptions.",
       type: 'string',
+      description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
     },
   },
-
-  additionalProperties: false,
-  required: [],
 } as const;
 
 export const DeleteSubscriptionsPayloadSchema = {
@@ -253,13 +252,25 @@ export const DeleteSubscriptionsPayloadSchema = {
   type: 'object',
 
   properties: {
-    topic: {
-      title: 'topic',
-      description: "The topic for which we'd like to filter topic subscriptions.",
-      type: 'string',
+    categories: {
+      type: 'array',
+      description:
+        'A list of hashes containing the category slug and the reason for the subscription. Omiting categories deletes all topic subscriptions beloning to the topic.',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          slug: {
+            type: 'string',
+            description:
+              'The slug of the category to be subscribed to. * can also be be specified if the subscription should match all categories',
+          },
+        },
+      },
     },
   },
 
   additionalProperties: false,
-  required: [],
 } as const;

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -1,0 +1,368 @@
+// This file is generated. Do not update manually!
+export const CreateUsersResponseSchema = {
+  title: 'CreateUsersResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const CreateUsersPayloadSchema = {
+  title: 'CreateUsersPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateUsersResponseSchema = {
+  title: 'UpdateUsersResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateUsersPayloadSchema = {
+  title: 'UpdateUsersPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateByEmailUsersResponseSchema = {
+  title: 'UpdateByEmailUsersResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateByEmailUsersPayloadSchema = {
+  title: 'UpdateByEmailUsersPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateByExternalIdUsersResponseSchema = {
+  title: 'UpdateByExternalIdUsersResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;
+
+export const UpdateByExternalIdUsersPayloadSchema = {
+  title: 'UpdateByExternalIdUsersPayloadSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    external_id: {
+      type: 'string',
+      description:
+        "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+      maxLength: 255,
+    },
+
+    email: {
+      type: 'string',
+      description: "The user's email.",
+      maxLength: 255,
+    },
+
+    first_name: {
+      type: 'string',
+      description: "The user's first name.",
+      maxLength: 50,
+    },
+
+    last_name: {
+      type: 'string',
+      description: "The user's last name.",
+      maxLength: 50,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+      additionalProperties: true,
+    },
+
+    phone_numbers: {
+      type: 'array',
+      description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
+    },
+  },
+} as const;

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -40,6 +40,11 @@ export const CreateUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -86,6 +91,11 @@ export const CreateUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -132,6 +142,11 @@ export const UpdateUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -178,6 +193,11 @@ export const UpdateUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -224,6 +244,11 @@ export const UpdateByEmailUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -270,6 +295,11 @@ export const UpdateByEmailUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -316,6 +346,11 @@ export const UpdateByExternalIdUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },
@@ -362,6 +397,11 @@ export const UpdateByExternalIdUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+
+      items: {
+        type: 'string',
+      },
+
       maxItems: 50,
     },
   },

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -19,10 +19,15 @@ export type ClientOptions = {
   features?: Record<string, boolean>;
 };
 
-export type RequestOptions = Pick<
-  ClientOptions,
-  'userEmail' | 'userExternalId' | 'userHmac' | 'idempotencyKey' | 'timeout' | 'maxRetries' | 'maxRetryDelay'
->;
+export type RequestOptions = {
+  userEmail?: string;
+  userExternalId?: string;
+  userHmac?: string;
+  idempotencyKey?: string;
+  timeout?: number;
+  maxRetries?: number;
+  maxRetryDelay?: number;
+};
 
 export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7469,7 +7469,7 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-import@^2.25.3:
+eslint-plugin-import@^2.25.3, eslint-plugin-import@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -10223,6 +10223,15 @@ json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-schema-to-ts@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-2.6.0.tgz#17b1492571509ed0a6ea18dd06f26761a47920fe"
+  integrity sha512-j6x2ZFCN3exmGAaGusxZYB2mvgpy8I8UkkNmN1H6zlq+3mdBwSQMIsB5iAltGlBLWG4aPTYqeIkit4okTI0s7g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ts-algebra "^1.1.1"
+    ts-toolbelt "^9.6.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -14905,6 +14914,13 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-algebra@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-1.1.1.tgz#f7593cabcfd64f9d7211fa4f16ea9719e02461bc"
+  integrity sha512-W43a3/BN0Tp4SgRNERQF/QPVuY1rnHkgCr/fISLY0Ycu05P0NWPYRuViU8JFn+pFZuY6/zp9TgET1fxMzppR/Q==
+  dependencies:
+    ts-toolbelt "^9.6.0"
+
 ts-dedent@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.2.0.tgz#6aa2229d837159bb6d635b6b233002423b91e0b0"
@@ -14929,6 +14945,11 @@ ts-toolbelt@^6.15.1:
   version "6.15.5"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
   integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
+
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
Adds type coverage to all resource methods of [`magicbell`](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell). Type coverage is added by updating the codegen. Thereby types are an extraction from, and in sync with, our [openapi spec](https://github.com/magicbell-io/public/blob/main/openapi/spec/openapi.json).

Part of this pull are a couple of fixes to that spec:

- https://github.com/magicbell-io/public/pull/17
- https://github.com/magicbell-io/public/pull/18
- https://github.com/magicbell-io/public/pull/19
- https://github.com/magicbell-io/public/pull/20
- https://github.com/magicbell-io/public/pull/21
- https://github.com/magicbell-io/public/pull/22

Things you'll find in this change:

- type coverage for all resource methods
- json schemas which are stored under /schemas. These schemas drive our payload & response types with the help of https://github.com/ThomasAribart/json-schema-to-ts
- a removed "beta notice" from the readme, as types were the last blocking thing. Once this is merged, we can run a last test, and push v1 out.
- an added `accept-version: v2` header, so we use the latest version of our preferences api
- failed requests now log a curl command when `debug: true` is provided to the client
- requests no longer include empty headers
- requests no longer include empty wrapping entities in the body

Not so nice changes / findings / solutions:

- we don't encode url entities, as encoded urls are currently unsupported by `users-update-by-email`, the one method requiring it.
- we now place payload data from DELETE requests in the body instead of query params. This is an issue conform HTTP spec, but required by the implementation of our `subscriptions-delete` handler.
- response types are generally missing the `id` field. Adding that will require some big changes in our [openapi spec](https://github.com/magicbell-io/public/blob/main/openapi/spec/openapi.json).