### PR TITLE
chore: move uuid helper function to improve tree shaking

### DIFF
--- a/.changeset/great-eagles-collect.md
+++ b/.changeset/great-eagles-collect.md
@@ -1,0 +1,5 @@
+---
+'magicbell': minor
+---
+
+move uuidv4 helper function to different file for better tree shaking

--- a/packages/magicbell/src/client/headers.ts
+++ b/packages/magicbell/src/client/headers.ts
@@ -1,8 +1,15 @@
 import { deleteEmptyHeaders } from 'fetch-addons';
 import type { Hooks } from 'ky';
 
-import { uuid4 } from '../crypto';
 import { ClientOptions } from './types';
+
+function uuid4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
 
 function getDefaultIdempotencyKey(method: string, maxRetries: number) {
   if (method.toUpperCase() !== 'POST' || maxRetries === 0) return;

--- a/packages/magicbell/src/crypto.ts
+++ b/packages/magicbell/src/crypto.ts
@@ -28,12 +28,3 @@ export function createHmac(secret: string, data: UserData | string) {
 
   return crypto.createHmac('sha256', secret).update(msg).digest('base64');
 }
-
-export function uuid4() {
-  // TODO: should be upgradable to crypto.randomUUID(), introduced by node v14
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}


### PR DESCRIPTION
move uuid helper function to improve tree shaking. This should drop the crypto dependency from the user-client imports.