### PR TITLE
chore: remove eventsource polyfill

### DIFF
--- a/.changeset/chilly-cobras-compare.md
+++ b/.changeset/chilly-cobras-compare.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': minor
+---
+
+Add [EventSource](https://www.npmjs.com/package/eventsource) polyfill for the `listen` methods. This polyfill is removed from the `magicbell` package, to avoid bundling it in the browser SDKs.

--- a/.changeset/spicy-poems-clap.md
+++ b/.changeset/spicy-poems-clap.md
@@ -1,0 +1,5 @@
+---
+'magicbell': minor
+---
+
+Remove [EventSource](https://www.npmjs.com/package/eventsource) polyfill to avoid bundling it in the browser SDKs. If you're using the `listen` methods in an environment that does not support `eventsource`, you'll need to include the polyfill yourself.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@types/configstore": "^5.0.1",
     "commander": "^9.4.1",
     "configstore": "^5.0.1",
+    "eventsource": "^2.0.2",
     "fetch-addons": "^1.1.0",
     "json5": "^2.2.3",
     "kleur": "^4.1.5",

--- a/packages/cli/src/listen.ts
+++ b/packages/cli/src/listen.ts
@@ -1,7 +1,13 @@
+import EventSource from 'eventsource';
+
 import { getUserClient as getClient } from './lib/client';
 import { createCommand } from './lib/commands';
 import { parseOptions } from './lib/options';
 import { printJson } from './lib/printer';
+
+if (!globalThis.EventSource) {
+  globalThis.EventSource = EventSource;
+}
 
 export const listen = createCommand('listen')
   .description('Listen to events for a users inbox')

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -8,6 +8,8 @@ Node 18.13 or higher.
 
 When using older versions, you might need to polyfill `fetch`. See [isomorphic-fetch](https://npmjs.com/isomorphic-fetch) for more information.
 
+You also might need to polyfill `eventsource` when using the `listen` method in an environment that doesn't support it. See [eventsource](https://npmjs.com/eventsource) for more information.
+
 ## Installation
 
 Install the package with npm:

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -90,7 +90,6 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "eventsource": "^2.0.2",
     "fetch-addons": "^1.1.0",
     "json-schema-to-ts": "2.6.0",
     "ky": "npm:@smeijer/ky@^0.33.3"

--- a/packages/magicbell/src/resources/listen.ts
+++ b/packages/magicbell/src/resources/listen.ts
@@ -1,13 +1,8 @@
-import EventSourcePolyFill from 'eventsource';
 import ky from 'ky';
 
 import { Client } from '../client/client';
 import { ASYNC_ITERATOR_SYMBOL, makeForEach } from '../client/paginate';
 import { RequestOptions } from '../client/types';
-
-if (!globalThis.EventSource) {
-  globalThis.EventSource = EventSourcePolyFill;
-}
 
 type AuthResponse = {
   keyName: string;

--- a/scripts/vite/test.setup.js
+++ b/scripts/vite/test.setup.js
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom';
 
 import { useConfig, useNotificationPreferences } from '@magicbell/react-headless';
+import EventSource from 'eventsource';
+
+if (!globalThis.EventSource) {
+  globalThis.EventSource = EventSource;
+}
 
 // it's defined in vitest environment
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
I've moved the eventsource polyfill  from the `magicbell` SDK to the `cli`. The CLI is the only SDK that's running on node. Removing this polyfill from `magicbell` simplifies setup on build tools like vite, which would break on a missing `utils` (node only) package. Vite users could've fixed this by an import alias / polyfill for `util`, but this is the better way.

**magicbell**

Remove [EventSource](https://www.npmjs.com/package/eventsource) polyfill to avoid bundling it in the browser SDKs. If you're using the `listen` methods in an environment that does not support `eventsource`, you'll need to include the polyfill yourself.

**@magicbell/cli**

Add [EventSource](https://www.npmjs.com/package/eventsource) polyfill for the `listen` methods. This polyfill is removed from the `magicbell` package, to avoid bundling it in the browser SDKs.