### PR TITLE
fix: rename users.fetch to users.get

### DIFF
--- a/.changeset/many-lobsters-dance.md
+++ b/.changeset/many-lobsters-dance.md
@@ -1,0 +1,5 @@
+---
+'magicbell': minor
+---
+
+fix: rename users.fetch to users.get

--- a/.changeset/many-lobsters-dance.md
+++ b/.changeset/many-lobsters-dance.md
@@ -2,4 +2,4 @@
 'magicbell': minor
 ---
 
-fix: rename users.fetch to users.get
+Rename `users.fetch` to `users.get`. Tho it's in theory a breaking change, the users api is relatively new, and the convention in this sdk is to use `get` for single entity retrieval, and not `fetch`. So we're going with a `minor` instead to get this fixed.

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -587,12 +587,12 @@ await magicbell.users.list({
 });
 ```
 
-#### Fetch user by ID
+#### Get user by ID
 
 Fetch a user by id, for the project identified by the auth keys.
 
 ```js
-await magicbell.users.fetch('{user_id}');
+await magicbell.users.get('{user_id}');
 ```
 
 #### Update a user

--- a/packages/magicbell/src/resources/users.ts
+++ b/packages/magicbell/src/resources/users.ts
@@ -12,7 +12,7 @@ type CreateUsersResponse = FromSchema<typeof schemas.CreateUsersResponseSchema>;
 type CreateUsersPayload = FromSchema<typeof schemas.CreateUsersPayloadSchema>;
 type ListUsersResponse = FromSchema<typeof schemas.ListUsersResponseSchema>;
 type ListUsersPayload = FromSchema<typeof schemas.ListUsersPayloadSchema>;
-type FetchUsersResponse = FromSchema<typeof schemas.FetchUsersResponseSchema>;
+type GetUsersResponse = FromSchema<typeof schemas.GetUsersResponseSchema>;
 type UpdateUsersResponse = FromSchema<typeof schemas.UpdateUsersResponseSchema>;
 type UpdateUsersPayload = FromSchema<typeof schemas.UpdateUsersPayloadSchema>;
 type UpdateByEmailUsersResponse = FromSchema<typeof schemas.UpdateByEmailUsersResponseSchema>;
@@ -95,7 +95,7 @@ export class Users extends Resource {
    * @param options - override client request options.
    * @returns
    **/
-  fetch(userId: string, options?: RequestOptions): Promise<FetchUsersResponse> {
+  get(userId: string, options?: RequestOptions): Promise<GetUsersResponse> {
     return this.request(
       {
         method: 'GET',

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -262,8 +262,8 @@ export const ListUsersPayloadSchema = {
   required: [],
 } as const;
 
-export const FetchUsersResponseSchema = {
-  title: 'FetchUsersResponseSchema',
+export const GetUsersResponseSchema = {
+  title: 'GetUsersResponseSchema',
   type: 'object',
   additionalProperties: false,
 


### PR DESCRIPTION
rename `users.fetch` to `users.get`. Tho it's technically a breaking change, the users api is so new that I consider this a fix. The convention in the sdk is to use `get` for single entity retrievals, not `fetch`.