### PR TITLE
feat: support allOf in schema to combine types (#82

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -40,9 +40,13 @@
     "ast-types": "^0.14.2",
     "axios": "^0.27.2",
     "eslint": "^8.23.1",
+    "json-schema-merge-allof": "^0.8.1",
     "json5": "^2.2.1",
     "openapi-types": "^12.0.2",
     "prettier": "^2.7.1",
     "recast": "^0.21.5"
+  },
+  "devDependencies": {
+    "@types/json-schema-merge-allof": "^0.6.1"
   }
 }

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -1,4 +1,4 @@
-import { IJsonSchema, OpenAPI, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
 type Modify<T, R> = Omit<T, keyof R> & R;
 export type SchemaObject = OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject;
@@ -43,12 +43,13 @@ export function schemaToObject(schema: SchemaObject | ReferenceObject) {
   return schema;
 }
 
-export function isEmptySchema(schema: IJsonSchema) {
+export function isEmptySchema(schema: unknown) {
   return (
-    !schema ||
-    !schema.type ||
-    (schema.type === 'object' && !schema.properties) ||
-    (schema.type === 'array' && !schema.items)
+    typeof schema !== 'object' ||
+    schema == null ||
+    !('type' in schema) ||
+    ((schema as any).type === 'object' && !(schema as any).properties) ||
+    ((schema as any).type === 'array' && !(schema as any).items)
   );
 }
 

--- a/packages/magicbell/src/schemas/imports.ts
+++ b/packages/magicbell/src/schemas/imports.ts
@@ -147,12 +147,11 @@ export const CreateImportsPayloadSchema = {
           phone_numbers: {
             type: 'array',
             description: 'An array of phone numbers to use for sending SMS notifications.',
+            maxItems: 50,
 
             items: {
               type: 'string',
             },
-
-            maxItems: 50,
           },
 
           channels: {

--- a/packages/magicbell/src/schemas/notifications.ts
+++ b/packages/magicbell/src/schemas/notifications.ts
@@ -2,6 +2,7 @@
 export const CreateNotificationsResponseSchema = {
   title: 'CreateNotificationsResponseSchema',
   type: 'object',
+  required: ['id', 'title', 'sent_at'],
   additionalProperties: false,
 
   properties: {
@@ -61,13 +62,12 @@ export const CreateNotificationsResponseSchema = {
       readOnly: true,
     },
   },
-
-  required: ['id', 'title', 'sent_at'],
 } as const;
 
 export const CreateNotificationsPayloadSchema = {
   title: 'CreateNotificationsPayloadSchema',
   type: 'object',
+  required: ['title', 'recipients'],
   additionalProperties: false,
 
   properties: {
@@ -286,8 +286,6 @@ export const CreateNotificationsPayloadSchema = {
       },
     },
   },
-
-  required: ['title', 'recipients'],
 } as const;
 
 export const ListNotificationsResponseSchema = {
@@ -344,6 +342,7 @@ export const ListNotificationsResponseSchema = {
 
       items: {
         type: 'object',
+        required: ['title', 'recipient'],
         additionalProperties: false,
 
         properties: {
@@ -467,18 +466,15 @@ export const ListNotificationsResponseSchema = {
               phone_numbers: {
                 type: 'array',
                 description: 'An array of phone numbers to use for sending SMS notifications.',
+                maxItems: 50,
 
                 items: {
                   type: 'string',
                 },
-
-                maxItems: 50,
               },
             },
           },
         },
-
-        required: ['title', 'recipient'],
       },
     },
   },
@@ -552,6 +548,7 @@ export const ListNotificationsPayloadSchema = {
 export const GetNotificationsResponseSchema = {
   title: 'GetNotificationsResponseSchema',
   type: 'object',
+  required: ['title', 'recipient'],
   additionalProperties: false,
 
   properties: {
@@ -674,18 +671,15 @@ export const GetNotificationsResponseSchema = {
         phone_numbers: {
           type: 'array',
           description: 'An array of phone numbers to use for sending SMS notifications.',
+          maxItems: 50,
 
           items: {
             type: 'string',
           },
-
-          maxItems: 50,
         },
       },
     },
   },
-
-  required: ['title', 'recipient'],
 } as const;
 
 export const MarkAllReadNotificationsPayloadSchema = {

--- a/packages/magicbell/src/schemas/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/push-subscriptions.ts
@@ -27,6 +27,7 @@ export const CreatePushSubscriptionsResponseSchema = {
 export const CreatePushSubscriptionsPayloadSchema = {
   title: 'CreatePushSubscriptionsPayloadSchema',
   type: 'object',
+  required: ['device_token', 'platform'],
   additionalProperties: false,
 
   properties: {
@@ -51,6 +52,4 @@ export const CreatePushSubscriptionsPayloadSchema = {
       maxLength: 155,
     },
   },
-
-  required: ['device_token', 'platform'],
 } as const;

--- a/packages/magicbell/src/schemas/subscriptions.ts
+++ b/packages/magicbell/src/schemas/subscriptions.ts
@@ -95,6 +95,7 @@ export const CreateSubscriptionsResponseSchema = {
 export const CreateSubscriptionsPayloadSchema = {
   title: 'CreateSubscriptionsPayloadSchema',
   type: 'object',
+  required: ['categories', 'topic'],
   additionalProperties: false,
 
   properties: {
@@ -126,8 +127,6 @@ export const CreateSubscriptionsPayloadSchema = {
       description: 'The topic the user should be subscribed to. If the topic does not exist it will be created.',
     },
   },
-
-  required: ['categories', 'topic'],
 } as const;
 
 export const UnsubscribeSubscriptionsResponseSchema = {
@@ -175,6 +174,7 @@ export const UnsubscribeSubscriptionsResponseSchema = {
 export const UnsubscribeSubscriptionsPayloadSchema = {
   title: 'UnsubscribeSubscriptionsPayloadSchema',
   type: 'object',
+  required: ['categories'],
   additionalProperties: false,
 
   properties: {
@@ -201,8 +201,6 @@ export const UnsubscribeSubscriptionsPayloadSchema = {
       },
     },
   },
-
-  required: ['categories'],
 } as const;
 
 export const GetSubscriptionsResponseSchema = {

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -50,12 +50,11 @@ export const CreateUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -105,12 +104,11 @@ export const CreateUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -189,12 +187,11 @@ export const ListUsersResponseSchema = {
           phone_numbers: {
             type: 'array',
             description: 'An array of phone numbers to use for sending SMS notifications.',
+            maxItems: 50,
 
             items: {
               type: 'string',
             },
-
-            maxItems: 50,
           },
         },
       },
@@ -316,12 +313,11 @@ export const FetchUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -377,12 +373,11 @@ export const UpdateUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -432,12 +427,11 @@ export const UpdateUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -493,12 +487,11 @@ export const UpdateByEmailUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -548,12 +541,11 @@ export const UpdateByEmailUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -609,12 +601,11 @@ export const UpdateByExternalIdUsersResponseSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;
@@ -664,12 +655,11 @@ export const UpdateByExternalIdUsersPayloadSchema = {
     phone_numbers: {
       type: 'array',
       description: 'An array of phone numbers to use for sending SMS notifications.',
+      maxItems: 50,
 
       items: {
         type: 'string',
       },
-
-      maxItems: 50,
     },
   },
 } as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,13 @@
   resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
   integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
 
+"@types/json-schema-merge-allof@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@types/json-schema-merge-allof/-/json-schema-merge-allof-0.6.1.tgz#c476c2aeed04d8a14882ff872de9ddeca5608e0b"
+  integrity sha512-tBVtkCCbA1oF8vQ2cp2yuGLp0T2f0AZ2dAic64ZftoWQnKqrTYY/+PuiqPKX1XaxoR43ll/EkYcHnJbdbHUS2g==
+  dependencies:
+    "@types/json-schema" "*"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -6651,6 +6658,25 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
+
+compute-gcd@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compute-gcd/-/compute-gcd-1.2.1.tgz#34d639f3825625e1357ce81f0e456a6249d8c77f"
+  integrity sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==
+  dependencies:
+    validate.io-array "^1.0.3"
+    validate.io-function "^1.0.2"
+    validate.io-integer-array "^1.0.0"
+
+compute-lcm@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/compute-lcm/-/compute-lcm-1.1.2.tgz#9107c66b9dca28cefb22b4ab4545caac4034af23"
+  integrity sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==
+  dependencies:
+    compute-gcd "^1.2.1"
+    validate.io-array "^1.0.3"
+    validate.io-function "^1.0.2"
+    validate.io-integer-array "^1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -11085,6 +11111,22 @@ json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-compare@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/json-schema-compare/-/json-schema-compare-0.2.2.tgz#dd601508335a90c7f4cfadb6b2e397225c908e56"
+  integrity sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==
+  dependencies:
+    lodash "^4.17.4"
+
+json-schema-merge-allof@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz#ed2828cdd958616ff74f932830a26291789eaaf2"
+  integrity sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==
+  dependencies:
+    compute-lcm "^1.1.2"
+    json-schema-compare "^0.2.2"
+    lodash "^4.17.20"
+
 json-schema-to-ts@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-2.6.0.tgz#17b1492571509ed0a6ea18dd06f26761a47920fe"
@@ -11588,7 +11630,7 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -16018,11 +16060,9 @@ trough@^1.0.0:
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
 ts-algebra@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-1.1.1.tgz#f7593cabcfd64f9d7211fa4f16ea9719e02461bc"
-  integrity sha512-W43a3/BN0Tp4SgRNERQF/QPVuY1rnHkgCr/fISLY0Ycu05P0NWPYRuViU8JFn+pFZuY6/zp9TgET1fxMzppR/Q==
-  dependencies:
-    ts-toolbelt "^9.6.0"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-1.2.0.tgz#f91c481207a770f0d14d055c376cbee040afdfc9"
+  integrity sha512-kMuJJd8B2N/swCvIvn1hIFcIOrLGbWl9m/J6O3kHx9VRaevh00nvgjPiEGaRee7DRaAczMYR2uwWvXU22VFltw==
 
 ts-dedent@^1.1.0:
   version "1.2.0"
@@ -16732,6 +16772,36 @@ validate-npm-package-name@^3.0.0:
   integrity sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==
   dependencies:
     builtins "^1.0.3"
+
+validate.io-array@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/validate.io-array/-/validate.io-array-1.0.6.tgz#5b5a2cafd8f8b85abb2f886ba153f2d93a27774d"
+  integrity sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==
+
+validate.io-function@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/validate.io-function/-/validate.io-function-1.0.2.tgz#343a19802ed3b1968269c780e558e93411c0bad7"
+  integrity sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==
+
+validate.io-integer-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz#2cabde033293a6bcbe063feafe91eaf46b13a089"
+  integrity sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==
+  dependencies:
+    validate.io-array "^1.0.3"
+    validate.io-integer "^1.0.4"
+
+validate.io-integer@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/validate.io-integer/-/validate.io-integer-1.0.5.tgz#168496480b95be2247ec443f2233de4f89878068"
+  integrity sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==
+  dependencies:
+    validate.io-number "^1.0.3"
+
+validate.io-number@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
+  integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This change enables us to combine schemas in `openapi.json` using `allOf`, like:

```json
"schema": {
  "allOf": [
    { "$ref":  "#/components/schemas/PaginationProps" },
    {
      "type": "object",
      "required": ["broadcasts"],
      "properties": {
        "broadcasts": {
          "type": "array",
          "items": { "$ref": "#/components/schemas/Broadcast" }
        }
      }
    }
  ]
}
``` 