### PR TITLE
feat: release broadcasts resource as stable

### DIFF
--- a/.changeset/sweet-rocks-call.md
+++ b/.changeset/sweet-rocks-call.md
@@ -1,0 +1,29 @@
+---
+'magicbell': minor
+---
+
+Release [broadcasts resource](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#broadcasts) as stable. This includes the following apis:
+
+**List notification broadcasts**
+
+```js
+await magicbell.broadcasts.list({
+  page: 1,
+  per_page: 1,
+});
+```
+
+**Fetch a notification broadcast by its ID**
+
+```js
+await magicbell.broadcasts.get('{broadcast_id}');
+```
+
+**Fetch notifications by broadcast id.**
+
+```js
+await magicbell.broadcasts.notifications.list('{broadcast_id}', {
+  page: 1,
+  per_page: 1,
+});
+```

--- a/.changeset/sweet-rocks-call.md
+++ b/.changeset/sweet-rocks-call.md
@@ -2,7 +2,7 @@
 'magicbell': minor
 ---
 
-Release [broadcasts resource](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#broadcasts) as stable. This includes the following apis:
+Release [broadcasts resource](https://www.magicbell.com/docs/rest-api/reference#list-notification-broadcasts) as stable. This includes the following apis:
 
 **List notification broadcasts**
 

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -314,15 +314,12 @@ Below is a list of features that are currently behind feature flags.
 
 <!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
 
-| Feature Flag                      | Description                                                                   |
-| --------------------------------- | ----------------------------------------------------------------------------- |
-| `broadcasts-get`                  | Fetch a notification broadcast by its ID ([docs](#broadcasts-get))            |
-| `broadcasts-list`                 | List notification broadcasts ([docs](#broadcasts-list))                       |
-| `broadcasts-notifications-list`   | Fetch notifications by broadcast id. ([docs](#broadcasts-notifications-list)) |
-| `imports-create`                  | Create a import ([docs](#imports-create))                                     |
-| `imports-get`                     | Get the status of an import ([docs](#imports-get))                            |
-| `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete))    |
-| `users-push-subscriptions-list`   | Fetch user's push subscriptions ([docs](#users-push-subscriptions-list))      |
+| Feature Flag                      | Description                                                                |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `imports-create`                  | Create a import ([docs](#imports-create))                                  |
+| `imports-get`                     | Get the status of an import ([docs](#imports-get))                         |
+| `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete)) |
+| `users-push-subscriptions-list`   | Fetch user's push subscriptions ([docs](#users-push-subscriptions-list))   |
 
 <!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
@@ -338,10 +335,6 @@ Apart from the removal of the wrappers, returned entities and provided parameter
 
 #### List notification broadcasts
 
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-list` [feature flag](#feature-flags).
-
 List all notification broadcasts. Broadcasts are sorted in descending order by the sent_at timestamp.
 
 ```js
@@ -353,10 +346,6 @@ await magicbell.broadcasts.list({
 
 #### Fetch a notification broadcast by its ID
 
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-get` [feature flag](#feature-flags).
-
 Fetch a notification broadcast by its ID.
 
 ```js
@@ -366,10 +355,6 @@ await magicbell.broadcasts.get('{broadcast_id}');
 ### Broadcasts Notifications
 
 #### Fetch notifications by broadcast id.
-
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `broadcasts-notifications-list` [feature flag](#feature-flags).
 
 Fetch the notifications on a notification broadcast.
 

--- a/packages/magicbell/src/resources/broadcasts.ts
+++ b/packages/magicbell/src/resources/broadcasts.ts
@@ -23,8 +23,6 @@ export class Broadcasts extends Resource {
    *
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(options?: RequestOptions): IterablePromise<ListBroadcastsResponse>;
 
@@ -35,8 +33,6 @@ export class Broadcasts extends Resource {
    * @param data
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(data: ListBroadcastsPayload, options?: RequestOptions): IterablePromise<ListBroadcastsResponse>;
 
@@ -44,8 +40,6 @@ export class Broadcasts extends Resource {
     dataOrOptions: ListBroadcastsPayload | RequestOptions,
     options?: RequestOptions,
   ): IterablePromise<ListBroadcastsResponse> {
-    this.assertFeatureFlag('broadcasts-list');
-
     return this.request(
       {
         method: 'GET',
@@ -62,12 +56,8 @@ export class Broadcasts extends Resource {
    * @param broadcastId - ID of the notification broadcast.
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   get(broadcastId: string, options?: RequestOptions): Promise<GetBroadcastsResponse> {
-    this.assertFeatureFlag('broadcasts-get');
-
     return this.request(
       {
         method: 'GET',

--- a/packages/magicbell/src/resources/broadcasts/notifications.ts
+++ b/packages/magicbell/src/resources/broadcasts/notifications.ts
@@ -20,8 +20,6 @@ export class BroadcastsNotifications extends Resource {
    * @param broadcastId - ID of the notification broadcast.
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(broadcastId: string, options?: RequestOptions): IterablePromise<ListBroadcastsNotificationsResponse>;
 
@@ -32,8 +30,6 @@ export class BroadcastsNotifications extends Resource {
    * @param data
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(
     broadcastId: string,
@@ -46,8 +42,6 @@ export class BroadcastsNotifications extends Resource {
     dataOrOptions: ListBroadcastsNotificationsPayload | RequestOptions,
     options?: RequestOptions,
   ): IterablePromise<ListBroadcastsNotificationsResponse> {
-    this.assertFeatureFlag('broadcasts-notifications-list');
-
     return this.request(
       {
         method: 'GET',

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -17,9 +17,6 @@ export type ClientOptions = {
   telemetry?: boolean;
   debug?: boolean;
   features?: {
-    'broadcasts-get'?: true;
-    'broadcasts-list'?: true;
-    'broadcasts-notifications-list'?: true;
     'imports-create'?: true;
     'imports-get'?: true;
     'users-push-subscriptions-delete'?: true;


### PR DESCRIPTION
Release [broadcasts resource](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#broadcasts) as stable. This includes the following apis:

**List notification broadcasts**

```js
await magicbell.broadcasts.list({
  page: 1,
  per_page: 1,
});
```

**Fetch a notification broadcast by its ID**

```js
await magicbell.broadcasts.get('{broadcast_id}');
```

**Fetch notifications by broadcast id.**

```js
await magicbell.broadcasts.notifications.list('{broadcast_id}', {
  page: 1,
  per_page: 1,
});