### PR TITLE
feat: add 'magicbell api' method for authenticated requests to the MagicBell API

### DIFF
--- a/.changeset/fuzzy-stingrays-pay.md
+++ b/.changeset/fuzzy-stingrays-pay.md
@@ -1,0 +1,29 @@
+---
+'@magicbell/cli': minor
+---
+
+Add `magicbell api` method to make an authenticated HTTP request to the MagicBell API and print the response. This will be useful for debugging purposes or advanced users, though other existing commands are recommended for day-to-day use.
+
+**Examples**
+
+```shell
+magicbell api broadcasts --data @broadcast.json
+magicbell api broadcasts --data '{ broadcast: { title: "Hello World" } }' -i
+magicbell api broadcasts -f 'broadcast={ title: "Hello World" }' -s
+```
+
+**All options:**
+
+```shell
+Arguments
+  endpoint                      The API path to request
+
+Options
+  -H, --header <string...>      Add a HTTP request header in key:value format
+  -X, --method <string>         The HTTP method for the request (default "POST" when data is provided, "GET"
+                                otherwise)
+  -d, --data <string>           HTTP POST data (can also come from stdin)
+  -f, --field <string...>       Add a field parameter in key=value format
+  -i, --include                 Include HTTP response status line and headers in the output
+  -s, --silent                  Do not print the response body
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -499,6 +499,14 @@ magicbell user subscriptions delete <topic>  \
 
 <!-- AUTO-GENERATED-CONTENT:END (USER_RESOURCE_METHODS) -->
 
+### Raw API requests
+
+You can make raw API requests with the `api` command. This command makes an authenticated HTTP request to the MagicBell API and prints the response. Note that this client is authenticated using the project credentials, not the user credentials. You can use the `--profile` option to make requests against a different profile. This command is useful for debugging purposes, but we recommend using the other commands for day-to-day use.
+
+```shell
+magicbell api --help
+```
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `@magicbell/cli` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,104 @@
+import { Option } from 'commander';
+import fs from 'fs';
+
+import { getProjectClient } from './lib/client';
+import { createCommand } from './lib/commands';
+import { parseJsonLikes } from './lib/options';
+import { printError, printJson, printKeyValue, printMessage } from './lib/printer';
+import { readStdin } from './lib/stdin';
+
+function printResponse(response: Response) {
+  printMessage(`${response.status} ${response.statusText}`);
+
+  for (const [key, value] of response.headers) {
+    printKeyValue(key, value);
+  }
+
+  printMessage();
+}
+
+export const api = createCommand('api')
+  .description('Make an authenticated MagicBell API request')
+  .argument('<endpoint>', 'The API path to request')
+  .option('-H, --header <string...>', 'Add a HTTP request header in key:value format')
+  .option('-d, --data <string>', 'HTTP POST data (can also come from stdin)')
+  .option('-f, --field <string...>', 'Add a field parameter in key=value format')
+  .option('-i, --include', 'Include HTTP response status line and headers in the output')
+  .option('-s, --silent', 'Do not print the response body')
+  .option(
+    '-X, --method <string>',
+    'The HTTP method for the request (default "POST" when data is provided, "GET" otherwise)',
+  )
+  .addOption(new Option('--request <string>', 'Alias for --method for compatibility with curl').hideHelp())
+  .hook('preAction', async function (thisCommand) {
+    const options = thisCommand.opts();
+    const stdin = await readStdin();
+
+    if (stdin && options.data) printError('Cannot provide data via stdin and specify --data', true);
+    if (stdin && options.field) printError('Cannot provide data via stdin and specify --field', true);
+    if (options.data && options.field) printError('Cannot specify both --data and --field', true);
+
+    if (stdin) {
+      options.data = stdin;
+    } else if (options.data?.startsWith('@')) {
+      const file = options.data.slice(1);
+      options.data = fs.readFileSync(file, 'utf-8');
+    }
+  })
+  .action(async (endpoint, opts, cmd) => {
+    const path = '/' + (endpoint || '').replace(/^\/+/, '');
+    const headers = Object.fromEntries((opts.header || []).map((h) => h.split(':')));
+    const method = opts.method || opts.request || (opts.data || opts.field ? 'POST' : 'GET');
+
+    if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+      printError(`Invalid method: ${method}`, true);
+    }
+
+    let data = parseJsonLikes(opts.data) || {};
+
+    for (const field of opts.field || []) {
+      const [key, value] = field.split('=');
+      data[key] = parseJsonLikes(value);
+    }
+
+    if (!Object.keys(data).length) {
+      data = null;
+    }
+
+    let response: Response | null = null;
+    const client = getProjectClient(cmd, {
+      hooks: {
+        afterResponse: [
+          (req, opts, res) => {
+            response = res;
+            return res;
+          },
+        ],
+        beforeError: [
+          (error) => {
+            response = error.response;
+            return error;
+          },
+        ],
+      },
+    });
+
+    try {
+      const result = await client.request({
+        method,
+        path,
+        headers,
+        data,
+      });
+
+      if (opts.include) printResponse(response);
+      if (!opts.silent) printJson(result);
+    } catch (e) {
+      if (!response) printError(e.message, true);
+
+      if (opts.include) printResponse(response);
+      if (e.responseBody && !opts.silent) printJson(e.responseBody);
+
+      printError(`${response.statusText} (HTTP ${response.status}) - ${e.message}`, true);
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Option } from 'commander';
 
 import pkg from '../package.json';
+import { api } from './api';
 import { config } from './config';
 import { createCommand, findCommand, findTopCommand } from './lib/commands';
 import { configStore } from './lib/config';
@@ -53,7 +54,7 @@ for (const command of [...commands, user]) {
   program.addCommand(command.group('Resource commands'));
 }
 
-const otherCommands = [config, login, logout];
+const otherCommands = [api, config, login, logout];
 for (const command of otherCommands) {
   program.addCommand(command.group('Other commands'));
 }

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -49,10 +49,11 @@ function getConfig(cmd: Command, options?: Partial<ProjectClientOptions | UserCl
     }
   }
 
-  const hooks: Hooks = {};
+  const hooks: Hooks = options.hooks || {};
 
   if (printRequest) {
     hooks.beforeRequest = [
+      ...(hooks.beforeRequest || []),
       async (request) => {
         printMessage(await serialize(request, printRequest));
         process.exit(0);

--- a/packages/cli/src/lib/colorize.ts
+++ b/packages/cli/src/lib/colorize.ts
@@ -50,7 +50,7 @@ function getTokens(json: string) {
   return tokens;
 }
 
-const defaultColors: Record<TokenType, (str: string | number) => string | number> = {
+export const colors: Record<TokenType, (str: string | number) => string | number> = {
   BRACE: kleur.white,
   BRACKET: kleur.white,
   COLON: kleur.white,
@@ -64,11 +64,9 @@ const defaultColors: Record<TokenType, (str: string | number) => string | number
   WHITESPACE: (i) => i,
 };
 
-type Colors = { colors?: Record<keyof typeof defaultColors, (val: string | number) => string> };
+export type Colors = { colors?: Record<keyof typeof colors, (val: string | number) => string> };
 
-export function colorize(json: string, colors?: Colors) {
-  const colorMap = { ...defaultColors, ...colors };
-
+export function colorize(json: string) {
   const tokens = getTokens(json);
-  return tokens.reduce((acc, token) => acc + colorMap[token.type](token.value), '');
+  return tokens.reduce((acc, token) => acc + colors[token.type](token.value), '');
 }

--- a/packages/cli/src/lib/options.ts
+++ b/packages/cli/src/lib/options.ts
@@ -5,7 +5,7 @@ import { camelToSnakeCase } from './text';
 
 const optionKeys = new Set(['userEmail', 'userExternalId']);
 
-function parseJsonLikes(obj: unknown) {
+export function parseJsonLikes(obj: unknown) {
   if (Array.isArray(obj)) return obj.map(parseJsonLikes);
   if (typeof obj !== 'string') return obj;
 

--- a/packages/cli/src/lib/printer.ts
+++ b/packages/cli/src/lib/printer.ts
@@ -1,9 +1,15 @@
 /* eslint-disable no-console */
-import { colorize } from './colorize';
+import { colorize, colors } from './colorize';
 import { configStore } from './config';
 
 export function printMessage(message = ''): void {
   console.log(message);
+}
+
+export function printKeyValue(key: string, value: unknown, color = true) {
+  color = color && configStore.color;
+  if (!color) console.log(`${key}: ${value}`);
+  else console.log(`${colors.STRING_KEY(key)}: ${value}`);
 }
 
 export function printJson(data: any, color = true): void {

--- a/packages/cli/src/lib/stdin.ts
+++ b/packages/cli/src/lib/stdin.ts
@@ -1,0 +1,25 @@
+export async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) {
+      return resolve('');
+    }
+
+    let data = '';
+    process.stdin.setEncoding('utf8');
+
+    process.stdin.on('readable', () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+
+    process.stdin.on('end', () => {
+      resolve(data);
+    });
+
+    process.stdin.on('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
Add `magicbell api` method to make an authenticated HTTP request to the MagicBell API and print the response. This will be useful for debugging purposes or advanced users, though other existing commands are recommended for day-to-day use.

**Examples**

```shell
magicbell api broadcasts --data @broadcast.json
magicbell api broadcasts --data '{ broadcast: { title: "Hello World" } }' -i
magicbell api broadcasts -f 'broadcast={ title: "Hello World" }' -s
```

**All options:**

```shell
Arguments
  endpoint                      The API path to request

Options
  -H, --header <string...>      Add a HTTP request header in key:value format
  -X, --method <string>         The HTTP method for the request (default "POST" when data is provided, "GET"
                                otherwise)
  -d, --data <string>           HTTP POST data (can also come from stdin)
  -f, --field <string...>       Add a field parameter in key=value format
  -i, --include                 Include HTTP response status line and headers in the output
  -s, --silent                  Do not print the response body
```