### PR TITLE
fix: type fixes

### DIFF
--- a/.changeset/lovely-dingos-protect.md
+++ b/.changeset/lovely-dingos-protect.md
@@ -1,0 +1,9 @@
+---
+'magicbell': patch
+---
+
+Fixed a few misconfigured types:
+
+- import `status` is now an enum with the values `enqueued | processing | processed`
+- import `failures` now has the users array items typed as `object` with the properties `email` and `external_id` and `errors`
+- the `total` and `total_pages` props are removed from the `users.pushSubscriptions.list` response.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:example": "yarn --cwd example && yarn --cwd example start",
     "start:storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
     "start:playground": "yarn --cwd packages/playground start",
+    "generate:resources": "yarn --cwd packages/magicbell generate:resources && yarn --cwd packages/cli generate:resources",
     "build": "turbo run build",
     "build:example": "yarn --cwd example && yarn --cwd example build",
     "build:storybook": "build-storybook",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -495,7 +495,8 @@ magicbell user subscriptions get <topic>
 #### Delete topic subscription(s)
 
 ```shell
-magicbell user subscriptions delete <topic>
+magicbell user subscriptions delete <topic>  \
+  --categories '{"slug":"comments"}'
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END (USER_RESOURCE_METHODS) -->

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -900,7 +900,7 @@ await magicbell.subscriptions.get('{topic}');
 await magicbell.subscriptions.delete('{topic}', {
   categories: [
     {
-      slug: '…',
+      slug: 'comments',
     },
   ],
 });

--- a/packages/magicbell/src/schemas/imports.ts
+++ b/packages/magicbell/src/schemas/imports.ts
@@ -12,7 +12,7 @@ export const CreateImportsResponseSchema = {
 
     status: {
       type: 'string',
-      enum: ['processing'],
+      enum: ['enqueued', 'processing', 'processed'],
     },
 
     summary: {
@@ -70,23 +70,29 @@ export const CreateImportsResponseSchema = {
       properties: {
         users: {
           type: 'array',
-          description: 'User objects that could not be imported successfully',
-          additionalProperties: false,
 
-          properties: {
-            email: {
-              type: 'string',
-              description: 'The identifying email of the user if supplied in the import request.',
-            },
+          items: {
+            type: 'object',
+            description: 'User objects that could not be imported successfully',
+            additionalProperties: false,
 
-            external_id: {
-              type: 'string',
-              description: 'The identifying external_id of the user if supplied in the import request.',
-            },
+            properties: {
+              email: {
+                nullable: true,
+                type: 'string',
+                description: 'The identifying email of the user if supplied in the import request.',
+              },
 
-            errors: {
-              type: 'object',
-              description: 'The errors object reflecting the structure of the user oject',
+              external_id: {
+                nullable: true,
+                type: 'string',
+                description: 'The identifying external_id of the user if supplied in the import request.',
+              },
+
+              errors: {
+                type: 'object',
+                description: 'The errors object reflecting the structure of the user oject',
+              },
             },
           },
         },
@@ -177,7 +183,7 @@ export const GetImportsResponseSchema = {
 
     status: {
       type: 'string',
-      enum: ['processing'],
+      enum: ['enqueued', 'processing', 'processed'],
     },
 
     summary: {
@@ -235,23 +241,29 @@ export const GetImportsResponseSchema = {
       properties: {
         users: {
           type: 'array',
-          description: 'User objects that could not be imported successfully',
-          additionalProperties: false,
 
-          properties: {
-            email: {
-              type: 'string',
-              description: 'The identifying email of the user if supplied in the import request.',
-            },
+          items: {
+            type: 'object',
+            description: 'User objects that could not be imported successfully',
+            additionalProperties: false,
 
-            external_id: {
-              type: 'string',
-              description: 'The identifying external_id of the user if supplied in the import request.',
-            },
+            properties: {
+              email: {
+                nullable: true,
+                type: 'string',
+                description: 'The identifying email of the user if supplied in the import request.',
+              },
 
-            errors: {
-              type: 'object',
-              description: 'The errors object reflecting the structure of the user oject',
+              external_id: {
+                nullable: true,
+                type: 'string',
+                description: 'The identifying external_id of the user if supplied in the import request.',
+              },
+
+              errors: {
+                type: 'object',
+                description: 'The errors object reflecting the structure of the user oject',
+              },
             },
           },
         },

--- a/packages/magicbell/src/schemas/users/push-subscriptions.ts
+++ b/packages/magicbell/src/schemas/users/push-subscriptions.ts
@@ -5,15 +5,7 @@ export const ListUsersPushSubscriptionsResponseSchema = {
   additionalProperties: false,
 
   properties: {
-    total: {
-      type: 'integer',
-    },
-
     per_page: {
-      type: 'integer',
-    },
-
-    total_pages: {
       type: 'integer',
     },
 


### PR DESCRIPTION
**magicbell**

Fixed a few misconfigured types:

- import `status` is now an enum with the values `enqueued | processing | processed`
- import `failures` now has the users array items typed as `object` with the properties `email` and `external_id` and `errors`
- the `total` and `total_pages` props are removed from the `users.pushSubscriptions.list` response.