### PR TITLE
chore: remove `total` and `total_pages` from paginated responses

### DIFF
--- a/.changeset/angry-penguins-chew.md
+++ b/.changeset/angry-penguins-chew.md
@@ -1,0 +1,11 @@
+---
+'magicbell': minor
+---
+
+The `total` and `total_pages` props are removed from the following method return types:
+
+- `magicbell.broadcasts.list()`
+- `magicbell.broadcasts.notifications.list()`
+- `magicbell.users.list()`
+
+The [auto pagination](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#using-promises) methods are updated to support the paginated responses that do not have those fields. Thereby, pagination helpers like `.list().forEach()`, `.list().toArray()` and the iterator in `for await (const node of method.list())` keep working as before.

--- a/packages/magicbell/src/paginate.ts
+++ b/packages/magicbell/src/paginate.ts
@@ -3,12 +3,16 @@ import { hasOwn } from './lib/utils';
 export const ASYNC_ITERATOR_SYMBOL =
   typeof Symbol !== 'undefined' && Symbol.asyncIterator ? Symbol.asyncIterator : '@@asyncIterator';
 
-function hasMore(pageResult) {
-  return (
-    hasOwn(pageResult, 'current_page') &&
-    hasOwn(pageResult, 'total_pages') &&
-    pageResult.current_page < pageResult.total_pages
-  );
+function hasMore(pageResult, nodeCount: number) {
+  if (!hasOwn(pageResult, 'current_page') || !hasOwn(pageResult, 'per_page')) {
+    return false;
+  }
+
+  if (hasOwn(pageResult, 'total_pages')) {
+    return pageResult.current_page < pageResult.total_pages;
+  }
+
+  return nodeCount === pageResult.per_page;
 }
 
 export function autoPaginate(makeRequest, { data, params }) {
@@ -39,7 +43,7 @@ export function autoPaginate(makeRequest, { data, params }) {
       return { value, done: false };
     }
 
-    if (hasMore(pageResult)) {
+    if (hasMore(pageResult, data.length)) {
       // Reset counter, request next page, and recurse.
       i = 0;
       request = getNextPage(pageResult);

--- a/packages/magicbell/src/schemas/broadcasts.ts
+++ b/packages/magicbell/src/schemas/broadcasts.ts
@@ -2,24 +2,12 @@
 export const ListBroadcastsResponseSchema = {
   title: 'ListBroadcastsResponseSchema',
   type: 'object',
-  required: ['broadcasts', 'current_page', 'per_page', 'total', 'total_pages'],
+  required: ['broadcasts', 'current_page', 'per_page'],
 
   properties: {
-    total: {
-      type: 'integer',
-      description: 'Total number of entities for this query.',
-      readOnly: true,
-    },
-
     per_page: {
       type: 'integer',
       description: 'Number of entities per page.',
-      readOnly: true,
-    },
-
-    total_pages: {
-      type: 'integer',
-      description: 'Total number of pages.',
       readOnly: true,
     },
 

--- a/packages/magicbell/src/schemas/broadcasts/notifications.ts
+++ b/packages/magicbell/src/schemas/broadcasts/notifications.ts
@@ -2,24 +2,12 @@
 export const ListBroadcastsNotificationsResponseSchema = {
   title: 'ListBroadcastsNotificationsResponseSchema',
   type: 'object',
-  required: ['current_page', 'notifications', 'per_page', 'total', 'total_pages'],
+  required: ['current_page', 'notifications', 'per_page'],
 
   properties: {
-    total: {
-      type: 'integer',
-      description: 'Total number of entities for this query.',
-      readOnly: true,
-    },
-
     per_page: {
       type: 'integer',
       description: 'Number of entities per page.',
-      readOnly: true,
-    },
-
-    total_pages: {
-      type: 'integer',
-      description: 'Total number of pages.',
       readOnly: true,
     },
 

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -116,25 +116,22 @@ export const CreateUsersPayloadSchema = {
 export const ListUsersResponseSchema = {
   title: 'ListUsersResponseSchema',
   type: 'object',
+  required: ['current_page', 'per_page', 'user'],
 
   properties: {
     per_page: {
       type: 'integer',
+      description: 'Number of entities per page.',
+      readOnly: true,
     },
 
     current_page: {
       type: 'integer',
+      description: 'Number of the page returned.',
+      readOnly: true,
     },
 
-    total_pages: {
-      type: 'integer',
-    },
-
-    total: {
-      type: 'integer',
-    },
-
-    users: {
+    user: {
       type: 'array',
 
       items: {


### PR DESCRIPTION
The `total` and `total_pages` props are removed from the following method return types:

- `magicbell.broadcasts.list()`
- `magicbell.broadcasts.notifications.list()`
- `magicbell.users.list()`

The [auto pagination](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#using-promises) methods are updated to support the paginated responses that do not have those fields. Thereby, pagination helpers like `.list().forEach()`, `.list().toArray()` and the iterator in `for await (const node of method.list())` keep working as before.
