### PR TITLE
feat: add --host flag

### DIFF
--- a/.changeset/curly-grapes-boil.md
+++ b/.changeset/curly-grapes-boil.md
@@ -1,0 +1,21 @@
+---
+'@magicbell/cli': minor
+---
+
+add `--host` flag so the cli can be used against other environments, such as localhost, staging and review.
+
+```shell
+magicbell --host localhost:3000
+magicbell --host localhost:3000/api/v1
+```
+
+When an alternative host is provided during login, the host gets bound to that session. Meaning, the profile will use that host as default.
+
+```shell
+magicbell login
+magicbell users list # run against production
+
+# or export MAGICBELL_PROFILE=dev
+magicbell login -p dev -h localhost:3000
+magicbell users list -p dev # run against localhost:3000
+```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import pkg from '../package.json';
 import { config } from './config';
 import { createCommand, findCommand, findTopCommand } from './lib/commands';
 import { configStore } from './lib/config';
+import { parseHost } from './lib/options';
 import { printError, printMessage } from './lib/printer';
 import { listen } from './listen';
 import { login } from './login';
@@ -15,6 +16,7 @@ const program = createCommand()
   .description('Work with MagicBell from the command line')
   .version(pkg.version, '--version', 'Show magicbell version')
   .option('-p, --profile <string>', 'Profile to use', process.env.MAGICBELL_PROFILE || 'default')
+  .option('-h, --host <string>', 'MagicBell API host', parseHost)
   .option('--no-color', 'Color output', true);
 
 // configure configstore
@@ -22,6 +24,7 @@ program.hook('preAction', function (thisCommand) {
   const options = thisCommand.opts();
   configStore.profile = options.profile;
   configStore.color = options.color;
+  configStore.host = options.host;
 });
 
 // check auth on authenticated routes, and redirect to login if not authenticated

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -10,16 +10,22 @@ const features: ClientOptions['features'] = {};
 export function getClient(options?: Partial<ClientOptions>) {
   const project = configStore.getProject();
 
-  const apiKey = project?.apiKey || '';
-  const apiSecret = project?.apiSecret || '';
-  const userEmail = project?.userEmail || '';
-  const userExternalId = project?.userExternalId || '';
+  const defaultOptions = {
+    apiKey: project?.apiKey,
+    apiSecret: project?.apiSecret,
+    userEmail: project?.userEmail,
+    userExternalId: project?.userExternalId,
+    host: configStore.host || project?.host,
+  };
+
+  for (const key in defaultOptions) {
+    if (defaultOptions[key] == null || defaultOptions[key] === '') {
+      delete defaultOptions[key];
+    }
+  }
 
   const client = new Client({
-    apiKey,
-    apiSecret,
-    userEmail,
-    userExternalId,
+    ...defaultOptions,
     ...options,
     appInfo: { name: pkg.name, version: pkg.version },
     features,

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -7,11 +7,13 @@ type Project = {
   apiSecret: string;
   userEmail?: string;
   userExternalId?: string;
+  host?: string;
 };
 
 type Store = InstanceType<typeof ConfigStore> & {
   profile: string;
   color: boolean;
+  host?: string;
   getProject: () => Project;
   setProject: (project: Project) => void;
   unsetProject: () => void;
@@ -28,28 +30,9 @@ export const configStore = new ConfigStore(
   },
 ) as Store;
 
-const _state = {
-  profile: 'default',
-  color: true,
-};
-
-Object.defineProperty(configStore, 'color', {
-  get() {
-    return _state.color;
-  },
-  set(value) {
-    _state.color = value;
-  },
-});
-
-Object.defineProperty(configStore, 'profile', {
-  get() {
-    return _state.profile;
-  },
-  set(value) {
-    _state.profile = value;
-  },
-});
+configStore.profile = 'default';
+configStore.color = true;
+configStore.host = undefined;
 
 configStore.getProject = function getProject() {
   const alias = configStore.profile;
@@ -58,6 +41,10 @@ configStore.getProject = function getProject() {
 
 configStore.setProject = function setProject(project: Project) {
   const alias = configStore.profile;
+  if (configStore.host) {
+    project.host = project.host || configStore.host;
+  }
+
   configStore.set(`projects.${alias}`, project);
 };
 

--- a/packages/cli/src/lib/options.ts
+++ b/packages/cli/src/lib/options.ts
@@ -1,5 +1,6 @@
 import { parse } from 'json5';
 
+import { printError } from './printer';
 import { camelToSnakeCase } from './text';
 
 const optionKeys = new Set(['userEmail', 'userExternalId']);
@@ -52,4 +53,20 @@ export function parseOptions(obj: Record<string, unknown>) {
   }
 
   return { options, data: Object.keys(data).length ? data : undefined };
+}
+
+export function parseHost(host: string) {
+  if (!host) return;
+
+  if (host.startsWith('localhost')) host = `http://${host}`;
+  else if (host.startsWith('127.0.0.1')) host = `http://${host}`;
+  else if (!host.includes('://')) host = `https://${host}`;
+
+  try {
+    const url = new URL(host);
+    // support paths like http://localhost:3000/api/v1, but drop trailing slashes
+    return `${url.origin}${url.pathname}`.replace(/\/$/, '');
+  } catch (error) {
+    printError(`invalid host argument provided: ${host}`, true);
+  }
 }


### PR DESCRIPTION
add `--host` flag so the cli can be used against other environments, such as localhost, staging and review.

```shell
magicbell --host localhost:3000
magicbell --host localhost:3000/api/v1
```

When an alternative host is provided during login, the host gets bound to that session. Meaning, the profile will use that host as default.

```shell
magicbell login
magicbell users list # run against production

# or export MAGICBELL_PROFILE=dev
magicbell login -p dev -h localhost:3000
magicbell users list -p dev # run against localhost:3000
```