### PR TITLE
feat: release imports resource as stable

### DIFF
--- a/.changeset/polite-carrots-tan.md
+++ b/.changeset/polite-carrots-tan.md
@@ -1,0 +1,34 @@
+---
+'magicbell': minor
+---
+
+Release the [imports resource](https://www.magicbell.com/docs/rest-api/reference#imports-create) as stable. This includes the following apis:
+
+**Create a import**
+
+Enqueues an import - currently only supported for users.
+
+```js
+await magicbell.imports.create({
+  users: [
+    {
+      external_id: 'ugiabqertz',
+      email: 'johndoe@example.com',
+      first_name: 'John',
+      last_name: 'Doe',
+      custom_attributes: {
+        age: 32,
+        country: 'Spain',
+      },
+    },
+  ],
+});
+```
+
+**Get the status of an import**
+
+Query the status of the import for a summary of imported records and failures for each record that could not be imported successfully.
+
+```js
+await magicbell.imports.get('{import_id}');
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -314,10 +314,7 @@ Below is a list of features that are currently behind feature flags.
 
 <!-- AUTO-GENERATED-CONTENT:START (FEATURE_FLAGS) -->
 
-| Feature Flag     | Description                                        |
-| ---------------- | -------------------------------------------------- |
-| `imports-create` | Create a import ([docs](#imports-create))          |
-| `imports-get`    | Get the status of an import ([docs](#imports-get)) |
+_There are no features in beta at this time._
 
 <!-- AUTO-GENERATED-CONTENT:END (FEATURE_FLAGS) -->
 
@@ -840,10 +837,6 @@ await magicbell.subscriptions.delete(
 
 #### Create a import
 
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `imports-create` [feature flag](#feature-flags).
-
 Enqueues an import - currently only supported for users. Amongst other things, the users import allows associating slack channels (if you have already setup the oauth apps).
 
 ```js
@@ -879,10 +872,6 @@ await magicbell.imports.create({
 ```
 
 #### Get the status of an import
-
-> **Warning**
->
-> This method is in preview and is subject to change. It needs to be enabled via the `imports-get` [feature flag](#feature-flags).
 
 Query the status of the import for a summary of imported records and failures for each record that could not be imported successfully.
 

--- a/packages/magicbell/src/resources/imports.ts
+++ b/packages/magicbell/src/resources/imports.ts
@@ -21,8 +21,6 @@ export class Imports extends Resource {
    *
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   create(options?: RequestOptions): Promise<CreateImportsResponse>;
 
@@ -34,8 +32,6 @@ export class Imports extends Resource {
    * @param data
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   create(data: CreateImportsPayload, options?: RequestOptions): Promise<CreateImportsResponse>;
 
@@ -43,8 +39,6 @@ export class Imports extends Resource {
     dataOrOptions: CreateImportsPayload | RequestOptions,
     options?: RequestOptions,
   ): Promise<CreateImportsResponse> {
-    this.assertFeatureFlag('imports-create');
-
     return this.request(
       {
         method: 'POST',
@@ -62,12 +56,8 @@ export class Imports extends Resource {
    *   The ID of the import is returned when the import is created.
    * @param options - override client request options.
    * @returns
-   *
-   * @beta
    **/
   get(importId: string, options?: RequestOptions): Promise<GetImportsResponse> {
-    this.assertFeatureFlag('imports-get');
-
     return this.request(
       {
         method: 'GET',

--- a/packages/magicbell/src/types.ts
+++ b/packages/magicbell/src/types.ts
@@ -16,10 +16,7 @@ export type ClientOptions = {
   idempotencyKey?: string;
   telemetry?: boolean;
   debug?: boolean;
-  features?: {
-    'imports-create'?: true;
-    'imports-get'?: true;
-  };
+  features?: Record<string, never>;
   headers?: Record<string, string>;
 };
 


### PR DESCRIPTION
Release the [imports resource](https://www.magicbell.com/docs/rest-api/reference#imports-create) as stable. This includes the following apis:

**Create a import**

Enqueues an import - currently only supported for users.

```js
await magicbell.imports.create({
  users: [
    {
      external_id: 'ugiabqertz',
      email: 'johndoe@example.com',
      first_name: 'John',
      last_name: 'Doe',
      custom_attributes: {
        age: 32,
        country: 'Spain',
      },
    },
  ],
});
```

**Get the status of an import**

Query the status of the import for a summary of imported records and failures for each record that could not be imported successfully.

```js
await magicbell.imports.get('{import_id}');
```