### PR TITLE
feat: add `--print-request` option to cli

### DIFF
--- a/.changeset/gold-steaks-burn.md
+++ b/.changeset/gold-steaks-burn.md
@@ -1,0 +1,10 @@
+---
+'@magicbell/cli': minor
+---
+
+The CLI now accepts the global `--print-request curl` option that prints the request object to the console. When that option is provided, the request will be printed in the requested format, and no network requests will be made. We'll add more formats in the future.
+
+```shell
+magicbell notifications list --print-request curl
+magicbell notifications create --title hi --print-request curl
+```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,5 @@
+import { Option } from 'commander';
+
 import pkg from '../package.json';
 import { config } from './config';
 import { createCommand, findCommand, findTopCommand } from './lib/commands';
@@ -17,7 +19,10 @@ const program = createCommand()
   .version(pkg.version, '--version', 'Show magicbell version')
   .option('-p, --profile <string>', 'Profile to use', process.env.MAGICBELL_PROFILE || 'default')
   .option('-h, --host <string>', 'MagicBell API host', parseHost)
-  .option('--no-color', 'Color output', true);
+  .option('--no-color', 'Color output', true)
+  .addOption(
+    new Option('-r, --print-request <string>', 'Print the request command, without sending').choices(['curl']),
+  );
 
 // configure configstore
 program.hook('preAction', function (thisCommand) {

--- a/packages/cli/src/lib/serializers.ts
+++ b/packages/cli/src/lib/serializers.ts
@@ -1,0 +1,26 @@
+import { AxiosRequestConfig } from 'axios';
+
+import { printError } from './printer';
+
+// we don't want to print these headers, as we don't want to have people copy/paste them
+// into other requests, and thereby mess up our telemetry / request logs
+const excludeHeaders = /user-agent|x-magicbell-client-user-agent|x-magicbell-client-telemetry/i;
+
+export function toCurl({ method, baseURL, url, data, headers }: AxiosRequestConfig) {
+  return [
+    `curl --request ${method.toUpperCase()}`,
+    `--url ${baseURL}/${url.replace(/^\//, '')}`,
+    ...Object.entries(headers)
+      .map(([key, value]) => [key.toLowerCase(), value] as [string, string])
+      .filter(([key]) => !excludeHeaders.test(key))
+      .map(([key, value]) => `--header '${key}: ${value}'`),
+    data && `--data '${JSON.stringify(data)}'`,
+  ]
+    .filter(Boolean)
+    .join(' \\\n  ');
+}
+
+export const serialize = (config: AxiosRequestConfig, method: 'curl') => {
+  if (method === 'curl') return toCurl(config);
+  printError(`Unknown serialization method: ${method}`, true);
+};


### PR DESCRIPTION
The CLI now accepts the global `--print-request curl` option that prints the request object to the console. When that option is provided, the request will be printed in the requested format, and no network requests will be made. We'll add more formats in the future.

```shell
magicbell notifications list --print-request curl
magicbell notifications create --title hi --print-request curl
```