### PR TITLE
Remove null from useBell return type

### DIFF
--- a/packages/react-headless/src/hooks/useBell.ts
+++ b/packages/react-headless/src/hooks/useBell.ts
@@ -17,7 +17,7 @@ interface useBellArgs {
  * @example
  * const { unreadCount, markAllAsSeen } = useBell();
  */
-export default function useBell({ storeId }: useBellArgs = {}): NotificationStore | null {
+export default function useBell({ storeId }: useBellArgs = {}): NotificationStore {
   const store = useNotifications(storeId);
 
   const markAllAsSeen = () => {


### PR DESCRIPTION
Hey! I'm using the `useBell` hook in my application, and TypeScript complains that `unreadCount` (or any other method/variable) doesn't exist if I use destructuring assignment.

As expected, removing the `null` from the `useBell` return type works. It also works if you don't destructure and assign the return to a variable, but since I couldn't find a reason for having the `null` on the docs, I thought this could be a typo.

```ts
//  Property 'unreadCount' does not exist on type 'NotificationStore | null'
const { unreadCount } = useBell();

// Works:
const bell = useBell();
console.log(bell?.unreadCount)
```

Feel free to close my PR if this `null` is needed.