### PR TITLE
feat: add `isSubscribed` method to webpush package

### DIFF
--- a/.changeset/two-trains-repeat.md
+++ b/.changeset/two-trains-repeat.md
@@ -1,0 +1,21 @@
+---
+'@magicbell/webpush': minor
+---
+
+Adds an 'isSubscribed' method that checks if the user is subscribed to push notifications in the current browser, e.g.
+
+```js
+import { isSubscribed } from '@magicbell/webpush';
+
+const subscribed = await isSubscribed({
+  token: 'jwt-token',
+  host: 'https://api.magicbell.com',
+  project: 'string',
+});
+
+if (subscribed) {
+  // Do something
+} else {
+  // Do something else
+}
+```

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -88,6 +88,26 @@ prefetchConfig({
 });
 ```
 
+### isSubscribed
+
+Check if the user is subscribed to push notifications in the current browser.
+
+```js
+import { isSubscribed } from '@magicbell/webpush';
+
+const subscribed = await isSubscribed({
+  token: 'jwt-token',
+  host: 'https://api.magicbell.com',
+  project: 'string',
+});
+
+if (subscribed) {
+  // Do something
+} else {
+  // Do something else
+}
+```
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `magicbell` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
@@ -100,3 +120,7 @@ Credit where credits due, this package is inspired by and based on the [Stripe N
 [idempotent-requests]: https://www.magicbell.com/docs/rest-api/idempotent-requests
 [hmac-authentication]: https://www.magicbell.com/docs/hmac-authentication
 [api-reference]: https://www.magicbell.com/docs/rest-api/reference
+
+```
+
+```

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -120,7 +120,3 @@ Credit where credits due, this package is inspired by and based on the [Stripe N
 [idempotent-requests]: https://www.magicbell.com/docs/rest-api/idempotent-requests
 [hmac-authentication]: https://www.magicbell.com/docs/hmac-authentication
 [api-reference]: https://www.magicbell.com/docs/rest-api/reference
-
-```
-
-```


### PR DESCRIPTION
Adds "isSubscribed" function as a more reliable method (than using localStorage flags) of detecting a currently active push subscription in current browser.