### PR TITLE
feat: add --max-items to paginatable methods

### DIFF
--- a/.changeset/swift-cars-march.md
+++ b/.changeset/swift-cars-march.md
@@ -1,0 +1,9 @@
+---
+'@magicbell/cli': minor
+---
+
+Add `--max-items` to methods supporting `--paginate`. This way it's trivial to auto paginate over records at MagicBell, till a certain reasonable limit is reached. By default, `--paginate` iterates over every single record potentially hitting, but respecting, API rate limits.
+
+```shell
+$ magicbell broadcasts list --paginate --max-items 1000
+```

--- a/packages/cli/src/resources/broadcasts.ts
+++ b/packages/cli/src/resources/broadcasts.ts
@@ -15,13 +15,17 @@ broadcasts
   .option('--page <integer>', 'The page number of the paginated response. Defaults to 1.')
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async ({ paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async ({ paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().broadcasts.list(data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/broadcasts/notifications.ts
+++ b/packages/cli/src/resources/broadcasts/notifications.ts
@@ -14,13 +14,17 @@ broadcastsNotifications
   .option('--page <integer>', 'The page number of the paginated response. Defaults to 1.')
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async (broadcastId, { paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async (broadcastId, { paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().broadcasts.notifications.list(broadcastId, data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/notifications.ts
+++ b/packages/cli/src/resources/notifications.ts
@@ -66,13 +66,17 @@ notifications
   )
   .option('--topics <string...>', 'A filter on the notifications based on the topic.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async ({ paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async ({ paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().notifications.list(data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/subscriptions.ts
+++ b/packages/cli/src/resources/subscriptions.ts
@@ -11,13 +11,17 @@ subscriptions
   .command('list')
   .description("Fetch user's topic subscriptions")
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async ({ paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async ({ paginate, maxItems, ...opts }) => {
     const { options } = parseOptions(opts);
 
     const response = getClient().subscriptions.list(options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/users.ts
+++ b/packages/cli/src/resources/users.ts
@@ -56,13 +56,17 @@ users
   )
   .option('--order-by <string>', 'Use it to order the returned list of users. Defaults to `created_at,DESC`')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async ({ paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async ({ paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().users.list(data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/users/notifications.ts
+++ b/packages/cli/src/resources/users/notifications.ts
@@ -14,13 +14,17 @@ usersNotifications
   .option('--page <integer>', 'The page number of the paginated response. Defaults to 1.')
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async (userId, { paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async (userId, { paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().users.notifications.list(userId, data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/cli/src/resources/users/push-subscriptions.ts
+++ b/packages/cli/src/resources/users/push-subscriptions.ts
@@ -16,13 +16,17 @@ usersPushSubscriptions
   .option('--page <integer>', 'The page number of the paginated response. Defaults to 1.')
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
-  .action(async (userId, { paginate, ...opts }) => {
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async (userId, { paginate, maxItems, ...opts }) => {
     const { data, options } = parseOptions(opts);
 
     const response = getClient().users.pushSubscriptions.list(userId, data, options);
 
     if (paginate) {
-      await response.forEach((notification) => printJson(notification));
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
     } else {
       await response.then((result) => printJson(result));
     }

--- a/packages/codegen/src/builders.ts
+++ b/packages/codegen/src/builders.ts
@@ -10,13 +10,15 @@ export function importDeclaration(specifiers: string | string[], source: string)
   const specifierArray = Array.isArray(specifiers) ? specifiers : [specifiers];
 
   return builders.importDeclaration.from({
-    specifiers: specifierArray.map((x) =>
-      x.startsWith('* as ')
-        ? builders.importNamespaceSpecifier(builders.identifier(x.replace('* as ', '')))
-        : typeof specifiers === 'string'
-        ? builders.importDefaultSpecifier(builders.identifier(x))
-        : builders.importSpecifier(builders.identifier(x)),
-    ),
+    specifiers: specifierArray
+      .filter(Boolean)
+      .map((x) =>
+        x.startsWith('* as ')
+          ? builders.importNamespaceSpecifier(builders.identifier(x.replace('* as ', '')))
+          : typeof specifiers === 'string'
+          ? builders.importDefaultSpecifier(builders.identifier(x))
+          : builders.importSpecifier(builders.identifier(x)),
+      ),
     source: builders.literal(source),
   });
 }


### PR DESCRIPTION

Add `--max-items` to methods supporting `--paginate`. This way it's trivial to auto paginate over records at MagicBell, till a certain reasonable limit is reached. By default, `--paginate` iterates over every single record potentially hitting, but respecting, API rate limits.

```shell
$ magicbell broadcasts list --paginate --max-items 1000
```