### PR TITLE
fix: prettify feature table during generation

### DIFF
--- a/packages/magicbell/scripts/generate-resources.ts
+++ b/packages/magicbell/scripts/generate-resources.ts
@@ -303,7 +303,7 @@ function createFeatureFlagTable(methods: Method[]) {
     lines.push(`| \`${method.operationId}\` | ${method.summary} ([docs](#${method.operationId})) |`);
   }
 
-  return lines.join('\n');
+  return formatMarkdown(lines.join('\n'));
 }
 
 async function updateTypes(filePath: string, betaMethods: Method[]) {


### PR DESCRIPTION
Forgot to format the feature flag table during code-generation. Pre-commit still caught it, but having the false positive in the git diff --staged, only complicates reading the real changes.