### PR TITLE
fix: handle cases where `pushManager` is `undefined`

### DIFF
--- a/.changeset/heavy-lizards-watch.md
+++ b/.changeset/heavy-lizards-watch.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/webpush': patch
+---
+
+Fixes an issue where webpush 'isSubscribed' method throws an error in some mobile browsers.

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -107,7 +107,7 @@ export async function isSubscribed(options: SubscribeOptions) {
   const baseURL = options.host || location.origin;
   const subscriptions = await api.getSubscriptions({ ...options, baseURL });
   const currentPushSubscriptionEndpoint = await navigator.serviceWorker?.ready
-    .then((sw) => sw.pushManager.getSubscription())
+    .then((sw) => sw.pushManager?.getSubscription())
     .then((x) => x?.endpoint);
   return (
     Boolean(currentPushSubscriptionEndpoint) &&


### PR DESCRIPTION
Sometimes pushManager can be undefined in certain mobile browsers. In this case `isSubscribed` should just return false instead of throwing an error.

e.g. 

https://github.com/angular/angular/issues/25781