### PR TITLE
feat: add close method to realtime listener (#56

### DIFF
--- a/.changeset/odd-rats-hug.md
+++ b/.changeset/odd-rats-hug.md
@@ -1,0 +1,18 @@
+---
+'magicbell': minor
+---
+
+feat: add close method to realtime listener
+
+```ts
+const listener = magicbell.listen();
+
+listener.forEach((notification) => {
+  console.log(notification.data.id);
+});
+
+// stop listening after 5 seconds
+setTimeout(() => {
+  listener.close();
+}, 5_000);
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -831,6 +831,21 @@ magicbell.listen().forEach((notification) => {
 });
 ```
 
+**close** - stop listening. This will close the connection and stop the auto-reconnect.
+
+```js
+const listener = magicbell.listen();
+
+listener.forEach((notification) => {
+  console.log(notification.data.id);
+});
+
+// stop listening after 5 seconds
+setTimeout(() => {
+  listener.close();
+}, 5_000);
+```
+
 ### Realtime events
 
 The following events are emitted by the client:

--- a/packages/magicbell/src/listen.test.ts
+++ b/packages/magicbell/src/listen.test.ts
@@ -8,6 +8,8 @@ import { createListener } from './listen';
 const server = setupMockServer();
 let listen;
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 beforeEach(async () => {
   server.intercept('all', (req) => {
     if (req.url.pathname === '/config') return { ws: { channel: 'project:1:channel:2' } };
@@ -72,4 +74,20 @@ test('return false in forEach helper closes listener', async () => {
   expect(events).toHaveLength(2);
   expect(events[0].data).toEqual({ id: 1 });
   expect(events[1].data).toEqual({ id: 2 });
+});
+
+test('can close listener', async () => {
+  const events = [];
+
+  const iterator = listen();
+  setTimeout(() => {
+    iterator.close();
+  }, 100);
+
+  for await (const event of iterator) {
+    events.push(event);
+    await sleep(1000);
+  }
+
+  expect(events).toHaveLength(1);
 });

--- a/packages/magicbell/src/listen.ts
+++ b/packages/magicbell/src/listen.ts
@@ -145,12 +145,15 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
 
     const dispose = () => {
       eventSource.close();
+      // push to resolve async iterators, return for sync ones
+      pushMessage({ done: true, value: undefined });
       return { done: true, value: undefined };
     };
 
     const forEach = makeForEach(asyncIteratorNext, dispose);
     const autoPaginationMethods = {
       forEach,
+      close: dispose,
 
       next: asyncIteratorNext,
       return: dispose,


### PR DESCRIPTION
This adds a close method to the realtime listener, so we can stop listening for events.

```ts
const listener = magicbell.listen();

listener.forEach((notification) => {
  console.log(notification.data.id);
});

// stop listening after 5 seconds
setTimeout(() => {
  listener.close();
}, 5_000);
```

and async iterator:

```ts
const listener = magicbell.listen();

setTimeout(() => {
  listener.close();
}, 5_000);

for await (let notification of listener) {
  console.log(notification.data.id);
};

// continues here after 5 sec
```
