### PR TITLE
chore: support safari proprietary push protocol

### DIFF
--- a/.changeset/old-suits-deliver.md
+++ b/.changeset/old-suits-deliver.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/webpush': minor
+---
+
+Restore support for Safari proprietary push protocol.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@magicbell/react-headless": "4.2.7",
-    "@magicbell/webpush": "^1.0.0",
+    "@magicbell/webpush": "1.1.0",
     "@tippyjs/react": "^4.2.5",
     "dayjs": "^1.11.5",
     "humps": "^2.0.1",

--- a/packages/react/src/components/PushNotificationsSubscriber/PushNotificationsSubscriber.tsx
+++ b/packages/react/src/components/PushNotificationsSubscriber/PushNotificationsSubscriber.tsx
@@ -1,5 +1,5 @@
 import { useConfig } from '@magicbell/react-headless';
-import { registerServiceWorker, subscribe } from '@magicbell/webpush';
+import { isSupported, registerServiceWorker, subscribe } from '@magicbell/webpush';
 import { useEffect } from 'react';
 
 export interface Props {
@@ -25,7 +25,7 @@ export default function PushNotificationsSubscriber({
   skipServiceWorkerRegistration = false,
 }: Props) {
   const config = useConfig();
-  const isPushAPISupported = 'PushManager' in window;
+  const isPushAPISupported = isSupported();
 
   useEffect(() => {
     if (skipServiceWorkerRegistration) return;

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -8,10 +8,21 @@ type Config = {
   user: { id: string; email?: string | null; external_id?: string | null; hmac?: string | null };
   project: { id: number; subdomain: string; api_key: string; vapid_public_key: string };
   website_push_id: string;
+  baseURL: string;
+  safariPushURL: string;
+  serviceWorkerPath?: string;
 };
+
+type PushSubscription = Omit<Config, 'baseURL' | 'safariPushURL'>;
+
+let _config: (PushSubscription & Pick<Config, 'safariPushURL' | 'baseURL'>) | null = null;
+let _cacheKey = '';
 
 const api = {
   async getConfig({ token, project, baseURL }: RequestOptions) {
+    const cacheKey = [token, project, baseURL].join('-');
+    if (_config && _cacheKey === cacheKey) return _config;
+
     return fetch(`${baseURL}/web_push_subscriptions?access_token=${token}&project=${project}`, {
       method: 'GET',
       headers: {
@@ -19,8 +30,12 @@ const api = {
         Accept: 'application/json',
       },
     })
-      .then((x) => x.json() as Promise<{ push_subscription: Config }>)
-      .then((x) => ({ ...x.push_subscription, baseURL }));
+      .then((x) => x.json() as Promise<{ push_subscription: PushSubscription }>)
+      .then((x) => {
+        _config = { ...x.push_subscription, baseURL, safariPushURL: `${baseURL}/safari/push` };
+        _cacheKey = cacheKey;
+        return _config;
+      });
   },
 
   async updateSubscription({ token, project, baseURL }: RequestOptions, subscription: PushSubscriptionJSON) {
@@ -41,6 +56,11 @@ const api = {
   },
 };
 
+export function isSupported() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
+  return ('PushManager' in window && 'serviceWorker' in navigator) || 'safari' in window;
+}
+
 export async function registerServiceWorker({ path = '/sw.js' }: { path?: string } = {}) {
   // don't register a service-worker if there's already one
   if (navigator.serviceWorker.controller) return navigator.serviceWorker.ready;
@@ -48,22 +68,35 @@ export async function registerServiceWorker({ path = '/sw.js' }: { path?: string
   return navigator.serviceWorker.ready;
 }
 
-/**
- * Request permission to send push notifications and post the subscription to the MagicBell API.
- */
-export async function subscribe(options: {
+type SubscribeOptions = {
   token: string;
   project: string;
   host?: string;
   serviceWorkerPath?: string;
-}) {
-  if (!('PushManager' in window)) {
+};
+
+/**
+ * Request permission to send push notifications and post the subscription to the MagicBell API.
+ */
+export async function subscribe(options: SubscribeOptions) {
+  const requestOptions = { ...options, baseURL: options.host || location.origin };
+  const config = await api.getConfig(requestOptions);
+
+  if (!isSupported()) {
     throw new Error('Push notifications are not supported in this browser');
   }
 
-  const baseURL = options.host || location.origin;
-  const config = await api.getConfig({ ...options, baseURL });
-  const registration = await registerServiceWorker({ path: options.serviceWorkerPath });
+  const subscription =
+    'PushManager' in window
+      ? await createPushSubscription({ ...options, ...config })
+      : await createSafariPushSubscription(config);
+
+  if (!('endpoint' in subscription)) throw new Error('Invalid subscription');
+  await api.updateSubscription(requestOptions, subscription);
+}
+
+async function createPushSubscription(config: Config): Promise<PushSubscriptionJSON> {
+  const registration = await registerServiceWorker({ path: config.serviceWorkerPath });
 
   // remove active subscription if there's any
   const activeSubscription = await registration.pushManager.getSubscription();
@@ -71,16 +104,37 @@ export async function subscribe(options: {
     await activeSubscription.unsubscribe().catch(() => void 0);
   }
 
-  // strip the base64 padding, it's either that or convert to uint8array
   const applicationServerKey = config.project.vapid_public_key.replace(/=/g, '');
+  const subscription = await registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey });
+  return subscription.toJSON();
+}
 
-  const subscription = await registration.pushManager
-    .subscribe({ userVisibleOnly: true, applicationServerKey })
-    .then((x) => x.toJSON());
+export async function prefetchConfig(options: SubscribeOptions) {
+  await api.getConfig({ ...options, baseURL: options.host || location.origin });
+}
 
-  if (!('endpoint' in subscription)) {
-    throw new Error('Failed to subscribe to push notifications, browser did not return an subscription endpoint.');
-  }
+async function createSafariPushSubscription(config: Config): Promise<PushSubscriptionJSON> {
+  const safari = 'safari' in window ? (window['safari'] as any) : undefined;
+  if (!safari) throw new Error('This is not Safari');
 
-  await api.updateSubscription({ ...options, baseURL }, subscription);
+  const permissionData = safari.pushNotification.permission(config.website_push_id);
+  if (permissionData.permission === 'granted') return permissionData;
+  if (permissionData.permission === 'denied') throw new Error('permission denied');
+
+  return new Promise<PushSubscriptionJSON & { platform: string }>(function (resolve, reject) {
+    safari.pushNotification.requestPermission(
+      config.safariPushURL,
+      config.website_push_id,
+      { authenticationToken: config.user.id },
+      (permissionData: { deviceToken: string }) => {
+        if (!permissionData.deviceToken) return reject(new Error('permission denied'));
+
+        resolve({
+          endpoint: permissionData.deviceToken,
+          keys: { websitePushID: config.website_push_id },
+          platform: 'safari',
+        });
+      },
+    );
+  });
 }


### PR DESCRIPTION
Restore support for Safari proprietary push protocol. It's too early to ditch it, as Safari for iOS does not yet support Web Push.