### PR TITLE
fix: ensure query params are (typed in) snake_case (#68

### DIFF
--- a/.changeset/nervous-boxes-worry.md
+++ b/.changeset/nervous-boxes-worry.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+fix typescript issue that showed arguments in camelCase vs snake_case.

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -72,7 +72,7 @@ export function getRootPathMethods(document: OpenAPI.Document, path: string) {
       const params = urlParams.map((param) => {
         const source = operation.parameters.find((x) => x.in === 'path' && x.name === param);
         return {
-          title: camelCase(param),
+          title: param,
           description: source?.description,
           type: 'string',
           ...source?.schema,
@@ -83,7 +83,7 @@ export function getRootPathMethods(document: OpenAPI.Document, path: string) {
       const query = (operation.parameters || [])
         .filter((x) => x.in === 'query')
         .map((x) => ({
-          title: camelCase(x.name),
+          title: x.name,
           description: x.description,
           ...x.schema,
         }));

--- a/packages/magicbell/scripts/generate-resources.ts
+++ b/packages/magicbell/scripts/generate-resources.ts
@@ -50,11 +50,13 @@ function createMethod(method: Method) {
   const payloadType = method.data?.title.replace(/Schema$/, '');
   const payloadOrOptionsType = `${payloadType} | RequestOptions`;
 
-  const pathParams = method.params.map((param) => b.param(param.title, 'string'));
+  const pathParams = method.params.map((param) => b.param(camelCase(param.title), 'string'));
   const dataParam = b.param('data', payloadType);
   const optionsParam = b.param('options', 'RequestOptions', true);
 
-  const paramsDocs = method.params.map((x) => `@param ${x.title} ${x.description ? `- ${x.description}` : ''}`);
+  const paramsDocs = method.params.map(
+    (x) => `@param ${camelCase(x.title)} ${x.description ? `- ${x.description}` : ''}`,
+  );
 
   const fullSignatureComment = b.commentBlock(
     method.description || method.summary,
@@ -124,7 +126,7 @@ function createMethod(method: Method) {
                 method.path && b.objectProperty('path', method.path),
                 paged && b.objectProperty('paged', true),
               ),
-              ...method.params.map((param) => 'title' in param && builders.identifier(param.title)),
+              ...method.params.map((param) => 'title' in param && builders.identifier(camelCase(param.title))),
               method.data && builders.identifier(hasOverloads ? 'dataOrOptions' : 'data'),
               builders.identifier('options'),
             ),

--- a/packages/magicbell/src/schemas/notifications.ts
+++ b/packages/magicbell/src/schemas/notifications.ts
@@ -489,8 +489,8 @@ export const ListNotificationsPayloadSchema = {
   type: 'object',
 
   properties: {
-    perPage: {
-      title: 'perPage',
+    per_page: {
+      title: 'per_page',
       description:
         'A limit on the number of notifications to be returned. It can range between 1 and 100, and the default is 15.',
       type: 'integer',

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -213,40 +213,40 @@ export const ListUsersPayloadSchema = {
       type: 'integer',
     },
 
-    perPage: {
-      title: 'perPage',
+    per_page: {
+      title: 'per_page',
       description: 'The number of items per page. Defaults to 20.',
       type: 'integer',
     },
 
-    'lastSeenAt:before': {
-      title: 'lastSeenAt:before',
+    'last_seen_at:before': {
+      title: 'last_seen_at:before',
       description: 'Fetch users seen before the specified `last_seen_at` timestamp. Please send it in RFC3339 format',
       type: 'string',
     },
 
-    'lastSeenAt:after': {
-      title: 'lastSeenAt:after',
+    'last_seen_at:after': {
+      title: 'last_seen_at:after',
       description: 'Fetch users seen after the specified `last_seen_at` timestamp. Please send it in RFC3339 format',
       type: 'string',
     },
 
-    'lastNotifiedAt:before': {
-      title: 'lastNotifiedAt:before',
+    'last_notified_at:before': {
+      title: 'last_notified_at:before',
       description:
         'Fetch users last notified before the specified `last_notified_at` timestamp. Please send it in RFC3339 format',
       type: 'string',
     },
 
-    'lastNotifiedAt:after': {
-      title: 'lastNotifiedAt:after',
+    'last_notified_at:after': {
+      title: 'last_notified_at:after',
       description:
         'Fetch users last notified after the specified `last_notified_at` timestamp. Please send it in RFC3339 format',
       type: 'string',
     },
 
-    orderBy: {
-      title: 'orderBy',
+    order_by: {
+      title: 'order_by',
       description: 'Use it to order the returned list of users. Defaults to `created_at,DESC`',
       type: 'string',
 

--- a/packages/magicbell/src/schemas/users/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/users/push-subscriptions.ts
@@ -73,8 +73,8 @@ export const ListUsersPushSubscriptionsPayloadSchema = {
       type: 'integer',
     },
 
-    perPage: {
-      title: 'perPage',
+    per_page: {
+      title: 'per_page',
       description: 'The number of items per page. Defaults to 20.',
       type: 'integer',
     },


### PR DESCRIPTION
This ensures that query params keep the casing convention from our REST api. They were incorrectly forced to camelCase, which affects for example the `per_page` param.