### PR TITLE
fix: support controlled state by passing isOpen to MagicBell provider

### DIFF
--- a/.changeset/six-steaks-add.md
+++ b/.changeset/six-steaks-add.md
@@ -1,0 +1,33 @@
+---
+'@magicbell/magicbell-react': patch
+---
+
+Add `isOpen` prop to `MagicBell` provider, together with the existing `onToggle` prop, this allows for controlled open/closed states.
+
+```tsx
+function App() {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const open = () => setIsOpen(true);
+  const close = () => setIsOpen(false);
+  const toggle = () => setIsOpen((open) => !open);
+
+  return (
+    <>
+      <button type="button" onClick={open}>
+        open
+      </button>
+      <button type="button" onClick={close}>
+        close
+      </button>
+      <button type="button" onClick={toggle}>
+        toggle
+      </button>
+
+      <MagicBell apiKey="__API_KEY__" userEmail="__USER_EMAIL__" onToggle={toggle} isOpen={isOpen}>
+        {(props) => <FloatingNotificationInbox height={450} {...props} />}
+      </MagicBell>
+    </>
+  );
+}
+```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -81,6 +81,7 @@ These are all the properties accepted by this component.
 | `defaultIsOpen`     | `boolean`                                          | An optional flag to set the default visibility state of the element returned by the children function. It is `false` by default.                                  |
 | `onNewNotification` | `(notification) => void`                           | An optional function called when a new notification arrives.                                                                                                      |
 | `onToggle`          | `(isOpen) => void`                                 | An optional function called when the bell is clicked.                                                                                                             |
+| `isOpen`            | `boolean`                                          | An optional flag to control the visibility state of the element returned by the children function.                                                                |
 | `bellCounter`       | `string`                                           | Counter to show in the bell. If set to 'unread' it will show the number of unread notifications. It is set to 'unseen' by default.                                |
 
 ### Children function

--- a/packages/react/src/components/MagicBell/MagicBell.tsx
+++ b/packages/react/src/components/MagicBell/MagicBell.tsx
@@ -41,6 +41,7 @@ export type Props = {
   disableRealtime?: boolean;
   onNewNotification?: (notification: IRemoteNotification) => void;
   onToggle?: (isOpen: boolean) => void;
+  isOpen?: boolean;
   bellCounter?: 'unread' | 'unseen';
 } & ({ userExternalId: string } | { userEmail: string });
 
@@ -61,6 +62,7 @@ const defaultInbox = (props) => <FloatingNotificationInbox height={500} {...prop
  * @param props.locale Locale to use in the components
  * @param props.onNewNotification Function called when a notification is created.
  * @param props.onToggle Function called when the bell is clicked.
+ * @param props.isOpen Whether the notification inbox is open or not, use to control state.
  * @param props.bellCounter Counter to show in the bell. If set to 'unread' it will show the number of unread notifications.
  *
  * @example
@@ -80,14 +82,21 @@ export default function MagicBell({
   onNewNotification,
   onToggle,
   bellCounter = 'unseen',
+  isOpen: externalIsOpen,
   ...settings
 }: Props) {
   const launcherRef = useRef(null);
-  const [isOpen, toggleChildren] = useToggle(defaultIsOpen);
+  const isControlled = typeof externalIsOpen !== 'undefined';
+
+  const [internalIsOpen, toggleInternal] = useToggle(defaultIsOpen);
+  const isOpen = isControlled ? externalIsOpen : internalIsOpen;
 
   const handleToggle = () => {
-    toggleChildren();
-    onToggle?.(isOpen);
+    if (!isControlled) {
+      toggleInternal();
+    }
+
+    onToggle?.(!isOpen);
   };
 
   const handleNewNotification = (notification: IRemoteNotification) => {

--- a/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -153,6 +153,52 @@ test('calls the onToggle callback when the button is clicked', async () => {
   expect(onToggle).toHaveBeenCalledTimes(1);
 });
 
+test('supports controlled state', async () => {
+  function App() {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const open = () => setIsOpen(true);
+    const close = () => setIsOpen(false);
+    const toggle = () => setIsOpen((open) => !open);
+
+    return (
+      <>
+        <button type="button" onClick={open}>
+          open
+        </button>
+        <button type="button" onClick={close}>
+          close
+        </button>
+        <button type="button" onClick={toggle}>
+          toggle
+        </button>
+
+        <MagicBell apiKey="__API_KEY__" userEmail="__USER_EMAIL__" onToggle={toggle} isOpen={isOpen}>
+          {(props) => <div data-testid="children" {...props} />}
+        </MagicBell>
+      </>
+    );
+  }
+
+  render(<App />);
+
+  expect(screen.queryByTestId('children')).not.toBeInTheDocument();
+
+  const button = screen.getByRole('button', { name: 'open' });
+  await userEvent.click(button);
+  expect(screen.getByTestId('children')).toBeInTheDocument();
+
+  const closeButton = screen.getByRole('button', { name: 'close' });
+  await userEvent.click(closeButton);
+  expect(screen.queryByTestId('children')).not.toBeInTheDocument();
+
+  const toggleButton = screen.getByRole('button', { name: 'toggle' });
+  await userEvent.click(toggleButton);
+  expect(screen.getByTestId('children')).toBeInTheDocument();
+  await userEvent.click(toggleButton);
+  expect(screen.queryByTestId('children')).not.toBeInTheDocument();
+});
+
 test('sets the headers for fetching from the API', async () => {
   const status = server.intercept('all', '/notifications', fake.notificationPage);
 


### PR DESCRIPTION
Add `isOpen` prop to `MagicBell` provider, together with the existing `onToggle` prop, this allows for controlled open/closed states.

```tsx
function App() {
  const [isOpen, setIsOpen] = React.useState(false);

  const open = () => setIsOpen(true);
  const close = () => setIsOpen(false);
  const toggle = () => setIsOpen((open) => !open);

  return (
    <>
      <button type="button" onClick={open}>open</button>
      <button type="button" onClick={close}>close</button>
      <button type="button" onClick={toggle}>toggle</button>

      <MagicBell apiKey="__API_KEY__" userEmail="__USER_EMAIL__" onToggle={toggle} isOpen={isOpen}>
        {(props) => <FloatingNotificationInbox height={450} {...props} />}
      </MagicBell>
    </>
  );
}
```