### PR TITLE
chore: remove apiSecret and index signature

### DIFF
--- a/.changeset/rotten-onions-thank.md
+++ b/.changeset/rotten-onions-thank.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/react-headless': patch
+---
+
+Removed `apiSecret` from `ClientSettings`.

--- a/.changeset/strong-camels-explode.md
+++ b/.changeset/strong-camels-explode.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/react-headless': patch
+---
+
+Removed index signature from `QueryParams`, so TypeScript will properly warn about misspelled options.

--- a/packages/react-headless/src/lib/ajax.ts
+++ b/packages/react-headless/src/lib/ajax.ts
@@ -24,14 +24,13 @@ type AxiosMethod =
   | 'PATCH';
 
 export function buildAPIHeaders() {
-  const { apiKey, apiSecret, clientId, userEmail, userExternalId, userKey } = clientSettings.getState();
+  const { apiKey, clientId, userEmail, userExternalId, userKey } = clientSettings.getState();
   const headers = {
     'X-MAGICBELL-CLIENT-ID': clientId,
     'X-MAGICBELL-API-KEY': apiKey,
     'X-MagicBell-Client': 'ReactHeadless/4.0.0', // @todo: Get value from package.json
   };
 
-  if (apiSecret) headers['X-MAGICBELL-API-SECRET'] = apiSecret;
   if (userEmail) headers['X-MAGICBELL-USER-EMAIL'] = userEmail;
   if (userKey) headers['X-MAGICBELL-USER-HMAC'] = userKey;
   if (userExternalId) headers['X-MAGICBELL-USER-EXTERNAL-ID'] = userExternalId;

--- a/packages/react-headless/src/stores/clientSettings.ts
+++ b/packages/react-headless/src/stores/clientSettings.ts
@@ -2,7 +2,6 @@ import create from 'zustand/vanilla';
 
 export interface ClientSettings {
   apiKey: string;
-  apiSecret?: string;
   userEmail?: string;
   userExternalId?: string;
   userKey?: string;
@@ -19,7 +18,6 @@ export interface ClientSettings {
  */
 const clientSettings = create<ClientSettings>(() => ({
   apiKey: '',
-  apiSecret: undefined,
   userEmail: undefined,
   userExternalId: undefined,
   userKey: undefined,

--- a/packages/react-headless/src/types/INotificationsStoresCollection.ts
+++ b/packages/react-headless/src/types/INotificationsStoresCollection.ts
@@ -32,9 +32,6 @@ export type QueryParams = {
    * The page number to be returned.
    */
   page?: number;
-
-  // accept any other key supported by the backend, but not yet typed in this SDK
-  [key: string]: unknown;
 };
 
 export default interface INotificationsStoresCollection {

--- a/packages/react-headless/tests/src/lib/ajax.spec.ts
+++ b/packages/react-headless/tests/src/lib/ajax.spec.ts
@@ -102,21 +102,6 @@ describe('lib', () => {
           });
         });
 
-        describe('the api secret is set', () => {
-          it('sends the X-MAGICBELL-API-SECRET header', async () => {
-            const apiSecret = faker.random.alphaNumeric();
-            const { setState } = clientSettings;
-            setState({ apiSecret });
-
-            await fetchAPI('/notifications');
-
-            const requests = server.pretender.handledRequests;
-            expect(requests[0].requestHeaders).toMatchObject({
-              'X-MAGICBELL-API-SECRET': apiSecret,
-            });
-          });
-        });
-
         describe('the user key is set', () => {
           it('sends the X-MAGICBELL-USER-HMAC header', async () => {
             const userKey = faker.random.alphaNumeric();


### PR DESCRIPTION
Remove `apiSecret` from types, as client side apis don't need it.

Remove index signature from `QueryParams` so TypeScript will properly warn about misspelled options.