### PR TITLE
fix: declare theme and store props as optional

### DIFF
--- a/.changeset/smart-eyes-fly.md
+++ b/.changeset/smart-eyes-fly.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/embeddable': patch
+---
+
+Declare widget `theme` and `store` props as optional.

--- a/packages/embeddable/src/components/Widget/Widget.tsx
+++ b/packages/embeddable/src/components/Widget/Widget.tsx
@@ -26,10 +26,10 @@ export interface WidgetProps extends FrameContentProps {
   images?: Partial<{
     emptyInboxUrl: string;
   }>;
-  theme: DeepPartial<IMagicBellTheme>;
+  theme?: DeepPartial<IMagicBellTheme>;
   onNewNotification?: MagicBellProps['onNewNotification'];
   defaultIsOpen?: boolean;
-  stores: MagicBellProps['stores'];
+  stores?: MagicBellProps['stores'];
 }
 
 /**


### PR DESCRIPTION
The `theme` and `stores` props are optional, this change makes sure typescript agrees to that.