### PR TITLE
fix: wait for `markAsRead` before opening action url

### DIFF
--- a/.changeset/curvy-adults-repeat.md
+++ b/.changeset/curvy-adults-repeat.md
@@ -1,0 +1,7 @@
+---
+'@magicbell/magicbell-react': patch
+---
+
+fix: wait for `markAsRead` before opening notification `action_url`.
+
+This fixes a race-condition where the page reload and fetching new notifications is faster than marking the notification as read, which would result in showing the notification as 'unread' upon page (re)load.

--- a/packages/react/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
+++ b/packages/react/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { openActionUrl } from '../ClickableNotification/eventHandlers';
 import NotificationInbox, { NotificationInboxProps } from '../NotificationInbox';
 import { NotificationListItem } from '../NotificationList/NotificationList';
 import { PopoverPlacement, PopperOptions } from '../Popover';
@@ -42,8 +41,6 @@ export default function FloatingNotificationInbox({
 }: Props) {
   const handleNotificationClick = (notification) => {
     if (onNotificationClick) onNotificationClick(notification);
-    else openActionUrl(notification);
-
     if (closeOnNotificationClick) toggle?.();
   };
 

--- a/packages/react/tests/src/components/ClickableNotification/ClickableNotification.spec.tsx
+++ b/packages/react/tests/src/components/ClickableNotification/ClickableNotification.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -132,8 +132,9 @@ test('opens the action url in the same tab', async () => {
 
   await userEvent.click(notification);
 
-  expect(global.open).toHaveBeenCalledTimes(1);
-  expect(global.open).toHaveBeenCalledWith('https://example.com', '_self');
+  await waitFor(() => {
+    expect(global.open).toHaveBeenCalledWith('https://example.com', '_self');
+  });
 });
 
 test('does not invoke the click handler when clicking on a link in the notification', async () => {


### PR DESCRIPTION
Wait for `markAsRead` before opening notification `action_url`.

This fixes a race-condition where the page reload and fetching new notifications is faster than marking the notification as read, which would result in showing the notification as 'unread' upon page (re)load.