### PR TITLE
feat: make category labels translatable (#53

### DIFF
--- a/.changeset/strong-dolphins-own.md
+++ b/.changeset/strong-dolphins-own.md
@@ -1,0 +1,26 @@
+---
+'@magicbell/magicbell-react': minor
+---
+
+feat: category labels in the preferences pane are now translatable.
+
+```typescript jsx
+const customLocale = {
+  name: 'en',
+  translations: {
+    preferences: {
+      categories: { // mapping from slug > label
+        billing: 'My Billing',
+      },
+    },
+  },
+};
+
+function MyComponent() {
+  return (
+    <MagicBell locale={customLocale} apiKey={MAGICBELL_API_KEY} userEmail="john@example.com" />
+      {(props) => <FloatingNotificationInbox height={450} {...props} />}
+    </MagicBell>
+  );
+}
+```

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -4,10 +4,21 @@ import MagicBell, { FloatingNotificationInbox } from '@magicbell/magicbell-react
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
+const customLocale = {
+  name: 'en',
+  translations: {
+    preferences: {
+      categories: {
+        billing: 'My Billing',
+      },
+    },
+  },
+};
+
 function App() {
   return (
     <div id="target">
-      <MagicBell apiKey="api-key-here" userEmail="stephan@magicbell.io" userKey="...">
+      <MagicBell apiKey="api-key-here" userEmail="stephan@magicbell.io" userKey="..." locale={customLocale}>
         {(props) => <FloatingNotificationInbox height={450} {...props} />}
       </MagicBell>
     </div>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -577,6 +577,34 @@ ReactDOM.render(
 );
 ```
 
+## Custom translations
+
+All elements in the inbox can be translated by providing a `translations` object to the `MagicBell` component. This includes category labels:
+
+```typescript jsx
+const customLocale = {
+  name: 'en',
+  translations: {
+    header: {
+      title: 'Notifications',
+    },
+    preferences: {
+      categories: { // mapping from slug > label
+        billing: 'My Billing',
+      },
+    },
+  },
+};
+
+function MyComponent() {
+  return (
+    <MagicBell locale={customLocale} apiKey={MAGICBELL_API_KEY} userEmail="john@example.com" />
+      {(props) => <FloatingNotificationInbox height={450} {...props} />}
+    </MagicBell>
+  );
+}
+```
+
 ## The notification model
 
 The `Notification` class can be imported from `@magicbell/magicbell-react`. It implements this interface.

--- a/packages/react/src/components/UserPreferencesPanel/CategoryPreferences.tsx
+++ b/packages/react/src/components/UserPreferencesPanel/CategoryPreferences.tsx
@@ -1,6 +1,7 @@
 import { IRemoteNotificationPreferences, useNotificationPreferences } from '@magicbell/react-headless';
 import React from 'react';
 
+import { useTranslate } from '../../context/TranslationsContext';
 import ToggleInput from './ToggleInput';
 
 type CategoryChannelPreference = IRemoteNotificationPreferences['categories'][number];
@@ -14,6 +15,7 @@ interface CategoryPreferencesProps {
 export default function CategoryPreferences({ category, onChange }: CategoryPreferencesProps) {
   const preferences = useNotificationPreferences();
   const channels = category.channels;
+  const t = useTranslate();
 
   const updatePreferences = async (channel: ChannelPreference, channelEnabled: boolean) => {
     const preference: CategoryChannelPreference = {
@@ -34,7 +36,7 @@ export default function CategoryPreferences({ category, onChange }: CategoryPref
 
   return (
     <>
-      <div>{category.label}</div>
+      <div>{t(`preferences.categories.${category.slug}`, category.label)}</div>
       {channels.map((channel) => (
         <div key={channel.slug}>
           <ToggleInput


### PR DESCRIPTION
category labels in the preferences pane are now translatable.

```typescript jsx
const customLocale = {
  name: 'en',
  translations: {
    preferences: {
      categories: { // mapping from slug > label
        billing: 'My Billing',
      },
    },
  },
};

function MyComponent() {
  return (
    <MagicBell locale={customLocale} apiKey={MAGICBELL_API_KEY} userEmail="john@example.com" />
      {(props) => <FloatingNotificationInbox height={450} {...props} />}
    </MagicBell>
  );
}
```