### PR TITLE
feat: add broadcasts.notifications.list() method

### DIFF
--- a/.changeset/new-houses-pretend.md
+++ b/.changeset/new-houses-pretend.md
@@ -1,0 +1,13 @@
+---
+'magicbell': minor
+---
+
+feat: add `broadcasts.notifications.list` method to the client.
+
+```ts
+const notifications = magicbell.broadcasts.notifications.list(broadcastId, { per_page: 10 });
+
+await notifications.forEach((notification) => {
+  console.log(notification.id);
+});
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -314,14 +314,15 @@ Below is a list of features that are currently behind feature flags.
 
 <!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
 
-| Feature Flag                      | Description                                                                |
-| --------------------------------- | -------------------------------------------------------------------------- |
-| `broadcasts-get`                  | Fetch a notification broadcast by its ID ([docs](#broadcasts-get))         |
-| `broadcasts-list`                 | List notification broadcasts ([docs](#broadcasts-list))                    |
-| `imports-create`                  | Create a import ([docs](#imports-create))                                  |
-| `imports-get`                     | Get the status of an import ([docs](#imports-get))                         |
-| `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete)) |
-| `users-push-subscriptions-list`   | Fetch user's push subscriptions ([docs](#users-push-subscriptions-list))   |
+| Feature Flag                      | Description                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------- |
+| `broadcasts-get`                  | Fetch a notification broadcast by its ID ([docs](#broadcasts-get))            |
+| `broadcasts-list`                 | List notification broadcasts ([docs](#broadcasts-list))                       |
+| `broadcasts-notifications-list`   | Fetch notifications by broadcast id. ([docs](#broadcasts-notifications-list)) |
+| `imports-create`                  | Create a import ([docs](#imports-create))                                     |
+| `imports-get`                     | Get the status of an import ([docs](#imports-get))                            |
+| `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete))    |
+| `users-push-subscriptions-list`   | Fetch user's push subscriptions ([docs](#users-push-subscriptions-list))      |
 
 <!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
@@ -360,6 +361,23 @@ Fetch a notification broadcast by its ID.
 
 ```js
 await magicbell.broadcasts.get('{broadcast_id}');
+```
+
+### Broadcasts Notifications
+
+#### Fetch notifications by broadcast id.
+
+> **Warning**
+>
+> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-notifications-list` [feature flag](#feature-flags).
+
+Fetch the notifications on a notification broadcast.
+
+```js
+await magicbell.broadcasts.notifications.list('{broadcast_id}', {
+  page: 1,
+  per_page: 1,
+});
 ```
 
 ### Notifications

--- a/packages/magicbell/src/resources/broadcasts.ts
+++ b/packages/magicbell/src/resources/broadcasts.ts
@@ -6,6 +6,7 @@ import { type IterablePromise } from '../method';
 import { Resource } from '../resource';
 import * as schemas from '../schemas/broadcasts';
 import { type RequestOptions } from '../types';
+import { BroadcastsNotifications } from './broadcasts/notifications';
 
 type ListBroadcastsResponse = FromSchema<typeof schemas.ListBroadcastsResponseSchema>;
 type ListBroadcastsPayload = FromSchema<typeof schemas.ListBroadcastsPayloadSchema>;
@@ -14,6 +15,7 @@ type GetBroadcastsResponse = FromSchema<typeof schemas.GetBroadcastsResponseSche
 export class Broadcasts extends Resource {
   path = 'broadcasts';
   entity = 'broadcast';
+  notifications = new BroadcastsNotifications(this.client);
 
   /**
    * List all notification broadcasts. Broadcasts are sorted in descending order by

--- a/packages/magicbell/src/resources/broadcasts/notifications.ts
+++ b/packages/magicbell/src/resources/broadcasts/notifications.ts
@@ -1,0 +1,62 @@
+// This file is generated. Do not update manually!
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { type IterablePromise } from '../../method';
+import { Resource } from '../../resource';
+import * as schemas from '../../schemas/broadcasts/notifications';
+import { type RequestOptions } from '../../types';
+
+type ListBroadcastsNotificationsResponse = FromSchema<typeof schemas.ListBroadcastsNotificationsResponseSchema>;
+type ListBroadcastsNotificationsPayload = FromSchema<typeof schemas.ListBroadcastsNotificationsPayloadSchema>;
+
+export class BroadcastsNotifications extends Resource {
+  path = 'broadcasts';
+  entity = 'notification';
+
+  /**
+   * Fetch the notifications on a notification broadcast.
+   *
+   * @param broadcastId - ID of the notification broadcast.
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
+   **/
+  list(broadcastId: string, options?: RequestOptions): IterablePromise<ListBroadcastsNotificationsResponse>;
+
+  /**
+   * Fetch the notifications on a notification broadcast.
+   *
+   * @param broadcastId - ID of the notification broadcast.
+   * @param data
+   * @param options - override client request options.
+   * @returns
+   *
+   * @beta
+   **/
+  list(
+    broadcastId: string,
+    data: ListBroadcastsNotificationsPayload,
+    options?: RequestOptions,
+  ): IterablePromise<ListBroadcastsNotificationsResponse>;
+
+  list(
+    broadcastId: string,
+    dataOrOptions: ListBroadcastsNotificationsPayload | RequestOptions,
+    options?: RequestOptions,
+  ): IterablePromise<ListBroadcastsNotificationsResponse> {
+    this.assertFeatureFlag('broadcasts-notifications-list');
+
+    return this.request(
+      {
+        method: 'GET',
+        path: '{broadcast_id}/notifications',
+        paged: true,
+      },
+      broadcastId,
+      dataOrOptions,
+      options,
+    );
+  }
+}

--- a/packages/magicbell/src/schemas/broadcasts/notifications.ts
+++ b/packages/magicbell/src/schemas/broadcasts/notifications.ts
@@ -1,0 +1,180 @@
+// This file is generated. Do not update manually!
+export const ListBroadcastsNotificationsResponseSchema = {
+  title: 'ListBroadcastsNotificationsResponseSchema',
+  type: 'object',
+  required: ['current_page', 'notifications', 'per_page', 'total', 'total_pages'],
+
+  properties: {
+    total: {
+      type: 'integer',
+      description: 'Total number of entities for this query.',
+      readOnly: true,
+    },
+
+    per_page: {
+      type: 'integer',
+      description: 'Number of entities per page.',
+      readOnly: true,
+    },
+
+    total_pages: {
+      type: 'integer',
+      description: 'Total number of pages.',
+      readOnly: true,
+    },
+
+    current_page: {
+      type: 'integer',
+      description: 'Number of the page returned.',
+      readOnly: true,
+    },
+
+    notifications: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+
+        properties: {
+          id: {
+            type: 'string',
+            description: 'The unique id for this notification.',
+            readOnly: true,
+          },
+
+          category: {
+            type: 'string',
+            description:
+              'Category the notification belongs to. This is useful to allow users to set their preferences.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          topic: {
+            type: 'string',
+            description: 'Topic the notification belongs to. This is useful to create threads.',
+            nullable: true,
+            maxLength: 100,
+          },
+
+          sent_at: {
+            type: 'number',
+            description: 'The timestamp when the notification was sent to its recipients.',
+            readOnly: true,
+          },
+
+          user: {
+            type: 'object',
+            additionalProperties: false,
+
+            properties: {
+              id: {
+                type: 'string',
+                description: 'The unique id for this user.',
+                readOnly: true,
+              },
+
+              external_id: {
+                type: 'string',
+                description:
+                  "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+                maxLength: 255,
+                nullable: true,
+              },
+
+              email: {
+                type: 'string',
+                description: "The user's email.",
+                maxLength: 255,
+                nullable: true,
+              },
+
+              first_name: {
+                type: 'string',
+                description: "The user's first name.",
+                maxLength: 50,
+                nullable: true,
+              },
+
+              last_name: {
+                type: 'string',
+                description: "The user's last name.",
+                maxLength: 50,
+                nullable: true,
+              },
+
+              custom_attributes: {
+                type: 'object',
+                description:
+                  "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+                additionalProperties: true,
+              },
+
+              phone_numbers: {
+                type: 'array',
+                description: 'An array of phone numbers to use for sending SMS notifications.',
+                maxItems: 50,
+
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+
+          deliveries: {
+            type: 'array',
+
+            items: {
+              type: 'object',
+              required: ['id', 'channel', 'scheduled_at', 'status'],
+              additionalProperties: false,
+
+              properties: {
+                id: {
+                  type: 'string',
+                },
+
+                channel: {
+                  type: 'string',
+                },
+
+                scheduled_at: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+
+                status: {
+                  type: 'integer',
+                  description: '0: unseen, 5: unread, 10: read, 20: archived',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const ListBroadcastsNotificationsPayloadSchema = {
+  title: 'ListBroadcastsNotificationsPayloadSchema',
+  type: 'object',
+
+  properties: {
+    page: {
+      title: 'page',
+      description: 'The page number of the paginated response. Defaults to 1.',
+      type: 'integer',
+    },
+
+    per_page: {
+      title: 'per_page',
+      description: 'The number of items per page. Defaults to 20.',
+      type: 'integer',
+    },
+  },
+
+  additionalProperties: false,
+  required: [],
+} as const;

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -19,6 +19,7 @@ export type ClientOptions = {
   features?: {
     'broadcasts-get'?: true;
     'broadcasts-list'?: true;
+    'broadcasts-notifications-list'?: true;
     'imports-create'?: true;
     'imports-get'?: true;
     'users-push-subscriptions-delete'?: true;


### PR DESCRIPTION
This adds the `broadcasts.notifications.list` method to the client.

```ts
const notifications = magicbell.broadcasts.notifications.list(broadcastId, { per_page: 10 });
await notifications.forEach((notification) => {
  console.log(notification.id);
});
```