### PR TITLE
feat: add push-subscriptions list

### DIFF
--- a/.changeset/eleven-cooks-bow.md
+++ b/.changeset/eleven-cooks-bow.md
@@ -1,0 +1,12 @@
+---
+'@magicbell/cli': minor
+---
+
+We've added a method to list the registered push subscriptions for a given user using user credentials.
+
+```shell
+magicbell user push-subscriptions list \
+  --user-email person@example.com
+```
+
+Note that this method returns the same data as the project scoped `magicbell users push-subscriptions <user-id>`.

--- a/.changeset/thick-eyes-retire.md
+++ b/.changeset/thick-eyes-retire.md
@@ -1,0 +1,12 @@
+---
+'magicbell': minor
+---
+
+We've added a method to the `UserClient` to list the registered push notifications for the authenticated user.
+
+```js
+const magicbell = new UserClient({ ... });
+await magicbell.pushSubscriptions.list();
+```
+
+This method returns the same data as `users.pushSubscriptions.list` on the `Projectclient`, but using user credentials instead of the secret key. Thereby, it's safe to use this method on the frontend to offer a way to the user to manage their push subscriptions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -420,6 +420,14 @@ magicbell user push-subscriptions create  \
   --platform 'ios'
 ```
 
+#### List user's device tokens
+
+Returns the list of device tokens registered for push notifications.
+
+```shell
+magicbell user push-subscriptions list
+```
+
 #### Delete user's device token
 
 Deletes the registered device token to remove the mobile push subscription.

--- a/packages/cli/src/user-resources/push-subscriptions.ts
+++ b/packages/cli/src/user-resources/push-subscriptions.ts
@@ -30,6 +30,26 @@ pushSubscriptions
   });
 
 pushSubscriptions
+  .command('list')
+  .description("List user's device tokens")
+  .option('--paginate', 'Make additional HTTP requests to fetch all pages of results')
+  .option('--max-items <number>', 'Maximum number of items to fetch', Number)
+  .action(async ({ paginate, maxItems, ...opts }, cmd) => {
+    const { options } = parseOptions(opts);
+
+    const response = getClient(cmd).pushSubscriptions.list(options);
+
+    if (paginate) {
+      await response.forEach((notification, idx) => {
+        printJson(notification);
+        return !(maxItems && idx + 1 >= maxItems);
+      });
+    } else {
+      await response.then((result) => printJson(result));
+    }
+  });
+
+pushSubscriptions
   .command('delete')
   .description("Delete user's device token")
   .argument('<device-token>', 'Token of the device you want to remove')

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -796,6 +796,14 @@ await magicbell.pushSubscriptions.create({
 });
 ```
 
+#### List user's device tokens
+
+Returns the list of device tokens registered for push notifications.
+
+```js
+await magicbell.pushSubscriptions.list();
+```
+
 #### Delete user's device token
 
 Deletes the registered device token to remove the mobile push subscription.

--- a/packages/magicbell/src/schemas/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/push-subscriptions.ts
@@ -53,3 +53,58 @@ export const CreatePushSubscriptionsPayloadSchema = {
     },
   },
 } as const;
+
+export const ListPushSubscriptionsResponseSchema = {
+  title: 'ListPushSubscriptionsResponseSchema',
+  type: 'object',
+  additionalProperties: false,
+
+  properties: {
+    per_page: {
+      type: 'integer',
+    },
+
+    current_page: {
+      type: 'integer',
+    },
+
+    push_subscriptions: {
+      type: 'array',
+
+      items: {
+        type: 'object',
+        additionalProperties: false,
+
+        properties: {
+          id: {
+            type: 'string',
+          },
+
+          user_id: {
+            type: 'string',
+            format: 'uuid',
+          },
+
+          device_token: {
+            type: 'string',
+          },
+
+          platform: {
+            type: 'string',
+          },
+
+          created_at: {
+            type: 'string',
+            format: 'date-time',
+          },
+
+          discarded_at: {
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/magicbell/src/user-resources/push-subscriptions.ts
+++ b/packages/magicbell/src/user-resources/push-subscriptions.ts
@@ -2,12 +2,14 @@
 
 import { type FromSchema } from 'json-schema-to-ts';
 
+import { type IterablePromise } from '../client/method';
 import { Resource } from '../client/resource';
 import { type RequestOptions } from '../client/types';
 import * as schemas from '../schemas/push-subscriptions';
 
 type CreatePushSubscriptionsResponse = FromSchema<typeof schemas.CreatePushSubscriptionsResponseSchema>;
 type CreatePushSubscriptionsPayload = FromSchema<typeof schemas.CreatePushSubscriptionsPayloadSchema>;
+type ListPushSubscriptionsResponse = FromSchema<typeof schemas.ListPushSubscriptionsResponseSchema>;
 
 export class PushSubscriptions extends Resource {
   path = 'push_subscriptions';
@@ -29,6 +31,22 @@ export class PushSubscriptions extends Resource {
         method: 'POST',
       },
       data,
+      options,
+    );
+  }
+
+  /**
+   * Returns the list of device tokens registered for push notifications.
+   *
+   * @param options - override client request options.
+   * @returns
+   **/
+  list(options?: RequestOptions): IterablePromise<ListPushSubscriptionsResponse> {
+    return this.request(
+      {
+        method: 'GET',
+        paged: true,
+      },
       options,
     );
   }


### PR DESCRIPTION
**magicbell**

We've added a method to the `UserClient` to list the registered push notifications for the authenticated user.

```js
const magicbell = new UserClient({ ... });
await magicbell.pushSubscriptions.list();
```

This method returns the same data as `users.pushSubscriptions.list` on the `Projectclient`, but using user credentials instead of the secret key. Thereby, it's safe to use this method on the frontend to offer a way to the user to manage their push subscriptions.

**@magicbell/cli**


We've added a method to list the registered push subscriptions for a given user using user credentials.

```shell
magicbell user push-subscriptions list \
  --user-email person@example.com
```

Note that this method returns the same data as the project scoped `magicbell users push-subscriptions <user-id>`.
