### PR TITLE
feat: support css variables as theme color value

### DIFF
--- a/.changeset/stale-yaks-hug.md
+++ b/.changeset/stale-yaks-hug.md
@@ -1,0 +1,19 @@
+---
+'@magicbell/magicbell-react': minor
+---
+
+feat: support css variables as theme color value
+
+```tsx
+import MagicBell, { NotificationInbox } from '@magicbell/magicbell-react';
+
+const customTheme = {
+  icon: {
+    borderColor: 'var(--magicbell-icon-border-color)',
+  },
+};
+
+<MagicBell theme={customTheme} apiKey={...} userEmail={...}>
+    {() => <NotificationInbox height={500} />}
+</MagicBell>
+```

--- a/packages/react/src/lib/color.ts
+++ b/packages/react/src/lib/color.ts
@@ -7,6 +7,8 @@ import tinycolor from 'tinycolor2';
  * @param alpha Alpha for this color
  */
 export function toRGBA(baseColor: string, alpha: number) {
+  // tinycolor doesn't support css variables, so assume the variable is correct as is
+  if (baseColor.startsWith('var(')) return baseColor; 
   const color = tinycolor(baseColor);
   color.setAlpha(alpha);
 


### PR DESCRIPTION
I can clean up the comments if not needed, but this fixed an issue of magicbell ui not respecting my sites theme css variables in some cases.