### PR TITLE
ci: scope playground rebuilds to changes in /packages/playground

### DIFF
--- a/packages/playground/scripts/vercel-ignore-step.sh
+++ b/packages/playground/scripts/vercel-ignore-step.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main" ]]; then
+  echo "✅ Commit to `main`, build can proceed"
+  exit 1;
+
+else
+  git remote add origin "https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git"
+  git fetch origin main
+  git diff --quiet origin/main HEAD -- ../playground
+  CHANGED=$?
+
+  if [[ $CHANGED == 0 ]]; then
+    echo "🛑 Skip build, no changes in /playground"
+    exit 0;
+
+  else
+    echo "✅ Playground changed, let's build"
+    exit 1;
+  fi
+fi


### PR DESCRIPTION
Use a [vercel ignored-build-step](https://vercel.com/docs/concepts/projects/overview#ignored-build-step) to skip playground builds when playground hasn't changed.

This ignores all changes outside of [/packages/playground.](https://github.com/magicbell-io/magicbell-js/tree/main/packages/playground)