### PR TITLE
fix: support react strict mode

### DIFF
--- a/.changeset/perfect-mice-sniff.md
+++ b/.changeset/perfect-mice-sniff.md
@@ -1,0 +1,6 @@
+---
+'magicbell': patch
+'@magicbell/magicbell-react': patch
+---
+
+support react strict mode

--- a/packages/magicbell/src/client/paginate.ts
+++ b/packages/magicbell/src/client/paginate.ts
@@ -97,12 +97,15 @@ export function makeForEach(asyncIteratorNext, onDoneCallback?: () => void) {
     return new Promise<void>((resolve, reject) => {
       let idx = 0;
       function handleIteration(iterResult) {
-        if (iterResult.done) {
+        // iterResult can be undefined if the iterator is closed and quickly
+        // reconnected, this happens when wrapped in <React.StrictMode />.
+        // See github pr for more context: https://github.com/magicbell-io/magicbell-js/pull/189
+        if (iterResult?.done) {
           resolve();
           return;
         }
 
-        const item = iterResult.value;
+        const item = iterResult?.value;
         return new Promise((resolve) => {
           resolve(onItem(item, idx));
         }).then((shouldContinue) => {

--- a/packages/react-headless/src/components/RealtimeListener.tsx
+++ b/packages/react-headless/src/components/RealtimeListener.tsx
@@ -30,6 +30,7 @@ export default function RealtimeListener() {
     const listen = client.listen();
 
     listen.forEach((event) => {
+      if (!event) return;
       void handleAblyEvent(event);
     });
 


### PR DESCRIPTION
react strict mode renders hooks twice, which causes the iterator to be quickly closed & reopened. This change makes that experience less buggy, tho I wouldn't say it's ideal.

Ideally, we'd figure out how to properly clean the message queue, and how to prevent that `undefined` event.  The promise resolves without having a new message. I suspect because there are two listeners resolving the same promise, resulting in one popping an empty `message`. 

Question is, how to properly ignore that old listener, while the new one is being initialized.