### PR TITLE
feat: support theming the enable-push-subscription dialog (#103

### DIFF
--- a/.changeset/eight-maps-brush.md
+++ b/.changeset/eight-maps-brush.md
@@ -3,7 +3,6 @@
 ---
 
 feat: Add support for theming the enable-push-subscriptions dialog.
-.
 
 ```typescript jsx
 const theme = {

--- a/.changeset/eight-maps-brush.md
+++ b/.changeset/eight-maps-brush.md
@@ -1,0 +1,20 @@
+---
+'@magicbell/magicbell-react': minor
+---
+
+feat: Add support for theming the enable-push-subscriptions dialog.
+.
+
+```typescript jsx
+const theme = {
+  dialog: {
+    backgroundColor: '#FFFFFF',
+    textColor: '#3A424D',
+    accentColor: '#5225C1',
+  }
+}
+
+<MagicBell theme={theme} apiKey={...} userEmail={...}>
+    {() => <NotificationInbox height={500} />}
+</MagicBell>
+```

--- a/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
+++ b/packages/react/src/components/EnablePushNotificationsBanner/EnablePushNotificationsBanner.tsx
@@ -18,12 +18,10 @@ import EnablePushNotificationsButton from './EnablePushNotificationsButton';
  * <EnablePushNotificationsBanner />
  */
 export default function EnablePushNotificationsBanner() {
-  const config = useConfig();
-  const { channels } = config;
+  const { channels } = useConfig();
   const isWebPushEnabled = pathOr(false, ['webPush', 'enabled'], channels);
 
-  const { getState } = clientSettings;
-  const { apiKey, userEmail, userExternalId } = getState();
+  const { apiKey, userEmail, userExternalId } = clientSettings.getState();
 
   const theme = useTheme();
 
@@ -34,14 +32,17 @@ export default function EnablePushNotificationsBanner() {
 
   const enablePushNotifications = () => {
     const subscribeUrl = path<string>(['webPush', 'config', 'subscribeUrl'], channels);
-
-    const { backgroundColor, textColor } = theme.header;
+    const { accentColor, backgroundColor, textColor } = theme.dialog;
 
     const url = new URL(subscribeUrl);
-    if (userEmail) url.searchParams.append('user_email', userEmail);
-    if (userExternalId) url.searchParams.append('user_external_id', userExternalId);
-    if (backgroundColor) url.searchParams.append('background_color', backgroundColor);
-    if (textColor) url.searchParams.append('text_color', textColor);
+    if (userEmail) url.searchParams.set('user_email', userEmail);
+    if (userExternalId) url.searchParams.set('user_external_id', userExternalId);
+
+    if (accentColor && backgroundColor && textColor) {
+      url.searchParams.set('background_color', backgroundColor);
+      url.searchParams.set('text_color', textColor);
+      url.searchParams.set('accent_color', textColor);
+    }
 
     setRequestedAt(Date.now());
     openWindow(url.toString());

--- a/packages/react/src/context/Theme.ts
+++ b/packages/react/src/context/Theme.ts
@@ -83,6 +83,11 @@ export interface IMagicBellTheme {
     unread: NotificationTheme;
     unseen: NotificationTheme;
   };
+  dialog: {
+    backgroundColor: string;
+    textColor: string;
+    accentColor: string;
+  };
 }
 
 export const defaultTheme: IMagicBellTheme = lightTheme;

--- a/packages/react/src/themes/classic.ts
+++ b/packages/react/src/themes/classic.ts
@@ -66,6 +66,11 @@ export const classicTheme: DeepPartial<IMagicBellTheme> = {
     fontSize: '12px',
     boxShadow: 'none',
   },
+  dialog: {
+    backgroundColor: colors.bg,
+    textColor: colors.text,
+    accentColor: colors.accent,
+  },
   unseenBadge: {
     backgroundColor: colors.badge,
     backgroundOpacity: 1,

--- a/packages/react/src/themes/flat.ts
+++ b/packages/react/src/themes/flat.ts
@@ -52,6 +52,11 @@ export const flatTheme: DeepPartial<IMagicBellTheme> = {
     fontSize: '12px',
     boxShadow: `inset 0 1px 0 0 ${colors.stroke}`,
   },
+  dialog: {
+    backgroundColor: colors.bg,
+    textColor: colors.text,
+    accentColor: colors.accent,
+  },
   unseenBadge: {
     backgroundColor: colors.badge,
   },

--- a/packages/react/src/themes/light.ts
+++ b/packages/react/src/themes/light.ts
@@ -147,6 +147,12 @@ const unreadNotification: IMagicBellTheme['notification']['unread'] = {
   },
 };
 
+const dialog: IMagicBellTheme['dialog'] = {
+  backgroundColor: colors.bg,
+  textColor: colors.text,
+  accentColor: colors.accent,
+};
+
 export const lightTheme: IMagicBellTheme = {
   prose,
   icon,
@@ -154,6 +160,7 @@ export const lightTheme: IMagicBellTheme = {
   header,
   footer,
   banner,
+  dialog,
   unseenBadge,
   container,
   notification: {


### PR DESCRIPTION
Add support for theming the enable-push-subscriptions dialog.

```typescript jsx
const theme = {
  dialog: {
    backgroundColor: '#FFFFFF',
    textColor: '#3A424D',
    accentColor: '#5225C1',
  }
}

<MagicBell theme={theme} apiKey={...} userEmail={...}>
    {() => <NotificationInbox height={500} />}
</MagicBell>
```