### PR TITLE
feat: add broadcasts.get() method

### DIFF
--- a/.changeset/thin-melons-roll.md
+++ b/.changeset/thin-melons-roll.md
@@ -1,0 +1,10 @@
+---
+'magicbell': minor
+---
+
+feat: add `broadcasts.get` method to the client.
+
+```ts
+const broadcasts = await magicbell.broadcasts.get(broadcastId);
+console.log(broadcast.id);
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -316,6 +316,7 @@ Below is a list of features that are currently behind feature flags.
 
 | Feature Flag                      | Description                                                                |
 | --------------------------------- | -------------------------------------------------------------------------- |
+| `broadcasts-get`                  | Fetch a notification broadcast by its ID ([docs](#broadcasts-get))         |
 | `broadcasts-list`                 | List notification broadcasts ([docs](#broadcasts-list))                    |
 | `imports-create`                  | Create a import ([docs](#imports-create))                                  |
 | `imports-get`                     | Get the status of an import ([docs](#imports-get))                         |
@@ -347,6 +348,18 @@ await magicbell.broadcasts.list({
   page: 1,
   per_page: 1,
 });
+```
+
+#### Fetch a notification broadcast by its ID
+
+> **Warning**
+>
+> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-get` [feature flag](#feature-flags).
+
+Fetch a notification broadcast by its ID.
+
+```js
+await magicbell.broadcasts.get('{broadcast_id}');
 ```
 
 ### Notifications

--- a/packages/magicbell/src/resources/broadcasts.ts
+++ b/packages/magicbell/src/resources/broadcasts.ts
@@ -9,6 +9,7 @@ import { type RequestOptions } from '../types';
 
 type ListBroadcastsResponse = FromSchema<typeof schemas.ListBroadcastsResponseSchema>;
 type ListBroadcastsPayload = FromSchema<typeof schemas.ListBroadcastsPayloadSchema>;
+type GetBroadcastsResponse = FromSchema<typeof schemas.GetBroadcastsResponseSchema>;
 
 export class Broadcasts extends Resource {
   path = 'broadcasts';
@@ -49,6 +50,28 @@ export class Broadcasts extends Resource {
         paged: true,
       },
       dataOrOptions,
+      options,
+    );
+  }
+
+  /**
+   * Fetch a notification broadcast by its ID.
+   *
+   * @param broadcastId - ID of the notification broadcast.
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
+   **/
+  get(broadcastId: string, options?: RequestOptions): Promise<GetBroadcastsResponse> {
+    this.assertFeatureFlag('broadcasts-get');
+
+    return this.request(
+      {
+        method: 'GET',
+        path: '{broadcast_id}',
+      },
+      broadcastId,
       options,
     );
   }

--- a/packages/magicbell/src/schemas/broadcasts.ts
+++ b/packages/magicbell/src/schemas/broadcasts.ts
@@ -206,3 +206,153 @@ export const ListBroadcastsPayloadSchema = {
   additionalProperties: false,
   required: [],
 } as const;
+
+export const GetBroadcastsResponseSchema = {
+  title: 'GetBroadcastsResponseSchema',
+  type: 'object',
+  required: ['id', 'title', 'sent_at'],
+  additionalProperties: false,
+
+  properties: {
+    id: {
+      type: 'string',
+      description: 'The unique id for this broadcast.',
+      readOnly: true,
+    },
+
+    title: {
+      type: 'string',
+      description: 'Title of the broadcast.',
+      nullable: false,
+      maxLength: 255,
+    },
+
+    content: {
+      type: 'string',
+      description: 'Content of the broadcast.',
+      nullable: true,
+      maxLength: 4194304,
+    },
+
+    action_url: {
+      type: 'string',
+      format: 'uri',
+      description: 'A URL to redirect the user to when they click the notification in their notification inbox.',
+      nullable: true,
+      maxLength: 2048,
+    },
+
+    category: {
+      type: 'string',
+      description: 'Category the notification belongs to. This is useful to allow users to set their preferences.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    topic: {
+      type: 'string',
+      description: 'Topic the notification belongs to. This is useful to create threads.',
+      nullable: true,
+      maxLength: 100,
+    },
+
+    custom_attributes: {
+      type: 'object',
+      description:
+        'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.\n\nYou can use it to share data between channels or to render a custom UI.',
+      nullable: true,
+      additionalProperties: true,
+    },
+
+    sent_at: {
+      type: 'number',
+      description: 'The timestamp when the notification was sent to its recipients.',
+      readOnly: true,
+    },
+
+    recipients: {
+      type: 'array',
+      nullable: false,
+      minItems: 1,
+      maxItems: 1000,
+
+      items: {
+        anyOf: [
+          {
+            type: 'object',
+            additionalProperties: false,
+            required: ['matches'],
+
+            properties: {
+              matches: {
+                type: 'string',
+                description:
+                  'An expression to match users by their stored attributes. Set it to `*` to match all users.',
+                nullable: false,
+              },
+            },
+          },
+          {
+            type: 'object',
+            additionalProperties: true,
+            required: ['email'],
+
+            properties: {
+              email: {
+                type: 'string',
+                format: 'email',
+                description: 'The identifying email of the recipient.',
+                nullable: false,
+              },
+            },
+          },
+          {
+            type: 'object',
+            additionalProperties: true,
+            required: ['external_id'],
+
+            properties: {
+              external_id: {
+                type: 'string',
+                format: 'email',
+                description: 'The identifying external_id of the recipient.',
+                nullable: false,
+              },
+            },
+          },
+        ],
+      },
+    },
+
+    recipients_count: {
+      type: 'integer',
+      description: 'The number of recipients that the broadcast was sent to.',
+      readOnly: true,
+      nullable: false,
+    },
+
+    overrides: {
+      type: 'object',
+      additionalProperties: true,
+    },
+
+    processing_status: {
+      status: 'string',
+
+      summary: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          total: {
+            type: 'integer',
+          },
+
+          failures: {
+            type: 'integer',
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -17,6 +17,7 @@ export type ClientOptions = {
   telemetry?: boolean;
   debug?: boolean;
   features?: {
+    'broadcasts-get'?: true;
     'broadcasts-list'?: true;
     'imports-create'?: true;
     'imports-get'?: true;


### PR DESCRIPTION
Adds the `broadcasts.get` method to the client.

```ts
const broadcasts = await magicbell.broadcasts.get(broadcastId);
console.log(broadcast.id);
```