### PR TITLE
chore: small user client improvements

### DIFF
--- a/.changeset/dirty-rocks-punch.md
+++ b/.changeset/dirty-rocks-punch.md
@@ -1,0 +1,13 @@
+---
+'magicbell': patch
+---
+
+Optional client options can now be `undefined` or `null`, rather than enforced to be absent. This eases initialization where options come from other configuration sources.
+
+```ts
+const client = new UserClient({
+  apiKey: '...',
+  userEmail: 'person@example.com',
+  userExternalId: undefined, // no longer throws
+})
+```

--- a/.changeset/lovely-knives-bow.md
+++ b/.changeset/lovely-knives-bow.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+The EventSource polyfill is now only applied when the `EventSource` is not supported in your environment.

--- a/.changeset/metal-ties-agree.md
+++ b/.changeset/metal-ties-agree.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+A bug where the eventsource was closed before opened is now fixed. This race condition occurred when closing the stream while the token request was still pending.

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -65,7 +65,7 @@
     "build:entry:user-client": "cross-env ENTRY=src/user-client.ts vite build",
     "build:entry:crypto": "cross-env ENTRY=src/crypto.ts vite build",
     "generate:resources": "tsx scripts/generate-resources.ts",
-    "start": "yarn build:dev --watch",
+    "start": "npm run clean && run-p 'build:entry:* --watch'",
     "size": "size-limit"
   },
   "size-limit": [

--- a/packages/magicbell/src/client/options.ts
+++ b/packages/magicbell/src/client/options.ts
@@ -32,7 +32,7 @@ export function isOptionsHash(object) {
 }
 
 export function assertHasValidOptions<T extends ClientOptions>(options: T) {
-  const invalidOptions = Object.keys(options).filter((x) => !optionValidators[x]?.(options[x]));
+  const invalidOptions = Object.keys(options).filter((x) => options[x] != null && !optionValidators[x]?.(options[x]));
   if (invalidOptions.length) {
     throw new Error(
       `You have provided invalid client options. Please check the options ${joinAnd(...invalidOptions)}.`,

--- a/packages/magicbell/src/resources/listen.ts
+++ b/packages/magicbell/src/resources/listen.ts
@@ -56,6 +56,7 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
 
   const messages: { value: Event; done: boolean }[] = [];
   let resolve;
+  let disposed = false;
 
   const pushMessage = (p) => {
     messages.push(p);
@@ -104,6 +105,8 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
       eventSource.close();
     }
 
+    // dispose could've been called while we were waiting for the config request to finish
+    if (disposed) return;
     eventSource = new EventSource(url.toString());
 
     // handle incoming messages
@@ -150,7 +153,8 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
     };
 
     const dispose = () => {
-      eventSource.close();
+      disposed = true;
+      eventSource?.close();
       // push to resolve async iterators, return for sync ones
       pushMessage({ done: true, value: undefined });
       return { done: true, value: undefined };

--- a/packages/magicbell/src/resources/listen.ts
+++ b/packages/magicbell/src/resources/listen.ts
@@ -1,9 +1,13 @@
-import EventSource from 'eventsource';
+import EventSourcePolyFill from 'eventsource';
 import ky from 'ky';
 
 import { Client } from '../client/client';
 import { ASYNC_ITERATOR_SYMBOL, makeForEach } from '../client/paginate';
 import { RequestOptions } from '../client/types';
+
+if (!globalThis.EventSource) {
+  globalThis.EventSource = EventSourcePolyFill;
+}
 
 type AuthResponse = {
   keyName: string;

--- a/packages/magicbell/vite.config.js
+++ b/packages/magicbell/vite.config.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-import { pkg } from '../../scripts/vite/settings';
 import baseConfig from '../../scripts/vite/vite.config.js';
 
 const extensions = {
@@ -32,13 +31,14 @@ export function copyStatics() {
           delete pkgJson[key];
         }
 
+        fs.mkdirSync('dist', { recursive: true });
         fs.writeFileSync('dist/package.json', JSON.stringify(pkgJson, null, 2));
 
         for (const file of ['LICENSE', 'CHANGELOG.md', 'README.md']) {
           fs.copyFileSync(file, path.join('dist', file));
         }
       } catch (error) {
-        this.error(`Failed to generate types for ${pkg.name}`);
+        this.error(`Failed to copy statics: ${error.message}`);
       }
     },
   };


### PR DESCRIPTION
Optional client options can now be `undefined` or `null`, rather than enforce to be absent.

The EventSource polyfill is now only used when the `EventSource` is not supported in your environment.

A bug where the eventsource was closed before it's opened is now fixed. This race condition occurred when closing the stream between token request and connection open.