### PR TITLE
feat: update broadcasts schemas to match api changes

### DIFF
--- a/.changeset/olive-carrots-admire.md
+++ b/.changeset/olive-carrots-admire.md
@@ -1,0 +1,11 @@
+---
+'magicbell': minor
+---
+
+Update schemas for broadcast methods.
+
+- dropped `broadcast.recipients_count`, use `broadcast.status.summary.total` instead.
+- broadcast notification `status` is now an enum string.
+- `sent_at` timestamps are now iso-strings.
+- added `created_at` to broadcast.
+- added `title` to broadcast notification

--- a/.changeset/olive-carrots-admire.md
+++ b/.changeset/olive-carrots-admire.md
@@ -6,6 +6,6 @@ Update schemas for broadcast methods.
 
 - dropped `broadcast.recipients_count`, use `broadcast.status.summary.total` instead.
 - broadcast notification `status` is now an enum string.
-- `sent_at` timestamps are now iso-strings.
+- changed `sent_at` timestamps to be iso-strings.
 - added `created_at` to broadcast.
 - added `title` to broadcast notification

--- a/packages/magicbell/src/schemas/broadcasts.ts
+++ b/packages/magicbell/src/schemas/broadcasts.ts
@@ -34,7 +34,7 @@ export const ListBroadcastsResponseSchema = {
 
       items: {
         type: 'object',
-        required: ['id', 'title', 'sent_at'],
+        required: ['id', 'title', 'created_at', 'recipients', 'status'],
         additionalProperties: false,
 
         properties: {
@@ -90,8 +90,17 @@ export const ListBroadcastsResponseSchema = {
           },
 
           sent_at: {
-            type: 'number',
+            type: 'string',
+            format: 'date-time',
             description: 'The timestamp when the notification was sent to its recipients.',
+            readOnly: true,
+            nullable: true,
+          },
+
+          created_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'The timestamp when the notification was created.',
             readOnly: true,
           },
 
@@ -139,7 +148,6 @@ export const ListBroadcastsResponseSchema = {
                   properties: {
                     external_id: {
                       type: 'string',
-                      format: 'email',
                       description: 'The identifying external_id of the recipient.',
                       nullable: false,
                     },
@@ -149,32 +157,51 @@ export const ListBroadcastsResponseSchema = {
             },
           },
 
-          recipients_count: {
-            type: 'integer',
-            description: 'The number of recipients that the broadcast was sent to.',
-            readOnly: true,
-            nullable: false,
-          },
-
           overrides: {
             type: 'object',
             additionalProperties: true,
           },
 
-          processing_status: {
-            status: 'string',
+          status: {
+            type: 'object',
+            required: ['status', 'summary', 'errors'],
+            additionalProperties: true,
 
-            summary: {
-              type: 'object',
-              additionalProperties: false,
+            properties: {
+              status: {
+                type: 'string',
+                readOnly: true,
+                nullable: false,
+              },
 
-              properties: {
-                total: {
-                  type: 'integer',
+              summary: {
+                type: 'object',
+                required: ['total', 'failures'],
+                additionalProperties: false,
+
+                properties: {
+                  total: {
+                    type: 'integer',
+                    description: 'The number of recipients that the broadcast was sent to.',
+                    readOnly: true,
+                    nullable: false,
+                  },
+
+                  failures: {
+                    type: 'integer',
+                    description: 'The number of failures while processing the broadcast.',
+                    readOnly: true,
+                    nullable: false,
+                  },
                 },
+              },
 
-                failures: {
-                  type: 'integer',
+              errors: {
+                type: 'array',
+
+                items: {
+                  type: 'object',
+                  additionalProperties: true,
                 },
               },
             },
@@ -210,7 +237,7 @@ export const ListBroadcastsPayloadSchema = {
 export const GetBroadcastsResponseSchema = {
   title: 'GetBroadcastsResponseSchema',
   type: 'object',
-  required: ['id', 'title', 'sent_at'],
+  required: ['id', 'title', 'created_at', 'recipients', 'status'],
   additionalProperties: false,
 
   properties: {
@@ -265,8 +292,17 @@ export const GetBroadcastsResponseSchema = {
     },
 
     sent_at: {
-      type: 'number',
+      type: 'string',
+      format: 'date-time',
       description: 'The timestamp when the notification was sent to its recipients.',
+      readOnly: true,
+      nullable: true,
+    },
+
+    created_at: {
+      type: 'string',
+      format: 'date-time',
+      description: 'The timestamp when the notification was created.',
       readOnly: true,
     },
 
@@ -314,7 +350,6 @@ export const GetBroadcastsResponseSchema = {
             properties: {
               external_id: {
                 type: 'string',
-                format: 'email',
                 description: 'The identifying external_id of the recipient.',
                 nullable: false,
               },
@@ -324,32 +359,51 @@ export const GetBroadcastsResponseSchema = {
       },
     },
 
-    recipients_count: {
-      type: 'integer',
-      description: 'The number of recipients that the broadcast was sent to.',
-      readOnly: true,
-      nullable: false,
-    },
-
     overrides: {
       type: 'object',
       additionalProperties: true,
     },
 
-    processing_status: {
-      status: 'string',
+    status: {
+      type: 'object',
+      required: ['status', 'summary', 'errors'],
+      additionalProperties: true,
 
-      summary: {
-        type: 'object',
-        additionalProperties: false,
+      properties: {
+        status: {
+          type: 'string',
+          readOnly: true,
+          nullable: false,
+        },
 
-        properties: {
-          total: {
-            type: 'integer',
+        summary: {
+          type: 'object',
+          required: ['total', 'failures'],
+          additionalProperties: false,
+
+          properties: {
+            total: {
+              type: 'integer',
+              description: 'The number of recipients that the broadcast was sent to.',
+              readOnly: true,
+              nullable: false,
+            },
+
+            failures: {
+              type: 'integer',
+              description: 'The number of failures while processing the broadcast.',
+              readOnly: true,
+              nullable: false,
+            },
           },
+        },
 
-          failures: {
-            type: 'integer',
+        errors: {
+          type: 'array',
+
+          items: {
+            type: 'object',
+            additionalProperties: true,
           },
         },
       },

--- a/packages/magicbell/src/schemas/broadcasts/notifications.ts
+++ b/packages/magicbell/src/schemas/broadcasts/notifications.ts
@@ -58,65 +58,69 @@ export const ListBroadcastsNotificationsResponseSchema = {
           },
 
           sent_at: {
-            type: 'number',
-            description: 'The timestamp when the notification was sent to its recipients.',
-            readOnly: true,
+            type: 'string',
           },
 
-          user: {
+          recipient: {
             type: 'object',
-            additionalProperties: false,
 
             properties: {
-              id: {
-                type: 'string',
-                description: 'The unique id for this user.',
-                readOnly: true,
-              },
-
-              external_id: {
-                type: 'string',
-                description:
-                  "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
-                maxLength: 255,
-                nullable: true,
-              },
-
-              email: {
-                type: 'string',
-                description: "The user's email.",
-                maxLength: 255,
-                nullable: true,
-              },
-
-              first_name: {
-                type: 'string',
-                description: "The user's first name.",
-                maxLength: 50,
-                nullable: true,
-              },
-
-              last_name: {
-                type: 'string',
-                description: "The user's last name.",
-                maxLength: 50,
-                nullable: true,
-              },
-
-              custom_attributes: {
+              user: {
                 type: 'object',
-                description:
-                  "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
-                additionalProperties: true,
-              },
+                additionalProperties: false,
 
-              phone_numbers: {
-                type: 'array',
-                description: 'An array of phone numbers to use for sending SMS notifications.',
-                maxItems: 50,
+                properties: {
+                  id: {
+                    type: 'string',
+                    description: 'The unique id for this user.',
+                    readOnly: true,
+                  },
 
-                items: {
-                  type: 'string',
+                  external_id: {
+                    type: 'string',
+                    description:
+                      "A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable.",
+                    maxLength: 255,
+                    nullable: true,
+                  },
+
+                  email: {
+                    type: 'string',
+                    description: "The user's email.",
+                    maxLength: 255,
+                    nullable: true,
+                  },
+
+                  first_name: {
+                    type: 'string',
+                    description: "The user's first name.",
+                    maxLength: 50,
+                    nullable: true,
+                  },
+
+                  last_name: {
+                    type: 'string',
+                    description: "The user's last name.",
+                    maxLength: 50,
+                    nullable: true,
+                  },
+
+                  custom_attributes: {
+                    type: 'object',
+                    description:
+                      "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
+                    additionalProperties: true,
+                  },
+
+                  phone_numbers: {
+                    type: 'array',
+                    description: 'An array of phone numbers to use for sending SMS notifications.',
+                    maxItems: 50,
+
+                    items: {
+                      type: 'string',
+                    },
+                  },
                 },
               },
             },
@@ -127,16 +131,23 @@ export const ListBroadcastsNotificationsResponseSchema = {
 
             items: {
               type: 'object',
-              required: ['id', 'channel', 'scheduled_at', 'status'],
+              required: ['id', 'title', 'channel', 'scheduled_at', 'status'],
               additionalProperties: false,
 
               properties: {
                 id: {
                   type: 'string',
+                  nullable: false,
+                },
+
+                title: {
+                  type: 'string',
+                  nullable: false,
                 },
 
                 channel: {
                   type: 'string',
+                  nullable: false,
                 },
 
                 scheduled_at: {
@@ -145,8 +156,10 @@ export const ListBroadcastsNotificationsResponseSchema = {
                 },
 
                 status: {
-                  type: 'integer',
+                  type: 'string',
                   description: '0: unseen, 5: unread, 10: read, 20: archived',
+                  enum: ['processing', 'scheduled', 'sent', 'invalid'],
+                  nullable: false,
                 },
               },
             },


### PR DESCRIPTION
Update schemas for broadcast methods.

- dropped `broadcast.recipients_count`, use `broadcast.status.summary.total` instead.
- broadcast notification `status` is now an enum string.
- changed `sent_at` timestamps to be iso-strings.
- added `created_at` to broadcast.
- added `title` to broadcast notification