### PR TITLE
fix: display array item types in --help

### DIFF
--- a/.changeset/tall-islands-leave.md
+++ b/.changeset/tall-islands-leave.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+Be more specific about the json type some arguments expect. For example, we used to show `--overrides <json>`, but json can also be an array, while we do expect an object. Now, those arguments are shown as `<object>`.

--- a/packages/cli/scripts/generate-resources.ts
+++ b/packages/cli/scripts/generate-resources.ts
@@ -110,14 +110,8 @@ function createResource(scope: 'user' | 'project', resource: Resource, children:
     // add options
     for (const [option, schema] of Object.entries(method.data?.properties || {})) {
       const flag = `--${hyphenCase(option)}`;
-      const type =
-        schema.type === 'boolean'
-          ? null
-          : schema.type === 'array'
-          ? 'string...'
-          : schema.type === 'object'
-          ? 'json'
-          : schema.type;
+      const type = schema.type === 'boolean' ? null : schema.type === 'array' ? `${schema.items.type}...` : schema.type;
+
       expression = builders.callExpression(builders.memberExpression(expression, b.id('option')), [
         builders.stringLiteral(type ? `${flag} <${type}>` : flag),
         builders.stringLiteral((cleanMarkdown(schema.description) || '').split('\n')[0]),

--- a/packages/cli/src/project-resources/imports.ts
+++ b/packages/cli/src/project-resources/imports.ts
@@ -10,7 +10,7 @@ export const imports = createCommand('imports').description('Manage imports');
 imports
   .command('create')
   .description('Create a import')
-  .option('--users <string...>', '')
+  .option('--users <object...>', '')
   .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 

--- a/packages/cli/src/project-resources/notifications.ts
+++ b/packages/cli/src/project-resources/notifications.ts
@@ -20,11 +20,11 @@ notifications
     'A URL to redirect the user to when they click the notification in their notification inbox.',
   )
   .option(
-    '--recipients <string...>',
+    '--recipients <object...>',
     'Users to send the notification to. You can specify up to 1000 users in the request body or use matches to send a notification to any number of users.',
   )
   .option(
-    '--custom-attributes <json>',
+    '--custom-attributes <object>',
     'Set of key-value pairs that you can attach to a notification, 6KB at maximum. It accepts objects for the value of a key.',
   )
   .option(
@@ -32,7 +32,7 @@ notifications
     'Category the notification belongs to. This is useful to allow users to set their preferences.',
   )
   .option('--topic <string>', 'Topic the notification belongs to. This is useful to create threads.')
-  .option('--overrides <json>', 'Optional overrides to configure notifications per target destination.')
+  .option('--overrides <object>', 'Optional overrides to configure notifications per target destination.')
   .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 

--- a/packages/cli/src/project-resources/users.ts
+++ b/packages/cli/src/project-resources/users.ts
@@ -22,7 +22,7 @@ users
   .option('--first-name <string>', "The user's first name.")
   .option('--last-name <string>', "The user's last name.")
   .option(
-    '--custom-attributes <json>',
+    '--custom-attributes <object>',
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
@@ -98,7 +98,7 @@ users
   .option('--first-name <string>', "The user's first name.")
   .option('--last-name <string>', "The user's last name.")
   .option(
-    '--custom-attributes <json>',
+    '--custom-attributes <object>',
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
@@ -135,7 +135,7 @@ users
   .option('--first-name <string>', "The user's first name.")
   .option('--last-name <string>', "The user's last name.")
   .option(
-    '--custom-attributes <json>',
+    '--custom-attributes <object>',
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')
@@ -169,7 +169,7 @@ users
   .option('--first-name <string>', "The user's first name.")
   .option('--last-name <string>', "The user's last name.")
   .option(
-    '--custom-attributes <json>',
+    '--custom-attributes <object>',
     "Any customer attributes that you'd like to associate with the user. You may want to use these attributes later when writing email templates, for example.",
   )
   .option('--phone-numbers <string...>', 'An array of phone numbers to use for sending SMS notifications.')

--- a/packages/cli/src/user-resources/notification-preferences.ts
+++ b/packages/cli/src/user-resources/notification-preferences.ts
@@ -22,7 +22,7 @@ notificationPreferences
 notificationPreferences
   .command('update')
   .description('Update user notification preferences')
-  .option('--categories <string...>', '')
+  .option('--categories <object...>', '')
   .action(async (opts, cmd) => {
     const { data, options } = parseOptions(opts);
 

--- a/packages/cli/src/user-resources/subscriptions.ts
+++ b/packages/cli/src/user-resources/subscriptions.ts
@@ -31,7 +31,7 @@ subscriptions
   .command('create')
   .description('Create a topic subscription')
   .option(
-    '--categories <string...>',
+    '--categories <object...>',
     'A list of hashes containing the category slug and the reason for the subscription',
   )
   .option(
@@ -50,7 +50,7 @@ subscriptions
   .description('Unsubscribe from a topic')
   .argument('<topic>', "The topic for which we'd like to filter topic subscriptions.")
   .option(
-    '--categories <string...>',
+    '--categories <object...>',
     'A list of hashes containing the category slug and the reason for the subscription',
   )
   .action(async (topic, opts, cmd) => {
@@ -76,7 +76,7 @@ subscriptions
   .description('Delete topic subscription(s)')
   .argument('<topic>', "The topic for which we'd like to filter topic subscriptions.")
   .option(
-    '--categories <string...>',
+    '--categories <object...>',
     'A list of hashes containing the category slug and the reason for the subscription. Omiting categories deletes all topic subscriptions beloning to the topic.',
   )
   .action(async (topic, opts, cmd) => {


### PR DESCRIPTION
Be more specific about the json type some arguments expect. For example, we used to show `--overrides <json>`, but json can also be an array, while we do expect an object. Now, those arguments are shown as `<object>`.