### PR TITLE
feat: support paths in host option

### DIFF
--- a/.changeset/orange-melons-deny.md
+++ b/.changeset/orange-melons-deny.md
@@ -1,0 +1,15 @@
+---
+'magicbell': minor
+---
+
+Add support for nested paths in `host` option.
+
+```ts
+import { ProjectClient } from 'magicbell/project-client';
+
+const magicbell = new ProjectClient({
+  apiKey: 'your-api-key',
+  apiSecret: 'your-api-secret',
+  host: 'https://example.com/api/mocks/magicbell',
+});
+```

--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -39,7 +39,10 @@ export class Client {
       headers: { ...this.#options.headers, ...reqHeaders },
     };
 
-    const url = new URL(path, requestOptions.host);
+    // don't just use `new URL(path, host)` as that will strip the path from the host
+    const url = new URL(requestOptions.host);
+    url.pathname = url.pathname.replace(/\/$/, '') + path;
+
     for (const [key, value] of Object.entries(params || {})) {
       url.searchParams.append(key, Array.isArray(value) ? value.join(',') : value);
     }


### PR DESCRIPTION

Add support for nested paths in `host` option.

```ts
import { ProjectClient } from 'magicbell/project-client';

const magicbell = new ProjectClient({
  apiKey: 'your-api-key',
  apiSecret: 'your-api-secret',
  host: 'https://example.com/api/mocks/magicbell',
});
```