### PR TITLE
refactor: consume global flags from command

### DIFF
--- a/packages/cli/scripts/generate-resources.ts
+++ b/packages/cli/scripts/generate-resources.ts
@@ -158,6 +158,7 @@ function createResource(resource: Resource, children: Resource[], meta: Resource
                 builders.restProperty(b.id('opts')),
               ])
             : b.id('opts'),
+          b.id('cmd'),
         ],
         body: builders.blockStatement([
           builders.variableDeclaration('const', [
@@ -177,7 +178,7 @@ function createResource(resource: Resource, children: Resource[], meta: Resource
                     builders.callExpression(
                       builders.memberExpression(
                         builders.memberExpression(
-                          builders.callExpression(b.id('getClient'), []),
+                          builders.callExpression(b.id('getClient'), [b.id('cmd')]),
                           b.id(methodNamespace),
                         ),
                         b.id(camelCase(method.name)),
@@ -249,7 +250,7 @@ function createResource(resource: Resource, children: Resource[], meta: Resource
                       builders.callExpression(
                         builders.memberExpression(
                           builders.memberExpression(
-                            builders.callExpression(b.id('getClient'), []),
+                            builders.callExpression(b.id('getClient'), [b.id('cmd')]),
                             b.id(methodNamespace),
                           ),
                           b.id(camelCase(method.name)),

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -17,8 +17,9 @@ config
 config
   .command('list')
   .description('Print a list of configuration keys and values')
-  .action(() => {
-    const project = configStore.getProject();
+  .action((opts, cmd) => {
+    const { profile } = cmd.optsWithGlobals();
+    const project = configStore.getProject(profile);
     if (!project) return;
 
     printJson({
@@ -31,9 +32,9 @@ config
   .command('get')
   .description('Print the value of a given configuration key.')
   .argument('<key>', 'The configuration key to print.')
-  .action((key) => {
-    const ns = `projects.${configStore.profile}`;
-    printMessage(configStore.get(`${ns}.${key}`));
+  .action((key, opts, cmd) => {
+    const { profile } = cmd.optsWithGlobals();
+    printMessage(configStore.get(`projects.${profile}.${key}`));
   });
 
 config
@@ -41,16 +42,16 @@ config
   .description('Update configuration with a value for the given key.')
   .argument('<key>', 'The configuration key to update.')
   .argument('<value>', 'The value to set.')
-  .action((key, value) => {
-    const ns = `projects.${configStore.profile}`;
-    configStore.set(`${ns}.${key}`, value);
+  .action((key, value, cmd) => {
+    const { profile } = cmd.optsWithGlobals();
+    configStore.set(`projects.${profile}.${key}`, value);
   });
 
 config
   .command('unset')
   .description('Remove the given key from the configuration.')
   .argument('<key>', 'The configuration key to remove.')
-  .action((key) => {
-    const ns = `projects.${configStore.profile}`;
-    configStore.delete(`${ns}.${key}`);
+  .action((key, cmd) => {
+    const { profile } = cmd.optsWithGlobals();
+    configStore.delete(`projects.${profile}.${key}`);
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,20 +22,18 @@ const program = createCommand()
 // configure configstore
 program.hook('preAction', function (thisCommand) {
   const options = thisCommand.opts();
-  configStore.profile = options.profile;
   configStore.color = options.color;
-  configStore.host = options.host;
 });
 
 // check auth on authenticated routes, and redirect to login if not authenticated
 program.hook('preAction', function (thisCommand, actionCommand) {
+  const { profile } = thisCommand.opts();
   const command = findTopCommand(actionCommand);
   if (publicCommands.includes(command.name()) || actionCommand.name() === 'help') return;
 
-  const project = configStore.getProject();
+  const project = configStore.getProject(profile);
 
   if (!project?.apiKey || !project?.apiSecret) {
-    const profile = configStore.profile;
     const error =
       profile === 'default'
         ? 'You are not logged in. Please run `magicbell login` to connect to your MagicBell account.'

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,3 +1,4 @@
+import { Command } from 'commander';
 import { Client, ClientOptions } from 'magicbell';
 
 import pkg from '../../package.json';
@@ -7,15 +8,16 @@ type ExtendedClient = InstanceType<typeof Client> & { getProject: () => Promise<
 
 const features: ClientOptions['features'] = {};
 
-export function getClient(options?: Partial<ClientOptions>) {
-  const project = configStore.getProject();
+export function getClient(cmd: Command, options?: Partial<ClientOptions>) {
+  const { profile, host } = cmd.optsWithGlobals();
+  const project = configStore.getProject(profile);
 
   const defaultOptions = {
     apiKey: project?.apiKey,
     apiSecret: project?.apiSecret,
     userEmail: project?.userEmail,
     userExternalId: project?.userExternalId,
-    host: configStore.host || project?.host,
+    host: host || project?.host,
   };
 
   for (const key in defaultOptions) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -14,9 +14,9 @@ type Store = InstanceType<typeof ConfigStore> & {
   profile: string;
   color: boolean;
   host?: string;
-  getProject: () => Project;
-  setProject: (project: Project) => void;
-  unsetProject: () => void;
+  getProject: (profile: string) => Project;
+  setProject: (profile: string, project: Project) => void;
+  unsetProject: (profile: string) => void;
   clearProjects: () => void;
 };
 
@@ -30,27 +30,24 @@ export const configStore = new ConfigStore(
   },
 ) as Store;
 
-configStore.profile = 'default';
 configStore.color = true;
-configStore.host = undefined;
 
-configStore.getProject = function getProject() {
-  const alias = configStore.profile;
-  return configStore.get(`projects.${alias}`);
+configStore.getProject = function getProject(profile: string) {
+  return configStore.get(`projects.${profile}`);
 };
 
-configStore.setProject = function setProject(project: Project) {
-  const alias = configStore.profile;
-  if (configStore.host) {
-    project.host = project.host || configStore.host;
+configStore.setProject = function setProject(profile: string, project: Project) {
+  for (const key of Object.keys(project)) {
+    if (project[key] === undefined) {
+      delete project[key];
+    }
   }
 
-  configStore.set(`projects.${alias}`, project);
+  configStore.set(`projects.${profile}`, project);
 };
 
-configStore.unsetProject = function unsetProject() {
-  const alias = configStore.profile;
-  configStore.delete(`projects.${alias}`);
+configStore.unsetProject = function unsetProject(profile: string) {
+  configStore.delete(`projects.${profile}`);
 };
 
 configStore.clearProjects = function clearProjects() {

--- a/packages/cli/src/listen.ts
+++ b/packages/cli/src/listen.ts
@@ -8,7 +8,7 @@ export const listen = createCommand('listen')
   .option('--user-email <string>', 'Email of the user to listen as')
   .option('--user-external-id <string>', 'External ID of the user to listen as')
   .option('--expand', 'Fetch additional notification details for incoming events.')
-  .action(({ expand, ...opts }) => {
+  .action(({ expand, ...opts }, cmd) => {
     const { options } = parseOptions(opts);
 
     if (!options.userEmail && !options.userExternalId) {
@@ -19,7 +19,7 @@ export const listen = createCommand('listen')
       printError('You can only specify one of --user-email or --user-external-id', true);
     }
 
-    const client = getClient();
+    const client = getClient(cmd);
     client.listen(options).forEach(async (event) => {
       let notification;
 

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -8,7 +8,7 @@ import { printError, printMessage } from './lib/printer';
 
 export const login = createCommand('login')
   .description('Login to your MagicBell account')
-  .action(async () => {
+  .action(async (opts, cmd) => {
     try {
       printMessage('Please enter your MagicBell API credentials.');
       printMessage(kleur.dim('You can find these at https://app.magicbell.com > Settings > API Keys.'));
@@ -19,18 +19,20 @@ export const login = createCommand('login')
         hideEchoBack: true,
       });
 
-      const client = getClient({
+      const client = getClient(cmd, {
         apiKey,
         apiSecret,
       });
 
+      const { profile, host } = cmd.optsWithGlobals();
       const project = await client.getProject();
 
-      configStore.setProject({
+      configStore.setProject(profile, {
         id: project.id,
         name: project.name,
         apiKey,
         apiSecret,
+        host,
       });
 
       printMessage(`\nYou are now logged in to project ${kleur.bold(project.name)}`);

--- a/packages/cli/src/logout.ts
+++ b/packages/cli/src/logout.ts
@@ -7,18 +7,20 @@ import { printMessage } from './lib/printer';
 export const logout = createCommand('logout')
   .description('Logout of your MagicBell account')
   .option('-a, --all', 'Clear credentials for all projects you are logged in to', false)
-  .action(async (options) => {
-    if (options.all) {
+  .action(async (opts, cmd) => {
+    const { profile } = cmd.optsWithGlobals();
+
+    if (opts.all) {
       configStore.clearProjects();
       printMessage(`You are now logged out from all projects.`);
     } else {
-      const project = configStore.getProject();
+      const project = configStore.getProject(profile);
       if (!project) {
         printMessage(`You are not logged in.`);
         return;
       }
 
-      configStore.unsetProject();
+      configStore.unsetProject(profile);
       printMessage(`You are now logged out from project ${kleur.bold(project.name)}.`);
     }
   });

--- a/packages/cli/src/resources/broadcasts.ts
+++ b/packages/cli/src/resources/broadcasts.ts
@@ -16,10 +16,10 @@ broadcasts
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async ({ paginate, maxItems, ...opts }) => {
+  .action(async ({ paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().broadcasts.list(data, options);
+    const response = getClient(cmd).broadcasts.list(data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {
@@ -35,9 +35,9 @@ broadcasts
   .command('get')
   .description('Fetch a notification broadcast by its ID')
   .argument('<broadcast-id>', 'ID of the notification broadcast.')
-  .action(async (broadcastId, opts) => {
+  .action(async (broadcastId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().broadcasts.get(broadcastId, options);
+    const response = await getClient(cmd).broadcasts.get(broadcastId, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/broadcasts/notifications.ts
+++ b/packages/cli/src/resources/broadcasts/notifications.ts
@@ -15,10 +15,10 @@ broadcastsNotifications
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async (broadcastId, { paginate, maxItems, ...opts }) => {
+  .action(async (broadcastId, { paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().broadcasts.notifications.list(broadcastId, data, options);
+    const response = getClient(cmd).broadcasts.notifications.list(broadcastId, data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {

--- a/packages/cli/src/resources/imports.ts
+++ b/packages/cli/src/resources/imports.ts
@@ -11,10 +11,10 @@ imports
   .command('create')
   .description('Create a import')
   .option('--users <string...>', '')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().imports.create(data, options);
+    const response = await getClient(cmd).imports.create(data, options);
     printJson(response);
   });
 
@@ -22,9 +22,9 @@ imports
   .command('get')
   .description('Get the status of an import')
   .argument('<import-id>', 'ID of the import.')
-  .action(async (importId, opts) => {
+  .action(async (importId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().imports.get(importId, options);
+    const response = await getClient(cmd).imports.get(importId, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/metrics.ts
+++ b/packages/cli/src/resources/metrics.ts
@@ -14,9 +14,9 @@ metrics.addCommand(metricsTopics);
 metrics
   .command('get')
   .description('Get notification metrics')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().metrics.get(options);
+    const response = await getClient(cmd).metrics.get(options);
     printJson(response);
   });

--- a/packages/cli/src/resources/metrics/categories.ts
+++ b/packages/cli/src/resources/metrics/categories.ts
@@ -10,9 +10,9 @@ export const metricsCategories = createCommand('categories').description('Manage
 metricsCategories
   .command('get')
   .description('Get notification metrics grouped by category')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().metrics.categories.get(options);
+    const response = await getClient(cmd).metrics.categories.get(options);
     printJson(response);
   });

--- a/packages/cli/src/resources/metrics/topics.ts
+++ b/packages/cli/src/resources/metrics/topics.ts
@@ -10,9 +10,9 @@ export const metricsTopics = createCommand('topics').description('Manage metrics
 metricsTopics
   .command('get')
   .description('Get notification metrics grouped by topic')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().metrics.topics.get(options);
+    const response = await getClient(cmd).metrics.topics.get(options);
     printJson(response);
   });

--- a/packages/cli/src/resources/notification-preferences.ts
+++ b/packages/cli/src/resources/notification-preferences.ts
@@ -12,10 +12,10 @@ export const notificationPreferences = createCommand('notification-preferences')
 notificationPreferences
   .command('get')
   .description('Fetch user notification preferences')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notificationPreferences.get(options);
+    const response = await getClient(cmd).notificationPreferences.get(options);
     printJson(response);
   });
 
@@ -23,9 +23,9 @@ notificationPreferences
   .command('update')
   .description('Update user notification preferences')
   .option('--categories <string...>', '')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().notificationPreferences.update(data, options);
+    const response = await getClient(cmd).notificationPreferences.update(data, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/notifications.ts
+++ b/packages/cli/src/resources/notifications.ts
@@ -33,10 +33,10 @@ notifications
   )
   .option('--topic <string>', 'Topic the notification belongs to. This is useful to create threads.')
   .option('--overrides <json>', 'Optional overrides to configure notifications per target destination.')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().notifications.create(data, options);
+    const response = await getClient(cmd).notifications.create(data, options);
     printJson(response);
   });
 
@@ -67,10 +67,10 @@ notifications
   .option('--topics <string...>', 'A filter on the notifications based on the topic.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async ({ paginate, maxItems, ...opts }) => {
+  .action(async ({ paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().notifications.list(data, options);
+    const response = getClient(cmd).notifications.list(data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {
@@ -86,10 +86,10 @@ notifications
   .command('get')
   .description('Fetch notification by ID')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.get(notificationId, options);
+    const response = await getClient(cmd).notifications.get(notificationId, options);
     printJson(response);
   });
 
@@ -97,10 +97,10 @@ notifications
   .command('delete')
   .description('Delete a notification')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.delete(notificationId, options);
+    const response = await getClient(cmd).notifications.delete(notificationId, options);
     printJson(response);
   });
 
@@ -108,10 +108,10 @@ notifications
   .command('mark-as-read')
   .description('Mark a notification as read')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.markAsRead(notificationId, options);
+    const response = await getClient(cmd).notifications.markAsRead(notificationId, options);
     printJson(response);
   });
 
@@ -119,10 +119,10 @@ notifications
   .command('mark-as-unread')
   .description('Mark a notification as unread')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.markAsUnread(notificationId, options);
+    const response = await getClient(cmd).notifications.markAsUnread(notificationId, options);
     printJson(response);
   });
 
@@ -130,10 +130,10 @@ notifications
   .command('archive')
   .description('Archive a notification')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.archive(notificationId, options);
+    const response = await getClient(cmd).notifications.archive(notificationId, options);
     printJson(response);
   });
 
@@ -141,10 +141,10 @@ notifications
   .command('unarchive')
   .description('Unarchive a notification')
   .argument('<notification-id>', 'ID of the user notification.')
-  .action(async (notificationId, opts) => {
+  .action(async (notificationId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().notifications.unarchive(notificationId, options);
+    const response = await getClient(cmd).notifications.unarchive(notificationId, options);
     printJson(response);
   });
 
@@ -168,10 +168,10 @@ notifications
     'A filter on the notifications based on the category. If you want to get uncategorized notifications, use the "uncategorized" value.',
   )
   .option('--topics <string...>', 'A filter on the notifications based on the topic.')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().notifications.markAllRead(data, options);
+    const response = await getClient(cmd).notifications.markAllRead(data, options);
     printJson(response);
   });
 
@@ -195,9 +195,9 @@ notifications
     'A filter on the notifications based on the category. If you want to get uncategorized notifications, use the "uncategorized" value.',
   )
   .option('--topics <string...>', 'A filter on the notifications based on the topic.')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().notifications.markAllSeen(data, options);
+    const response = await getClient(cmd).notifications.markAllSeen(data, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/push-subscriptions.ts
+++ b/packages/cli/src/resources/push-subscriptions.ts
@@ -22,10 +22,10 @@ pushSubscriptions
     '--app-bundle-id <string>',
     'The bundle ID of your app. This value is used to determine the delivery mechanism for mobile push notifications based on your workflow so that you can link several mobile applications to one project.',
   )
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().pushSubscriptions.create(data, options);
+    const response = await getClient(cmd).pushSubscriptions.create(data, options);
     printJson(response);
   });
 
@@ -33,9 +33,9 @@ pushSubscriptions
   .command('delete')
   .description("Delete user's device token")
   .argument('<device-token>', 'Token of the device you want to remove')
-  .action(async (deviceToken, opts) => {
+  .action(async (deviceToken, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().pushSubscriptions.delete(deviceToken, options);
+    const response = await getClient(cmd).pushSubscriptions.delete(deviceToken, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/subscriptions.ts
+++ b/packages/cli/src/resources/subscriptions.ts
@@ -12,10 +12,10 @@ subscriptions
   .description("Fetch user's topic subscriptions")
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async ({ paginate, maxItems, ...opts }) => {
+  .action(async ({ paginate, maxItems, ...opts }, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = getClient().subscriptions.list(options);
+    const response = getClient(cmd).subscriptions.list(options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {
@@ -38,10 +38,10 @@ subscriptions
     '--topic <string>',
     'The topic the user should be subscribed to. If the topic does not exist it will be created.',
   )
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().subscriptions.create(data, options);
+    const response = await getClient(cmd).subscriptions.create(data, options);
     printJson(response);
   });
 
@@ -53,10 +53,10 @@ subscriptions
     '--categories <string...>',
     'A list of hashes containing the category slug and the reason for the subscription',
   )
-  .action(async (topic, opts) => {
+  .action(async (topic, opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().subscriptions.unsubscribe(topic, data, options);
+    const response = await getClient(cmd).subscriptions.unsubscribe(topic, data, options);
     printJson(response);
   });
 
@@ -64,10 +64,10 @@ subscriptions
   .command('get')
   .description('Show a topic subscription')
   .argument('<topic>', "The topic for which we'd like to filter topic subscriptions.")
-  .action(async (topic, opts) => {
+  .action(async (topic, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().subscriptions.get(topic, options);
+    const response = await getClient(cmd).subscriptions.get(topic, options);
     printJson(response);
   });
 
@@ -79,9 +79,9 @@ subscriptions
     '--categories <string...>',
     'A list of hashes containing the category slug and the reason for the subscription. Omiting categories deletes all topic subscriptions beloning to the topic.',
   )
-  .action(async (topic, opts) => {
+  .action(async (topic, opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().subscriptions.delete(topic, data, options);
+    const response = await getClient(cmd).subscriptions.delete(topic, data, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/users.ts
+++ b/packages/cli/src/resources/users.ts
@@ -26,10 +26,10 @@ users
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
-  .action(async (opts) => {
+  .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().users.create(data, options);
+    const response = await getClient(cmd).users.create(data, options);
     printJson(response);
   });
 
@@ -57,10 +57,10 @@ users
   .option('--order-by <string>', 'Use it to order the returned list of users. Defaults to `created_at,DESC`')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async ({ paginate, maxItems, ...opts }) => {
+  .action(async ({ paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().users.list(data, options);
+    const response = getClient(cmd).users.list(data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {
@@ -76,10 +76,10 @@ users
   .command('get')
   .description('Get user by ID')
   .argument('<user-id>', 'The user id is the MagicBell user id. Accepts a UUID')
-  .action(async (userId, opts) => {
+  .action(async (userId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().users.get(userId, options);
+    const response = await getClient(cmd).users.get(userId, options);
     printJson(response);
   });
 
@@ -102,10 +102,10 @@ users
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
-  .action(async (userId, opts) => {
+  .action(async (userId, opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().users.update(userId, data, options);
+    const response = await getClient(cmd).users.update(userId, data, options);
     printJson(response);
   });
 
@@ -116,10 +116,10 @@ users
     '<user-id>',
     'The user id is the MagicBell user id. Alternatively, provide an id like `email:theusersemail@example.com` or `external_id:theusersexternalid` as the user id.',
   )
-  .action(async (userId, opts) => {
+  .action(async (userId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().users.delete(userId, options);
+    const response = await getClient(cmd).users.delete(userId, options);
     printJson(response);
   });
 
@@ -139,10 +139,10 @@ users
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
-  .action(async (userEmail, opts) => {
+  .action(async (userEmail, opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().users.updateByEmail(userEmail, data, options);
+    const response = await getClient(cmd).users.updateByEmail(userEmail, data, options);
     printJson(response);
   });
 
@@ -150,10 +150,10 @@ users
   .command('delete-by-email')
   .description('Delete a user identified by email')
   .argument('<user-email>', '')
-  .action(async (userEmail, opts) => {
+  .action(async (userEmail, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().users.deleteByEmail(userEmail, options);
+    const response = await getClient(cmd).users.deleteByEmail(userEmail, options);
     printJson(response);
   });
 
@@ -173,10 +173,10 @@ users
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
-  .action(async (externalId, opts) => {
+  .action(async (externalId, opts, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = await getClient().users.updateByExternalId(externalId, data, options);
+    const response = await getClient(cmd).users.updateByExternalId(externalId, data, options);
     printJson(response);
   });
 
@@ -184,9 +184,9 @@ users
   .command('delete-by-external-id')
   .description('Delete a user identified by external ID')
   .argument('<external-id>', '')
-  .action(async (externalId, opts) => {
+  .action(async (externalId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().users.deleteByExternalId(externalId, options);
+    const response = await getClient(cmd).users.deleteByExternalId(externalId, options);
     printJson(response);
   });

--- a/packages/cli/src/resources/users/notifications.ts
+++ b/packages/cli/src/resources/users/notifications.ts
@@ -15,10 +15,10 @@ usersNotifications
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async (userId, { paginate, maxItems, ...opts }) => {
+  .action(async (userId, { paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().users.notifications.list(userId, data, options);
+    const response = getClient(cmd).users.notifications.list(userId, data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {

--- a/packages/cli/src/resources/users/push-subscriptions.ts
+++ b/packages/cli/src/resources/users/push-subscriptions.ts
@@ -17,10 +17,10 @@ usersPushSubscriptions
   .option('--per-page <integer>', 'The number of items per page. Defaults to 20.')
   .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
   .option('--max-items <number>', 'Maximum number of items to fetch', Number)
-  .action(async (userId, { paginate, maxItems, ...opts }) => {
+  .action(async (userId, { paginate, maxItems, ...opts }, cmd) => {
     const { data, options } = parseOptions(opts);
 
-    const response = getClient().users.pushSubscriptions.list(userId, data, options);
+    const response = getClient(cmd).users.pushSubscriptions.list(userId, data, options);
 
     if (paginate) {
       await response.forEach((notification, idx) => {
@@ -37,9 +37,9 @@ usersPushSubscriptions
   .description("Delete user's push subscription")
   .argument('<user-id>', 'The user id is the MagicBell user id. Accepts a UUID')
   .argument('<subscription-id>', 'ID of the subscription.')
-  .action(async (userId, subscriptionId, opts) => {
+  .action(async (userId, subscriptionId, opts, cmd) => {
     const { options } = parseOptions(opts);
 
-    const response = await getClient().users.pushSubscriptions.delete(userId, subscriptionId, options);
+    const response = await getClient(cmd).users.pushSubscriptions.delete(userId, subscriptionId, options);
     printJson(response);
   });


### PR DESCRIPTION
Refactor so we can consume flags in the client, and don't need to use configStore as intermediate storage.