### PR TITLE
fix: handle network level request errors (#75

### DIFF
--- a/.changeset/brown-stingrays-guess.md
+++ b/.changeset/brown-stingrays-guess.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+fix: handle network level request errors

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -112,18 +112,19 @@ export class Client {
       this.#logLastRequest(response, { startTime });
 
       if (this.#shouldRetry(response, attempt, maxRetries)) {
-        const retryAfter = Number(response.headers['retry-after']);
+        const retryAfter = Number(response?.headers?.['retry-after']);
         await sleep(this.#getSleepTimeInMS(attempt, retryAfter, requestOptions.maxRetryDelay));
         continue;
       }
 
       if (error) {
         throw createError({
+          code: error.code,
           name: error.name,
           message: error.message,
           type: error['type'],
-          status: response.status,
-          statusText: response.statusText,
+          status: response?.status,
+          statusText: response?.statusText,
           ...(response?.data as any)?.errors?.[0],
         });
       }


### PR DESCRIPTION
Some errors, like unresolvable addresses, don't include a response. This makes sure those cases are handled properly, instead of failing on accessing properties on the undefined response object.