### PR TITLE
fix: return the full response from users.push_subscriptions.list()

### DIFF
--- a/.changeset/ninety-bears-perform.md
+++ b/.changeset/ninety-bears-perform.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+return the full response data from users.push_subscriptions.list()

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -65,7 +65,7 @@ export function getRootPathMethods(document: OpenAPI.Document, path: string) {
       const name = camelCase(operation.operationId.slice(rootPath.length + 1 + (group ? subPath.length + 1 : 0)));
       const type = name === 'list' ? 'list' : null;
 
-      const methodEntity = group ? snakeCase(group) : entity;
+      const methodEntity = group ? snakeCase(group.replace(/s$/, '')) : entity;
       const methodPath = apiPath.replace(`/${path}`, '').replace(/^\//, '');
 
       const urlParams = (apiPath.match(/{\w+}/g) || []).map((param) => param.replace(/[{}]/g, ''));

--- a/packages/magicbell/src/resources/users/push-subscriptions.ts
+++ b/packages/magicbell/src/resources/users/push-subscriptions.ts
@@ -12,7 +12,7 @@ type ListUsersPushSubscriptionsPayload = FromSchema<typeof schemas.ListUsersPush
 
 export class UsersPushSubscriptions extends Resource {
   path = 'users';
-  entity = 'push_subscriptions';
+  entity = 'push_subscription';
 
   /**
    * Fetch a user's push subscriptions. Returns a paginated list of web and mobile


### PR DESCRIPTION
Makes sure that the full response, including `page` and `page_count` is returned from the `users.push_subscriptions.list()` method.