### PR TITLE
fix: add types for listener close method (#70

### DIFF
--- a/.changeset/quick-cups-drum.md
+++ b/.changeset/quick-cups-drum.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+fix: add types for listener close method

--- a/packages/magicbell/src/listen.ts
+++ b/packages/magicbell/src/listen.ts
@@ -39,6 +39,7 @@ type Event = {
 type IterableEventSource<TNode> = {
   [Symbol.asyncIterator](): Iterator<TNode>;
   forEach(cb: (node: TNode, index: number) => void | boolean | Promise<void | boolean>): Promise<void>;
+  close(): void;
 };
 
 export type Listener = (options?: RequestOptions) => IterableEventSource<Event>;
@@ -153,7 +154,7 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
     const forEach = makeForEach(asyncIteratorNext, dispose);
     const autoPaginationMethods = {
       forEach,
-      close: dispose,
+      close: () => void dispose(),
 
       next: asyncIteratorNext,
       return: dispose,


### PR DESCRIPTION
Adds types for the listener close method, like:

```ts
const listener = magicbell.listen();

listener.forEach((notification) => {
  console.log(notification.data.id);
});

// stop listening after 5 seconds
setTimeout(() => {
  listener.close();  // <<< wasn't included in the return type of `listen()`
}, 5_000);
```