### PR TITLE
chore: remove short alias for --help and --version

### DIFF
--- a/.changeset/soft-donkeys-cross.md
+++ b/.changeset/soft-donkeys-cross.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+remove `-v` and `-h` alias. Use `--version` and `--help` instead.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,7 @@ const publicCommands = ['login', 'logout', 'config'];
 const program = createCommand()
   .name('magicbell')
   .description('Work with MagicBell from the command line')
-  .version(pkg.version, '-v, --version', 'Show magicbell version')
+  .version(pkg.version, '--version', 'Show magicbell version')
   .option('-p, --profile <string>', 'Profile to use', process.env.MAGICBELL_PROFILE || 'default')
   .option('--no-color', 'Color output', true);
 

--- a/packages/cli/src/lib/commands.ts
+++ b/packages/cli/src/lib/commands.ts
@@ -9,7 +9,7 @@ type ExtendedCommand = Command & {
 export function createCommand(name?: string): ExtendedCommand {
   const command = new Command(name) as ExtendedCommand;
 
-  command.helpOption('-h, --help', 'Show help for command');
+  command.helpOption('--help', 'Show help for command');
   command.showHelpAfterError(true);
   command.addHelpCommand(false);
 

--- a/packages/cli/src/lib/help.ts
+++ b/packages/cli/src/lib/help.ts
@@ -1,6 +1,19 @@
 import { Command, Help } from 'commander';
 import kleur from 'kleur';
 
+function sortOptions(a, b) {
+  // shorts before longs
+  if (a.short && !b.short) return -1;
+  if (!a.short && b.short) return 1;
+  // move --version to the end
+  if (a.long === '--version') return 1;
+  if (b.long === '--version') return -1;
+  // move ----help to the end
+  if (a.long === '--help') return 1;
+  if (b.long === '--help') return -1;
+  return a.flags > b.flags ? 1 : -1;
+}
+
 export function formatHelp(cmd: Command, helper: Help) {
   const termWidth = helper.padWidth(cmd, helper);
   const helpWidth = helper.helpWidth || 80;
@@ -52,6 +65,7 @@ export function formatHelp(cmd: Command, helper: Help) {
 
         return true;
       })
+      .sort(sortOptions)
       .map((option) => {
         return formatItem(helper.optionTerm(option), helper.optionDescription(option));
       }),
@@ -78,6 +92,7 @@ export function formatHelp(cmd: Command, helper: Help) {
             // don't return --version on sub commands
             return option.long !== '--version';
           })
+          .sort(sortOptions)
           .map((option) => {
             return formatItem(helper.optionTerm(option), helper.optionDescription(option));
           }),


### PR DESCRIPTION
remove `-v` and `-h` alias. Use `--version` and `--help` instead.
