### PR TITLE
fix: correct response type for users.list (#97

### DIFF
--- a/.changeset/chilly-ears-complain.md
+++ b/.changeset/chilly-ears-complain.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+fix: correct response type for `users.list()` by renaming `user` prop to `users`.

--- a/packages/magicbell/src/schemas/users.ts
+++ b/packages/magicbell/src/schemas/users.ts
@@ -116,7 +116,7 @@ export const CreateUsersPayloadSchema = {
 export const ListUsersResponseSchema = {
   title: 'ListUsersResponseSchema',
   type: 'object',
-  required: ['current_page', 'per_page', 'user'],
+  required: ['current_page', 'per_page', 'users'],
 
   properties: {
     per_page: {
@@ -131,7 +131,7 @@ export const ListUsersResponseSchema = {
       readOnly: true,
     },
 
-    user: {
+    users: {
       type: 'array',
 
       items: {


### PR DESCRIPTION
fix: correct response type for `users.list()` by renaming `user` prop to `users`.
