### PR TITLE
feat: add @magicbell/webpush package

### DIFF
--- a/.changeset/angry-numbers-join.md
+++ b/.changeset/angry-numbers-join.md
@@ -1,0 +1,13 @@
+---
+'@magicbell/webpush': major
+---
+
+Publish `@magicbell/webpush`, this package provides a convenient interface to subscribe to browser/web push notifications using [MagicBell](https://magicbell.com).
+
+```js
+import { subscribe } from '@magicbell/webpush';
+
+subscribe({
+  token: 'jwt-token',
+});
+```

--- a/.changeset/angry-numbers-join.md
+++ b/.changeset/angry-numbers-join.md
@@ -1,5 +1,5 @@
 ---
-'@magicbell/webpush': major
+'@magicbell/webpush': minor
 ---
 
 Publish `@magicbell/webpush`, this package provides a convenient interface to subscribe to browser/web push notifications using [MagicBell](https://magicbell.com).

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -1,0 +1,51 @@
+# MagicBell WebPush Library
+
+This package provides a convenient interface to subscribe to browser/web push notifications using [MagicBell](https://magicbell.com).
+
+## Installation
+
+Install the package with npm:
+
+```sh
+npm install @magicbell/webpush --save
+```
+
+or yarn:
+
+```sh
+yarn add @magicbell/webpush
+```
+
+## Usage
+
+```js
+import { subscribe } from '@magicbell/webpush';
+
+subscribe({
+  token: 'jwt-token',
+  host: 'https://api.magicbell.com',
+});
+```
+
+### Options
+
+**token** _String_
+
+The JWT token you received from the MagicBell API. This token is used to authenticate the request.
+
+**host** _String_
+
+Optional. The host of the MagicBell API. Defaults to `https://api.magicbell.com`.
+
+## Support
+
+New features and bug fixes are released on the latest major version of the `magicbell` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+
+## Credits
+
+Credit where credits due, this package is inspired by and based on the [Stripe Node.js SDK](https://github.com/stripe/stripe-node).
+
+[dashboard]: https://app.magicbell.com
+[idempotent-requests]: https://www.magicbell.com/docs/rest-api/idempotent-requests
+[hmac-authentication]: https://www.magicbell.com/docs/hmac-authentication
+[api-reference]: https://www.magicbell.com/docs/rest-api/reference

--- a/packages/webpush/package.json
+++ b/packages/webpush/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@magicbell/webpush",
+  "version": "0.0.0",
+  "description": "MagicBell WebPush SDK",
+  "author": "MagicBell <bot@magicbell.io> (https://magicbell.com)",
+  "contributors": [
+    "Stephan Meijer <stephan.meijer@gmail.com>"
+  ],
+  "license": "SEE LICENSE IN LICENSE",
+  "source": "./src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/magicbell-webpush.esm.js",
+  "typings": "dist/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "/dist",
+    "/src"
+  ],
+  "homepage": "https://magicbell.com",
+  "keywords": [
+    "magicbell",
+    "notifications",
+    "notification center",
+    "notification inbox",
+    "api"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:magicbell-io/magicbell-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "run-s clean build:*",
+    "build:dev": "vite build -c ../../scripts/vite/vite.config.js",
+    "build:prod": "vite build -c ../../scripts/vite/vite.config.js --minify",
+    "start": "yarn build:dev --watch",
+    "size": "size-limit"
+  }
+}

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -1,0 +1,112 @@
+function stringToUint8Array(plainString: string) {
+  const padding = '='.repeat((4 - (plainString.length % 4)) % 4);
+  const base64 = (plainString + padding).replace(/-/g, '+').replace(/_/g, '/');
+
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+
+  return outputArray;
+}
+
+type Config = {
+  user: { id: string; email?: string | null; external_id?: string | null; hmac?: string | null };
+  project: { id: number; subdomain: string; api_key: string; vapid_public_key: string };
+  website_push_id: string;
+  baseURL: string;
+  safariPushURL: string;
+};
+
+const api = {
+  async getConfig({ token, baseURL }: { token: string; baseURL: string }) {
+    return fetch(`${baseURL}/web_push_subscriptions?access_token=${token}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    })
+      .then((x) => x.json() as Promise<{ push_subscription: Omit<Config, 'baseURL' | 'safariPushURL'> }>)
+      .then((x) => ({ ...x.push_subscription, baseURL, safariPushURL: `${baseURL}/safari/push` }));
+  },
+
+  async updateSubscription({ user, project, baseURL }: Config, subscription: PushSubscriptionJSON) {
+    const headers: Record<string, string> = {};
+    if (user.email) headers['x-magicbell-user-email'] = user.email;
+    if (user.external_id) headers['x-magicbell-user-external-id'] = user.external_id;
+    if (user.hmac) headers['x-magicbell-user-hmac'] = user.hmac;
+
+    return fetch(`${baseURL}/web_push_subscriptions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        'x-magicbell-api-key': project.api_key,
+        ...headers,
+      },
+      body: JSON.stringify({
+        web_push_subscription: {
+          data: subscription,
+        },
+      }),
+    })
+      .then((x) => x.json() as Promise<{ web_push_subscription: { id: string } }>)
+      .then((x) => x.web_push_subscription);
+  },
+};
+
+/**
+ * Request permission to send push notifications and post the subscription to the MagicBell API.
+ */
+export async function subscribe(options: { token: string; host?: string }) {
+  const config = await api.getConfig({ ...options, baseURL: options.host || location.origin });
+
+  if (!('PushManager' in window) && !('safari' in window)) {
+    throw new Error('Push notifications are not supported in this browser');
+  }
+
+  const subscription = !('PushManager' in window)
+    ? await createSafariPushSubscription(config)
+    : await createPushSubscription(config);
+
+  if (!('endpoint' in subscription)) return;
+  await api.updateSubscription(config, subscription);
+}
+
+async function createPushSubscription(config: Config): Promise<PushSubscriptionJSON> {
+  await navigator.serviceWorker.register('/sw.js');
+  const registration = await navigator.serviceWorker.ready;
+
+  const applicationServerKey = stringToUint8Array(config.project.vapid_public_key);
+  const subscription = await registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey });
+  return subscription.toJSON();
+}
+
+async function createSafariPushSubscription(config: Config): Promise<PushSubscriptionJSON> {
+  const safari = 'safari' in window ? (window['safari'] as any) : undefined;
+  if (!safari) throw new Error('This is not Safari');
+
+  const permissionData = safari.pushNotification.permission(config.website_push_id);
+  if (permissionData.permission === 'granted') return permissionData;
+  if (permissionData.permission === 'denied') throw new Error('permission denied');
+
+  return new Promise<PushSubscriptionJSON & { platform: string }>(function (resolve, reject) {
+    safari.pushNotification.requestPermission(
+      config.safariPushURL,
+      config.website_push_id,
+      { authenticationToken: config.user.id },
+      (permissionData: { deviceToken: string }) => {
+        if (!permissionData.deviceToken) return reject(new Error('permission denied'));
+
+        resolve({
+          endpoint: permissionData.deviceToken,
+          keys: { websitePushID: config.website_push_id },
+          platform: 'safari',
+        });
+      },
+    );
+  });
+}

--- a/packages/webpush/tsconfig.build.json
+++ b/packages/webpush/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src", "types", "../../types"]
+}


### PR DESCRIPTION
Adds a new package that simplifies enabling web push subscriptions using MagicBell.

```js
import { subscribe } from '@magicbell/webpush';

subscribe({
  token: 'access-token',
  host: 'https://api.magicbell.com',
});
```

The `access-token` is exposed via react sdks and can be obtained using the `/config` api.