### PR TITLE
feat: export errors and add responseBody to them

### DIFF
--- a/.changeset/wild-zebras-think.md
+++ b/.changeset/wild-zebras-think.md
@@ -1,0 +1,16 @@
+---
+'magicbell': minor
+---
+
+Custom errors now include a `responseBody` property that holds the returned response
+from the API, when available. Custom errors are now also exported so they can be
+used with comparisons like `err instanceof MagicBellError`. Note that all errors
+extend the `MagicBellError` base class.
+
+They're exported from the root and `/errors`. For the sake of tree shaking, we
+recommend using the latter.
+
+```ts
+import { MagicBellError, UnauthorizedError } from 'magicbell';
+import { MagicBellError, UnauthorizedError } from 'magicbell/errors';
+```

--- a/packages/magicbell/README.md
+++ b/packages/magicbell/README.md
@@ -988,6 +988,38 @@ for await (let event of client.listen()) {
 }
 ```
 
+## Errors
+
+Errors returned by the SDK are instances of `MagicBellError`. This is a subclass of the native `Error` class, and contains the properties defined below. Error types can be imported from `magicbell/errors`.
+
+- **message** _String_
+
+  A human-readable message providing more details about the error.
+
+- **code** _String_
+
+  A short machine-readable string identifying the error.
+
+- **status** _Number_
+
+  The HTTP status code returned by the API.
+
+- **statusText** _String_
+
+  The HTTP status text returned by the API.
+
+- **responseBody** _unknown_
+
+  The raw response body returned by the API
+
+- **suggestion** _String_
+
+  A suggestion to resolve the error.
+
+- **docsUrl** _String_
+
+  A link to the documentation for the error.
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `magicbell` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/crypto.d.ts",
       "import": "./dist/crypto.mjs",
       "require": "./dist/crypto.cjs"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "import": "./dist/errors.mjs",
+      "require": "./dist/errors.cjs"
     }
   },
   "publishConfig": {
@@ -64,6 +69,7 @@
     "build:entry:project-client": "cross-env ENTRY=src/project-client.ts vite build",
     "build:entry:user-client": "cross-env ENTRY=src/user-client.ts vite build",
     "build:entry:crypto": "cross-env ENTRY=src/crypto.ts vite build",
+    "build:entry:errors": "cross-env ENTRY=src/errors.ts vite build",
     "generate:resources": "tsx scripts/generate-resources.ts",
     "start": "npm run clean && run-p 'build:entry:* --watch'",
     "size": "size-limit"

--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -78,6 +78,7 @@ export class Client {
           type: error['type'],
           status: error?.response?.status,
           statusText: error?.response?.statusText,
+          responseBody: body,
           ...body?.errors?.[0],
         });
       });

--- a/packages/magicbell/src/client/error.ts
+++ b/packages/magicbell/src/client/error.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO: sync & cleanup
 export function createError(rawError: ErrorConfig) {
   for (const field of ['code', 'type', 'status']) {
     switch (rawError[field]) {
@@ -34,6 +33,7 @@ type ErrorConfig = {
   help_link?: string;
   status?: number;
   statusText?: string;
+  responseBody?: unknown;
   message: string;
   suggestion?: string;
 };
@@ -42,15 +42,50 @@ type ErrorConfig = {
  * BaseError is the base error from which all other more specific errors derive.
  * Specifically for errors returned from REST API.
  */
-class BaseError extends Error {
+export class MagicBellError extends Error {
+  /**
+   * The name of the error.
+   */
   name: string;
+  /**
+   * The error message returned by the REST API.
+   */
   message: string;
+  /**
+   * The type of the error.
+   */
   type?: string;
-  docs_url?: string;
+  /**
+   * The URL to the documentation for the error.
+   */
+  docsUrl?: string;
+  /**
+   * The error code returned by the REST API.
+   */
   code?: string;
+  /**
+   * The HTTP status code returned by the REST API.
+   */
   status?: number;
+  /**
+   * The HTTP status text returned by the REST API.
+   */
   statusText?: string;
+  /**
+   * A suggestion on how to fix the error.
+   */
   suggestion?: string;
+  /**
+   * The raw response body returned by the REST API.
+   */
+  responseBody?: unknown;
+
+  /**
+   * @deprecated - use docsUrl instead
+   */
+  get docs_url() {
+    return this.docsUrl;
+  }
 
   constructor(raw: ErrorConfig) {
     super(raw.message);
@@ -59,19 +94,20 @@ class BaseError extends Error {
     this.code = raw.code;
     this.status = raw.status;
     this.statusText = raw.statusText;
+    this.responseBody = raw.responseBody;
     this.message = raw.message;
     this.suggestion = raw.suggestion;
-    this.docs_url = raw.docs_url || raw.help_link;
+    this.docsUrl = raw.docs_url || raw.help_link;
   }
 }
 
-export class InvalidRequestError extends BaseError {}
-export class UserInputError extends BaseError {}
-export class APIError extends BaseError {}
-export class AuthenticationError extends BaseError {}
-export class PermissionError extends BaseError {}
-export class RateLimitError extends BaseError {}
-export class ConnectionError extends BaseError {}
-export class IdempotencyError extends BaseError {}
-export class UnknownError extends BaseError {}
-export class NotFoundError extends BaseError {}
+export class InvalidRequestError extends MagicBellError {}
+export class UserInputError extends MagicBellError {}
+export class APIError extends MagicBellError {}
+export class AuthenticationError extends MagicBellError {}
+export class PermissionError extends MagicBellError {}
+export class RateLimitError extends MagicBellError {}
+export class ConnectionError extends MagicBellError {}
+export class IdempotencyError extends MagicBellError {}
+export class UnknownError extends MagicBellError {}
+export class NotFoundError extends MagicBellError {}

--- a/packages/magicbell/src/errors.ts
+++ b/packages/magicbell/src/errors.ts
@@ -1,0 +1,11 @@
+export { MagicBellError } from './client/error';
+export { InvalidRequestError } from './client/error';
+export { UserInputError } from './client/error';
+export { APIError } from './client/error';
+export { AuthenticationError } from './client/error';
+export { PermissionError } from './client/error';
+export { RateLimitError } from './client/error';
+export { ConnectionError } from './client/error';
+export { IdempotencyError } from './client/error';
+export { UnknownError } from './client/error';
+export { NotFoundError } from './client/error';

--- a/packages/magicbell/src/index.ts
+++ b/packages/magicbell/src/index.ts
@@ -1,4 +1,5 @@
 export type { RequestOptions } from './client/types';
 export { createHmac } from './crypto';
+export * from './errors';
 export { type ProjectClientOptions, ProjectClient } from './project-client';
 export { type UserClientOptions, UserClient } from './user-client';


### PR DESCRIPTION
Custom errors now include a `responseBody` property that holds the returned response
from the API, when available. Custom errors are now also exported so they can be
used with comparisons like `err instanceof MagicBellError`. Note that all errors
extend the `MagicBellError` base class.

They're exported from the root and `/errors`. For the sake of tree shaking, we
recommend using the latter.

```ts
import { MagicBellError, UnauthorizedError } from 'magicbell';
import { MagicBellError, UnauthorizedError } from 'magicbell/errors';