### PR TITLE
feat: release users.pushSubscriptions resource as stable

### DIFF
--- a/.changeset/light-taxis-float.md
+++ b/.changeset/light-taxis-float.md
@@ -1,0 +1,24 @@
+---
+'magicbell': minor
+---
+
+Release the [users.pushSubscriptions resource](https://www.magicbell.com/docs/rest-api/reference#fetch-user's-push-subscriptions) as stable. This includes the following apis:
+
+**Fetch user's push subscriptions**
+
+Fetch a user's push subscriptions. Returns a paginated list of web and mobile push subscriptions for all platforms.
+
+```js
+await magicbell.users.pushSubscriptions.list('{user_id}', {
+  page: 1,
+  per_page: 1,
+});
+```
+
+**Delete user's push subscription**
+
+Delete a user's push subscriptions. Identifies the user by the user's ID and the push subscription by the subscription's ID.
+
+```js
+await magicbell.users.pushSubscriptions.delete('{user_id}', '{subscription_id}');
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -314,12 +314,10 @@ Below is a list of features that are currently behind feature flags.
 
 <!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
 
-| Feature Flag                      | Description                                                                |
-| --------------------------------- | -------------------------------------------------------------------------- |
-| `imports-create`                  | Create a import ([docs](#imports-create))                                  |
-| `imports-get`                     | Get the status of an import ([docs](#imports-get))                         |
-| `users-push-subscriptions-delete` | Delete user's push subscription ([docs](#users-push-subscriptions-delete)) |
-| `users-push-subscriptions-list`   | Fetch user's push subscriptions ([docs](#users-push-subscriptions-list))   |
+| Feature Flag     | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `imports-create` | Create a import ([docs](#imports-create))          |
+| `imports-get`    | Get the status of an import ([docs](#imports-get)) |
 
 <!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
@@ -669,10 +667,6 @@ await magicbell.users.notifications.list('{user_id}', {
 
 #### Fetch user's push subscriptions
 
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `users-push-subscriptions-list` [feature flag](#feature-flags).
-
 Fetch a user's push subscriptions. Returns a paginated list of web and mobile push subscriptions for all platforms.
 
 ```js
@@ -683,10 +677,6 @@ await magicbell.users.pushSubscriptions.list('{user_id}', {
 ```
 
 #### Delete user's push subscription
-
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `users-push-subscriptions-delete` [feature flag](#feature-flags).
 
 Delete a user's push subscriptions. Identifies the user by the user's ID and the push subscription by the subscription's ID.
 

--- a/packages/magicbell/src/resources/users/push-subscriptions.ts
+++ b/packages/magicbell/src/resources/users/push-subscriptions.ts
@@ -21,8 +21,6 @@ export class UsersPushSubscriptions extends Resource {
    * @param userId - The user id is the MagicBell user id. Accepts a UUID
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(userId: string, options?: RequestOptions): IterablePromise<ListUsersPushSubscriptionsResponse>;
 
@@ -34,8 +32,6 @@ export class UsersPushSubscriptions extends Resource {
    * @param data
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   list(
     userId: string,
@@ -48,8 +44,6 @@ export class UsersPushSubscriptions extends Resource {
     dataOrOptions: ListUsersPushSubscriptionsPayload | RequestOptions,
     options?: RequestOptions,
   ): IterablePromise<ListUsersPushSubscriptionsResponse> {
-    this.assertFeatureFlag('users-push-subscriptions-list');
-
     return this.request(
       {
         method: 'GET',
@@ -72,12 +66,8 @@ export class UsersPushSubscriptions extends Resource {
    *   endpoint or from push events sent to the MagicBell React library.
    *
    * @param options - override client request options.
-   *
-   * @beta
    **/
   delete(userId: string, subscriptionId: string, options?: RequestOptions): Promise<void> {
-    this.assertFeatureFlag('users-push-subscriptions-delete');
-
     return this.request(
       {
         method: 'DELETE',

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -19,8 +19,6 @@ export type ClientOptions = {
   features?: {
     'imports-create'?: true;
     'imports-get'?: true;
-    'users-push-subscriptions-delete'?: true;
-    'users-push-subscriptions-list'?: true;
   };
   headers?: Record<string, string>;
 };


### PR DESCRIPTION
Release the [users.pushSubscriptions resource](https://www.magicbell.com/docs/rest-api/reference#fetch-user's-push-subscriptions) as stable. This includes the following apis:

**Fetch user's push subscriptions**

Fetch a user's push subscriptions. Returns a paginated list of web and mobile push subscriptions for all platforms.

```js
await magicbell.users.pushSubscriptions.list('{user_id}', {
  page: 1,
  per_page: 1,
});
```

**Delete user's push subscription**

Delete a user's push subscriptions. Identifies the user by the user's ID and the push subscription by the subscription's ID.

```js
await magicbell.users.pushSubscriptions.delete('{user_id}', '{subscription_id}');
```