### PR TITLE
feat: add support for per-request header overrides

### DIFF
--- a/.changeset/smart-fans-shop.md
+++ b/.changeset/smart-fans-shop.md
@@ -1,0 +1,24 @@
+---
+'magicbell': minor
+---
+
+Added support for per-request header overrides
+
+```js
+const magicbell = new Client({
+  headers: {
+    'x-custom-header-one': 'one',
+  },
+});
+
+await client.request({
+  path: '/me',
+  headers: {
+    'x-custom-header-two': 'two',
+  },
+});
+
+// request is made using the following headers:
+//   x-custom-header-one: one
+//   x-custom-header-two: two
+```

--- a/packages/magicbell/src/client.test.ts
+++ b/packages/magicbell/src/client.test.ts
@@ -163,3 +163,26 @@ test("custom headers don't override controlled ones", async () => {
   await client.request({ method: 'POST', path: '/me' });
   expect(status.lastRequest.headers.get('x-magicbell-api-key')).toEqual('my-api-key');
 });
+
+test('custom headers can be provided per request basis', async () => {
+  const status = server.intercept('all', () => ({ id: 1 }));
+
+  const client = new Client({
+    apiKey: 'my-api-key',
+    maxRetryDelay: 0,
+    headers: {
+      'x-custom-header-one': 'one',
+    },
+  });
+
+  await client.request({
+    method: 'POST',
+    path: '/me',
+    headers: {
+      'x-custom-header-two': 'two',
+    },
+  });
+
+  expect(status.lastRequest.headers.get('x-custom-header-one')).toEqual('one');
+  expect(status.lastRequest.headers.get('x-custom-header-two')).toEqual('two');
+});

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -47,4 +47,5 @@ export type RequestArgs = {
   path: string;
   data?: Record<string, unknown>;
   params?: Record<string, string>;
+  headers?: Record<string, string>;
 };


### PR DESCRIPTION
Added support for per-request header overrides

```js
const magicbell = new Client({
  headers: {
    'x-custom-header-one': 'one',
  },
});

await client.request({
  path: '/me',
  headers: {
    'x-custom-header-two': 'two',
  },
});

// request is made using the following headers:
//   x-custom-header-one: one
//   x-custom-header-two: two
```