### PR TITLE
feat: support custom request headers

### DIFF
--- a/.changeset/small-pianos-remain.md
+++ b/.changeset/small-pianos-remain.md
@@ -1,0 +1,18 @@
+---
+'magicbell': minor
+---
+
+feat: support custom request headers
+
+Custom request headers can be used to decorate requests for logs and metrics or for example to instruct proxy servers.
+
+```ts
+import MagicBell from 'magicbell';
+
+const magicbell = new MagicBell({
+  apiKey: 'my-api-key',
+  headers: {
+    'X-Custom-Header': 'foo',
+  },
+});
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -210,6 +210,10 @@ const magicbell = new MagicBell({
 
   A map of feature flags to get access to beta features. See [Feature Flags](#feature-flags) for more information.
 
+- **headers** _Record<string, string>_
+
+  Custom headers you wish to include on the request, for example to instruct your proxy servers or to decorate your logs.
+
 ### Configuring Timeout
 
 Timeout can be set globally via the config object:

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -142,10 +142,15 @@ export class Client {
 
     return compact(
       normalizeHeaders({
+        // overridable default headers
+        'Accept-Version': 'v2',
+        'Idempotency-Key': options.idempotencyKey || this.#getDefaultIdempotencyKey(method, options.maxRetries),
+
+        // user-provided headers
+        ...this.#options.headers,
+
         // can't set user-agent in the browser, see https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
         'User-Agent': isBrowser ? null : this.#userAgent,
-        'Idempotency-Key': options.idempotencyKey || this.#getDefaultIdempotencyKey(method, options.maxRetries),
-        'Accept-Version': 'v2',
         'X-MAGICBELL-API-KEY': options.apiKey,
         'X-MAGICBELL-API-SECRET': options.apiSecret,
         'X-MAGICBELL-CLIENT-USER-AGENT': this.#clientUserAgent,

--- a/packages/magicbell/src/options.ts
+++ b/packages/magicbell/src/options.ts
@@ -16,6 +16,7 @@ const optionValidators: Record<keyof ClientOptions, (value: unknown) => boolean>
   appInfo: isObject,
   debug: isBoolean,
   features: isObject,
+  headers: isObject,
 };
 
 export function isOptionsHash(object) {

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -17,6 +17,7 @@ export type ClientOptions = {
   telemetry?: boolean;
   debug?: boolean;
   features?: Record<string, boolean>;
+  headers?: Record<string, string>;
 };
 
 export type RequestOptions = {


### PR DESCRIPTION
Custom request headers can be used to decorate requests for logs and metrics or for example to instruct proxy servers.

```ts
import MagicBell from 'magicbell';

const magicbell = new MagicBell({
  apiKey: 'my-api-key',
  headers: {
    'X-Custom-Header': 'foo',
  },
});
```