### PR TITLE
fix: Initialize stores with effect instead of lazy useState

### DIFF
--- a/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx
+++ b/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx
@@ -71,7 +71,9 @@ export default function MagicBellProvider({
   ...clientSettings
 }: MagicBellProviderProps) {
   useState(() => setupXHR(clientSettings));
-  useState(() => setupStores(stores));
+  useEffect(() => {
+    setupStores(stores);
+  }, []);
 
   const config = useConfig();
 


### PR DESCRIPTION
Hey there 👋 

I wanted to contribute a small fix which lead to a warning during development when using react-headless

When [`setupStores`](https://github.com/magicbell-io/magicbell-js/blob/main/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx#L74) is called a call to [`setState`](https://github.com/magicbell-io/magicbell-js/blob/main/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx#L44) is triggered which leads to bad setState warning

```
Warning: Cannot update a component (`RealtimeListener`) while rendering a different component (`Unknown`). To locate the bad setState() call inside `Unknown`
```

By using `useEffect` instead the order of the lazy `useState` seems to be correct again.