### PR TITLE
feat: add metrics resource

### DIFF
--- a/.changeset/famous-shrimps-dress.md
+++ b/.changeset/famous-shrimps-dress.md
@@ -1,0 +1,13 @@
+---
+'magicbell': minor
+---
+
+Added the `metrics` resource. The metrics resource contains a collection of endpoints that return metrics about the sent Notifications. All metrics are for the last 30 days. The following endpoints are available:
+
+```ts
+const notificationCounts = await magicbell.metrics.get();
+
+const countsPerCategory = await magicbell.metrics.categories.get();
+
+const countsPerTopic = await magicbell.metrics.topics.get();
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -915,6 +915,36 @@ Query the status of the import for a summary of imported records and failures fo
 await magicbell.imports.get('{import_id}');
 ```
 
+### Metrics
+
+#### Get notification metrics
+
+Query the metrics of notification broadcasts and their recipients.
+
+```js
+await magicbell.metrics.get();
+```
+
+### Metrics Categories
+
+#### Get notification metrics grouped by category
+
+Query the metrics of notification broadcasts and their recipients, grouped by category.
+
+```js
+await magicbell.metrics.categories.get();
+```
+
+### Metrics Topics
+
+#### Get notification metrics grouped by topic
+
+Query the metrics of notification broadcasts and their recipients, grouped by topic.
+
+```js
+await magicbell.metrics.topics.get();
+```
+
 <!-- AUTO-GENERATED-CONTENT:END (RESOURCE_METHODS) -->
 
 ## Realtime

--- a/packages/magicbell/src/client.ts
+++ b/packages/magicbell/src/client.ts
@@ -10,6 +10,7 @@ import { createListener } from './listen';
 import { isOptionsHash } from './options';
 import { Broadcasts } from './resources/broadcasts';
 import { Imports } from './resources/imports';
+import { Metrics } from './resources/metrics';
 import { NotificationPreferences } from './resources/notification-preferences';
 import { Notifications } from './resources/notifications';
 import { PushSubscriptions } from './resources/push-subscriptions';
@@ -43,6 +44,7 @@ export class Client {
 
   broadcasts = new Broadcasts(this);
   imports = new Imports(this);
+  metrics = new Metrics(this);
   notificationPreferences = new NotificationPreferences(this);
   notifications = new Notifications(this);
   pushSubscriptions = new PushSubscriptions(this);

--- a/packages/magicbell/src/resources/metrics.ts
+++ b/packages/magicbell/src/resources/metrics.ts
@@ -1,0 +1,33 @@
+// This file is generated. Do not update manually!
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { Resource } from '../resource';
+import * as schemas from '../schemas/metrics';
+import { type RequestOptions } from '../types';
+import { MetricsCategories } from './metrics/categories';
+import { MetricsTopics } from './metrics/topics';
+
+type GetMetricsResponse = FromSchema<typeof schemas.GetMetricsResponseSchema>;
+
+export class Metrics extends Resource {
+  path = 'metrics';
+  entity = 'metric';
+  categories = new MetricsCategories(this.client);
+  topics = new MetricsTopics(this.client);
+
+  /**
+   * Query the metrics of notification broadcasts and their recipients.
+   *
+   * @param options - override client request options.
+   * @returns
+   **/
+  get(options?: RequestOptions): Promise<GetMetricsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+      },
+      options,
+    );
+  }
+}

--- a/packages/magicbell/src/resources/metrics/categories.ts
+++ b/packages/magicbell/src/resources/metrics/categories.ts
@@ -1,0 +1,31 @@
+// This file is generated. Do not update manually!
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { Resource } from '../../resource';
+import * as schemas from '../../schemas/metrics/categories';
+import { type RequestOptions } from '../../types';
+
+type GetMetricsCategoriesResponse = FromSchema<typeof schemas.GetMetricsCategoriesResponseSchema>;
+
+export class MetricsCategories extends Resource {
+  path = 'metrics';
+  entity = 'categorie';
+
+  /**
+   * Query the metrics of notification broadcasts and their recipients, grouped by
+   * category.
+   *
+   * @param options - override client request options.
+   * @returns
+   **/
+  get(options?: RequestOptions): Promise<GetMetricsCategoriesResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        path: 'categories',
+      },
+      options,
+    );
+  }
+}

--- a/packages/magicbell/src/resources/metrics/topics.ts
+++ b/packages/magicbell/src/resources/metrics/topics.ts
@@ -1,0 +1,31 @@
+// This file is generated. Do not update manually!
+
+import { type FromSchema } from 'json-schema-to-ts';
+
+import { Resource } from '../../resource';
+import * as schemas from '../../schemas/metrics/topics';
+import { type RequestOptions } from '../../types';
+
+type GetMetricsTopicsResponse = FromSchema<typeof schemas.GetMetricsTopicsResponseSchema>;
+
+export class MetricsTopics extends Resource {
+  path = 'metrics';
+  entity = 'topic';
+
+  /**
+   * Query the metrics of notification broadcasts and their recipients, grouped by
+   * topic.
+   *
+   * @param options - override client request options.
+   * @returns
+   **/
+  get(options?: RequestOptions): Promise<GetMetricsTopicsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        path: 'topics',
+      },
+      options,
+    );
+  }
+}

--- a/packages/magicbell/src/schemas/metrics.ts
+++ b/packages/magicbell/src/schemas/metrics.ts
@@ -1,0 +1,76 @@
+// This file is generated. Do not update manually!
+export const GetMetricsResponseSchema = {
+  title: 'GetMetricsResponseSchema',
+  type: 'object',
+  required: ['metrics', 'labels', 'schema'],
+  additionalProperties: false,
+
+  properties: {
+    metrics: {
+      type: 'array',
+      nullable: false,
+
+      items: {
+        type: 'array',
+
+        items: {
+          type: 'integer',
+        },
+      },
+    },
+
+    labels: {
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    schema: {
+      type: 'object',
+      required: ['metric', 'label'],
+      additionalProperties: false,
+
+      properties: {
+        metric: {
+          type: 'array',
+
+          items: {
+            type: 'object',
+            required: ['entity', 'operation'],
+            additionalProperties: false,
+
+            properties: {
+              entity: {
+                type: 'string',
+              },
+
+              operation: {
+                type: 'string',
+                enum: ['count', 'avg', 'sum', 'min', 'max'],
+              },
+            },
+          },
+        },
+
+        label: {
+          type: 'object',
+          required: ['name', 'type'],
+          additionalProperties: false,
+
+          properties: {
+            name: {
+              type: 'string',
+            },
+
+            type: {
+              type: 'string',
+              enum: ['timestamp', 'string'],
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/schemas/metrics/categories.ts
+++ b/packages/magicbell/src/schemas/metrics/categories.ts
@@ -1,0 +1,76 @@
+// This file is generated. Do not update manually!
+export const GetMetricsCategoriesResponseSchema = {
+  title: 'GetMetricsCategoriesResponseSchema',
+  type: 'object',
+  required: ['metrics', 'labels', 'schema'],
+  additionalProperties: false,
+
+  properties: {
+    metrics: {
+      type: 'array',
+      nullable: false,
+
+      items: {
+        type: 'array',
+
+        items: {
+          type: 'integer',
+        },
+      },
+    },
+
+    labels: {
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    schema: {
+      type: 'object',
+      required: ['metric', 'label'],
+      additionalProperties: false,
+
+      properties: {
+        metric: {
+          type: 'array',
+
+          items: {
+            type: 'object',
+            required: ['entity', 'operation'],
+            additionalProperties: false,
+
+            properties: {
+              entity: {
+                type: 'string',
+              },
+
+              operation: {
+                type: 'string',
+                enum: ['count', 'avg', 'sum', 'min', 'max'],
+              },
+            },
+          },
+        },
+
+        label: {
+          type: 'object',
+          required: ['name', 'type'],
+          additionalProperties: false,
+
+          properties: {
+            name: {
+              type: 'string',
+            },
+
+            type: {
+              type: 'string',
+              enum: ['timestamp', 'string'],
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/schemas/metrics/topics.ts
+++ b/packages/magicbell/src/schemas/metrics/topics.ts
@@ -1,0 +1,76 @@
+// This file is generated. Do not update manually!
+export const GetMetricsTopicsResponseSchema = {
+  title: 'GetMetricsTopicsResponseSchema',
+  type: 'object',
+  required: ['metrics', 'labels', 'schema'],
+  additionalProperties: false,
+
+  properties: {
+    metrics: {
+      type: 'array',
+      nullable: false,
+
+      items: {
+        type: 'array',
+
+        items: {
+          type: 'integer',
+        },
+      },
+    },
+
+    labels: {
+      type: 'array',
+
+      items: {
+        type: 'string',
+      },
+    },
+
+    schema: {
+      type: 'object',
+      required: ['metric', 'label'],
+      additionalProperties: false,
+
+      properties: {
+        metric: {
+          type: 'array',
+
+          items: {
+            type: 'object',
+            required: ['entity', 'operation'],
+            additionalProperties: false,
+
+            properties: {
+              entity: {
+                type: 'string',
+              },
+
+              operation: {
+                type: 'string',
+                enum: ['count', 'avg', 'sum', 'min', 'max'],
+              },
+            },
+          },
+        },
+
+        label: {
+          type: 'object',
+          required: ['name', 'type'],
+          additionalProperties: false,
+
+          properties: {
+            name: {
+              type: 'string',
+            },
+
+            type: {
+              type: 'string',
+              enum: ['timestamp', 'string'],
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION

Added the `metrics` resource. The metrics resource contains a collection of endpoints that return metrics about the sent Notifications. All metrics are for the last 30 days. The following endpoints are available:

```ts
const notificationCounts = await magicbell.metrics.get();
const countsPerCategory = await magicbell.metrics.categories.get();
const countsPerTopic = await magicbell.metrics.topics.get();
```