### PR TITLE
feat: add broadcasts.list() method

### DIFF
--- a/.changeset/heavy-badgers-exist.md
+++ b/.changeset/heavy-badgers-exist.md
@@ -1,0 +1,13 @@
+---
+'magicbell': minor
+---
+
+feat: add broadcasts.list method to the client.
+
+```ts
+const broadcasts = magicbell.broadcasts.list({ per_page: 10 });
+
+await broadcasts.forEach((broadcast) => {
+  console.log(broadcast.id);
+});
+```

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -53,7 +53,12 @@ export function getRootPathMethods(document: OpenAPI.Document, path: string) {
   // level decide for the method.
   const body = getRequestBody(document.paths[`/${path}`].post) || getResponseBody(document.paths[`/${path}`].get);
   const schema = mergeAllOf(body.schema as any);
-  const entity = Object.keys(schema.properties).find((x) => !paginationProps.includes(x));
+  let entity = Object.keys(schema.properties).find((x) => !paginationProps.includes(x));
+
+  // this ain't nice, see comment above
+  if (entity !== 'notification_preferences') {
+    entity = entity.replace(/s$/, '');
+  }
 
   for (const apiPath of apiPaths) {
     const [rootPath, subPath] = apiPath

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -316,6 +316,7 @@ Below is a list of features that are currently behind feature flags.
 
 | Feature Flag                      | Description                                                                |
 | --------------------------------- | -------------------------------------------------------------------------- |
+| `broadcasts-list`                 | List notification broadcasts ([docs](#broadcasts-list))                    |
 | `imports-create`                  | Create a import ([docs](#imports-create))                                  |
 | `imports-get`                     | Get the status of an import ([docs](#imports-get))                         |
 | `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete)) |
@@ -330,6 +331,23 @@ Below you'll find the all supported resource methods, with their signatures. The
 Apart from the removal of the wrappers, returned entities and provided parameters are identical between our REST API and this SDK.
 
 <!-- AUTO-GENERATED-CONTENT:START (RESOURCE_METHODS) -->
+
+### Broadcasts
+
+#### List notification broadcasts
+
+> **Warning**
+>
+> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-list` [feature flag](#feature-flags).
+
+List all notification broadcasts. Broadcasts are sorted in descending order by the sent_at timestamp.
+
+```js
+await magicbell.broadcasts.list({
+  page: 1,
+  per_page: 1,
+});
+```
 
 ### Notifications
 

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -8,6 +8,7 @@ import { Logger, toCurl } from './lib/log';
 import { compact, hasOwn, joinAnd, sleep, uuid4 } from './lib/utils';
 import { createListener } from './listen';
 import { isOptionsHash } from './options';
+import { Broadcasts } from './resources/broadcasts';
 import { Imports } from './resources/imports';
 import { NotificationPreferences } from './resources/notification-preferences';
 import { Notifications } from './resources/notifications';
@@ -40,6 +41,7 @@ export class Client {
   #lastRequest: Telemetry[] = [];
   listen = createListener(this);
 
+  broadcasts = new Broadcasts(this);
   imports = new Imports(this);
   notificationPreferences = new NotificationPreferences(this);
   notifications = new Notifications(this);

--- a/packages/magicbell/src/resources/broadcasts.ts
+++ b/packages/magicbell/src/resources/broadcasts.ts
@@ -1,0 +1,55 @@
+// This file is generated. Do not update manually!
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { type IterablePromise } from '../method';
+import { Resource } from '../resource';
+import * as schemas from '../schemas/broadcasts';
+import { type RequestOptions } from '../types';
+
+type ListBroadcastsResponse = FromSchema<typeof schemas.ListBroadcastsResponseSchema>;
+type ListBroadcastsPayload = FromSchema<typeof schemas.ListBroadcastsPayloadSchema>;
+
+export class Broadcasts extends Resource {
+  path = 'broadcasts';
+  entity = 'broadcast';
+
+  /**
+   * List all notification broadcasts. Broadcasts are sorted in descending order by
+   * the sent_at timestamp.
+   *
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
+   **/
+  list(options?: RequestOptions): IterablePromise<ListBroadcastsResponse>;
+
+  /**
+   * List all notification broadcasts. Broadcasts are sorted in descending order by
+   * the sent_at timestamp.
+   *
+   * @param data
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
+   **/
+  list(data: ListBroadcastsPayload, options?: RequestOptions): IterablePromise<ListBroadcastsResponse>;
+
+  list(
+    dataOrOptions: ListBroadcastsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): IterablePromise<ListBroadcastsResponse> {
+    this.assertFeatureFlag('broadcasts-list');
+
+    return this.request(
+      {
+        method: 'GET',
+        paged: true,
+      },
+      dataOrOptions,
+      options,
+    );
+  }
+}

--- a/packages/magicbell/src/schemas/broadcasts.ts
+++ b/packages/magicbell/src/schemas/broadcasts.ts
@@ -1,0 +1,208 @@
+// This file is generated. Do not update manually!
+export const ListBroadcastsResponseSchema = {
+  title: 'ListBroadcastsResponseSchema',
+  type: 'object',
+  required: ['broadcasts', 'current_page', 'per_page', 'total', 'total_pages'],
+
+  properties: {
+    total: {
+      type: 'integer',
+      description: 'Total number of entities for this query.',
+      readOnly: true,
+    },
+
+    per_page: {
+      type: 'integer',
+      description: 'Number of entities per page.',
+      readOnly: true,
+    },
+
+    total_pages: {
+      type: 'integer',
+      description: 'Total number of pages.',
+      readOnly: true,
+    },
+
+    current_page: {
+      type: 'integer',
+      description: 'Number of the page returned.',
+      readOnly: true,
+    },
+
+    broadcasts: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        required: ['id', 'title', 'sent_at'],
+        additionalProperties: false,
+
+        properties: {
+          id: {
+            type: 'string',
+            description: 'The unique id for this broadcast.',
+            readOnly: true,
+          },
+
+          title: {
+            type: 'string',
+            description: 'Title of the broadcast.',
+            nullable: false,
+            maxLength: 255,
+          },
+
+          content: {
+            type: 'string',
+            description: 'Content of the broadcast.',
+            nullable: true,
+            maxLength: 4194304,
+          },
+
+          action_url: {
+            type: 'string',
+            format: 'uri',
+            description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+            nullable: true,
+            maxLength: 2048,
+          },
+
+          category: {
+            type: 'string',
+            description:
+              'Category the notification belongs to. This is useful to allow users to set their preferences.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          topic: {
+            type: 'string',
+            description: 'Topic the notification belongs to. This is useful to create threads.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          custom_attributes: {
+            type: 'object',
+            description:
+              'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+            nullable: true,
+            additionalProperties: true,
+          },
+
+          sent_at: {
+            type: 'number',
+            description: 'The timestamp when the notification was sent to its recipients.',
+            readOnly: true,
+          },
+
+          recipients: {
+            type: 'array',
+            nullable: false,
+            minItems: 1,
+            maxItems: 1000,
+
+            items: {
+              anyOf: [
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['matches'],
+
+                  properties: {
+                    matches: {
+                      type: 'string',
+                      description:
+                        'An expression to match users by their stored attributes. Set it to `*` to match all users.',
+                      nullable: false,
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: true,
+                  required: ['email'],
+
+                  properties: {
+                    email: {
+                      type: 'string',
+                      format: 'email',
+                      description: 'The identifying email of the recipient.',
+                      nullable: false,
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: true,
+                  required: ['external_id'],
+
+                  properties: {
+                    external_id: {
+                      type: 'string',
+                      format: 'email',
+                      description: 'The identifying external_id of the recipient.',
+                      nullable: false,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+
+          recipients_count: {
+            type: 'integer',
+            description: 'The number of recipients that the broadcast was sent to.',
+            readOnly: true,
+            nullable: false,
+          },
+
+          overrides: {
+            type: 'object',
+            additionalProperties: true,
+          },
+
+          processing_status: {
+            status: 'string',
+
+            summary: {
+              type: 'object',
+              additionalProperties: false,
+
+              properties: {
+                total: {
+                  type: 'integer',
+                },
+
+                failures: {
+                  type: 'integer',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const ListBroadcastsPayloadSchema = {
+  title: 'ListBroadcastsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    page: {
+      title: 'page',
+      description: 'The page number of the paginated response. Defaults to 1.',
+      type: 'integer',
+    },
+
+    per_page: {
+      title: 'per_page',
+      description: 'The number of items per page. Defaults to 20.',
+      type: 'integer',
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -17,6 +17,7 @@ export type ClientOptions = {
   telemetry?: boolean;
   debug?: boolean;
   features?: {
+    'broadcasts-list'?: true;
     'imports-create'?: true;
     'imports-get'?: true;
     'users-push-subscriptions-delete'?: true;


### PR DESCRIPTION
Add's the `magicbell.broadcasts.list()` method:

```ts
const broadcasts = magicbell.broadcasts.list({ per_page: 10 });
await broadcasts.forEach((broadcast) => {
  console.log(broadcast.id);
});
```
