### PR TITLE
fix: ignore `undefined` request arguments

### DIFF
--- a/.changeset/cuddly-knives-shop.md
+++ b/.changeset/cuddly-knives-shop.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+fix: be forgiving about `undefined` arguments

--- a/packages/magicbell/src/method.ts
+++ b/packages/magicbell/src/method.ts
@@ -78,7 +78,7 @@ export function normalizeArgs({
   method: RequestMethod;
   args: (Record<string, unknown> | string)[];
 }) {
-  const argsCopy = [...args];
+  const argsCopy = [...args].filter((x) => x !== undefined);
 
   const urlParams = extractUrlParams(path);
   const urlData = urlParams.reduce((urlData, param) => {


### PR DESCRIPTION
Note that I only filter `undefined` and not `null`. This makes sure we support variable positions for the options object. 

```js
notifications.list({ userEmail: '...' }, undefined)
notifications.list(null, { userEmail: '' })
```