### PR TITLE
chore: declare exports in package.json

### DIFF
--- a/.changeset/lemon-emus-perform.md
+++ b/.changeset/lemon-emus-perform.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+declare exports in package.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
-      - name: Lint
+        # we need to upgrade to Node16 module resolution so TSC can use package.json#exports
+      - name: Build
+        run: yarn build
+      - name: TypeScript
         run: tsc -v && yarn lint:typescript
 
   test:
@@ -54,13 +57,3 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
       - run: yarn test:ci
-
-  build:
-    name: Build
-    needs: [setup]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-node
-      - run: yarn build

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest -c scripts/vite/vite.config.js --run --coverage",
     "test:watch": "vitest -c scripts/vite/vite.config.js",
     "test:ci": "cross-env CI=true vitest -c scripts/vite/vite.config.js",
-    "postinstall": "husky install && node scripts/sync-paths.js && manypkg check && link-workspaces",
+    "postinstall": "husky install && node scripts/sync-paths.js && manypkg check && link-workspaces --no-source",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:release": "yarn build && changeset publish",

--- a/packages/cli/src/lib/options.ts
+++ b/packages/cli/src/lib/options.ts
@@ -1,4 +1,4 @@
-import { parse } from 'json5';
+import json from 'json5';
 
 import { printError } from './printer';
 import { camelToSnakeCase } from './text';
@@ -14,10 +14,10 @@ function parseJsonLikes(obj: unknown) {
   const lastChar = str[str.length - 1];
 
   try {
-    if (firstChar === '{' && lastChar === '}') return parse(str);
-    if (firstChar === '[' && lastChar === ']') return parse(str);
-    if (firstChar === '"' && lastChar === '"') return parse(str);
-    if (firstChar === "'" && lastChar === "'") return parse(str);
+    if (firstChar === '{' && lastChar === '}') return json.parse(str);
+    if (firstChar === '[' && lastChar === ']') return json.parse(str);
+    if (firstChar === '"' && lastChar === '"') return json.parse(str);
+    if (firstChar === "'" && lastChar === "'") return json.parse(str);
     return obj;
   } catch {
     return obj;

--- a/packages/cli/vite.config.js
+++ b/packages/cli/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+import baseConfig from '../../scripts/vite/vite.config.js';
+
+export default defineConfig(async (configEnv) => {
+  const base = await baseConfig(configEnv);
+  base.build.lib.formats = ['cjs'];
+  base.build.lib.fileName = () => 'index.cjs';
+  base.build.sourcemap = false;
+  return base;
+});

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -11,6 +11,28 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "typings": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./project-client": {
+      "types": "./dist/project-client.d.ts",
+      "import": "./dist/project-client.mjs",
+      "require": "./dist/project-client.cjs"
+    },
+    "./user-client": {
+      "types": "./dist/user-client.d.ts",
+      "import": "./dist/user-client.mjs",
+      "require": "./dist/user-client.cjs"
+    },
+    "./crypto": {
+      "types": "./dist/crypto.d.ts",
+      "import": "./dist/crypto.mjs",
+      "require": "./dist/crypto.cjs"
+    }
+  },
   "publishConfig": {
     "access": "public",
     "directory": "./dist"

--- a/packages/magicbell/vite.config.js
+++ b/packages/magicbell/vite.config.js
@@ -21,8 +21,14 @@ export function copyStatics() {
           pkgJson[key] = pkgJson[key].replace(pkgJson.publishConfig.directory, '.');
         }
 
+        for (const key of Object.keys(pkgJson.exports)) {
+          for (const [format, file] of Object.entries(pkgJson.exports[key])) {
+            pkgJson.exports[key][format] = file.replace(pkgJson.publishConfig.directory, '.');
+          }
+        }
+
         // delete redundant properties
-        for (const key of ['files', 'devDependencies', 'size-limit', 'scripts', 'publishConfig', 'exports', 'source']) {
+        for (const key of ['files', 'devDependencies', 'size-limit', 'scripts', 'publishConfig', 'source']) {
           delete pkgJson[key];
         }
 


### PR DESCRIPTION
Add `exports` to the `magicbell` package.json, and change CI to build before running typescript. The building is necessary, as we symlink to the magicbell/dist folder during postinstall. Ideally, we'd drop that. But till we've upgraded tsconfig to use moduleResolution node16, we're kinda stuck to that.