### PR TITLE
fix: ensure a service worker is listening when calling isSubscribed

### DIFF
--- a/.changeset/chilled-crabs-study.md
+++ b/.changeset/chilled-crabs-study.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/webpush': patch
+---
+
+fix issue in `isSubscribed` method that caused it to be stuck waiting for the service worker `ready` event when no service worker was registered.


### PR DESCRIPTION
fix issue in `isSubscribed` method that caused it to be stuck waiting for the service worker `ready` event when no service worker was registered.
