### PR TITLE
feat: add `registerServiceWorker` method

### DIFF
--- a/.changeset/silly-olives-drive.md
+++ b/.changeset/silly-olives-drive.md
@@ -1,0 +1,22 @@
+---
+'@magicbell/webpush': major
+---
+
+feat: add `registerServiceWorker` method that can be used to register a service
+worker, prior to calling `subscribe`. This preflight allows for a faster
+subscription process.
+
+Registration will be skipped if a service worker is already registered. In which
+case, the active registration will be returned.
+
+The returned promise resolves when the registration is ready.
+
+```js
+import { registerServiceWorker } from '@magicbell/webpush';
+registerServiceWorker({ path: '/sw.js' });
+```
+
+**NOTE:**
+
+This milestone also marks the `@magicbell/webpush` as stable. We will be following
+[semantic versioning](https://semver.org/) going forward.

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -18,16 +18,20 @@ yarn add @magicbell/webpush
 
 ## Usage
 
+### Subscribe
+
 ```js
 import { subscribe } from '@magicbell/webpush';
 
 subscribe({
   token: 'jwt-token',
   host: 'https://api.magicbell.com',
+  project: 'string',
+  serviceWorkerPath: '/sw.js',
 });
 ```
 
-### Options
+#### Options
 
 **token** _String_
 
@@ -36,6 +40,38 @@ The JWT token you received from the MagicBell API. This token is used to authent
 **host** _String_
 
 Optional. The host of the MagicBell API. Defaults to `https://api.magicbell.com`.
+
+**project** _String_
+
+The random subdomain that MagicBell generated for your service worker registration.
+
+**serviceWorkerPath** _String_
+
+The path to the service worker file. Defaults to `/sw.js`.
+
+### Register a service worker
+
+A helper that can be used to register a service worker, prior to calling `subscribe`. This preflight allows for a faster
+subscription process. If this method isn't used, registration will be done during `subscribe`.
+
+Registration will be skipped if a service worker is already registered. In which case, the
+active registration will be returned.
+
+The returned promise resolves when the registration is ready.
+
+```js
+import { registerServiceWorker } from '@magicbell/webpush';
+
+registerServiceWorker({
+  path: '/sw.js',
+});
+```
+
+### Options
+
+**path** _String_
+
+The path to the service worker file. Defaults to `/sw.js`.
 
 ## Support
 

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -67,7 +67,7 @@ registerServiceWorker({
 });
 ```
 
-### Options
+#### Options
 
 **path** _String_
 


### PR DESCRIPTION
Add `registerServiceWorker` method that can be used to register a service worker, prior to calling `subscribe`. This preflight allows for a faster subscription process.

Registration will be skipped if a service worker is already registered. In which case, the active registration will be returned.

The returned promise resolves when the registration is ready.

```js
import { registerServiceWorker } from '@magicbell/webpush';
registerServiceWorker({ path: '/sw.js' });
```

**NOTE:**

This milestone also marks the `@magicbell/webpush` as stable. We will be following [semantic versioning](https://semver.org/) going forward.