### PR TITLE
feat: support loading no-code inbox theme

### DIFF
--- a/.changeset/old-hairs-begin.md
+++ b/.changeset/old-hairs-begin.md
@@ -1,0 +1,27 @@
+---
+'@magicbell/magicbell-react': minor
+---
+
+Theme, locale, and image settings can now be published from the MagicBell dashboard, and will be automatically used by the inbox. This means you can now change the look and feel of the inbox without needing to change code.
+
+The behavior is backward compatible. Config is only applied after publishing from the dashboard, and properties provided to the MagicBell provider precede the published settings.
+
+In other words, to enable this new behavior for a current integration, you'll need to remove the `theme`, `locale`, and/or `images` properties from the `MagicBell` component and publish the settings from the dashboard.
+
+When all three props are provided, remote settings will not be fetched.
+
+```tsx
+<MagicBell
+  apiKey="..."
+  userEmail="..."
+  locale={customLocale}
+  theme={{
+    header: {
+      backgroundColor: 'lightblue',
+    },
+  }}
+  images={{}}
+>
+  {(props) => <FloatingNotificationInbox height={450} {...props} isOpen />}
+</MagicBell>
+```

--- a/.storybook/server/index.js
+++ b/.storybook/server/index.js
@@ -130,7 +130,7 @@ function start() {
   server.post('/notifications/*/read', {});
   server.delete('/notifications/*', {});
 
-  server.post('/integrations/in_app/installations', {
+  server.post('/integrations/inbox/installations', {
     locale: 'en',
     theme: {},
     images: {},

--- a/.storybook/server/index.js
+++ b/.storybook/server/index.js
@@ -1,6 +1,6 @@
-import {Server} from 'miragejs';
+import { Server } from 'miragejs';
 import NotificationFactory from '../../packages/react/tests/factories/NotificationFactory';
-import {sampleNotificationPreferences} from "../../packages/react/tests/factories/NotificationPreferencesFactory";
+import { sampleNotificationPreferences } from "../../packages/react/tests/factories/NotificationPreferencesFactory";
 
 // TODO: move /server to packages/mock-server
 
@@ -129,6 +129,12 @@ function start() {
   server.post('/notifications/seen', {});
   server.post('/notifications/*/read', {});
   server.delete('/notifications/*', {});
+
+  server.post('/integrations/in_app/installations', {
+    locale: 'en',
+    theme: {},
+    images: {},
+  });
 
   // Realtime
   server.post('/ws/*', {

--- a/packages/react/src/components/Bell/Bell.tsx
+++ b/packages/react/src/components/Bell/Bell.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { useBell } from '@magicbell/react-headless';
 import { isNil } from 'ramda';
 
+import { useMagicBellContext } from '../../context/MagicBellContext';
 import { useTheme } from '../../context/MagicBellThemeContext';
 import { cleanslate } from '../Styled';
 import BellBadge from './BellBadge';
@@ -28,6 +29,7 @@ export interface Props {
 export default function Bell({ Icon, Badge = BellBadge, onClick, storeId, counter }: Props) {
   const notifications = useBell({ storeId });
   const theme = useTheme();
+  const { isFetchingConfig } = useMagicBellContext();
   const { icon: iconTheme } = theme;
 
   const handleClick = () => {
@@ -50,6 +52,10 @@ export default function Bell({ Icon, Badge = BellBadge, onClick, storeId, counte
       width: 100%;
     }
   `;
+
+  if (isFetchingConfig) {
+    return <div css={[cleanslate, containerStyle]} />;
+  }
 
   return (
     <a

--- a/packages/react/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
+++ b/packages/react/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useMagicBellContext } from '../../context/MagicBellContext';
 import NotificationInbox, { NotificationInboxProps } from '../NotificationInbox';
 import { NotificationListItem } from '../NotificationList/NotificationList';
 import { PopoverPlacement, PopperOptions } from '../Popover';
@@ -43,6 +44,9 @@ export default function FloatingNotificationInbox({
     if (closeOnNotificationClick) toggle?.();
     return onNotificationClick?.(notification);
   };
+
+  const { isFetchingConfig } = useMagicBellContext();
+  if (isFetchingConfig) return null;
 
   return (
     <FloatingInboxContainer

--- a/packages/react/src/components/MagicBellProvider/MagicBellProvider.tsx
+++ b/packages/react/src/components/MagicBellProvider/MagicBellProvider.tsx
@@ -78,9 +78,12 @@ function SettingsProviders({ children, theme, locale, images, ...props }: MagicB
     client
       .request({
         method: 'POST',
-        path: '/integrations/in_app/installations',
+        path: '/integrations/inbox/installations',
       })
-      .then((response) => setConfig(response))
+      .then((response) => {
+        if (!('inbox' in response)) return;
+        setConfig(response.inbox);
+      })
       .catch(() => void 0)
       .finally(() => setIsFetchingConfig(false));
 

--- a/packages/react/src/components/NotificationInbox/NotificationInbox.tsx
+++ b/packages/react/src/components/NotificationInbox/NotificationInbox.tsx
@@ -1,6 +1,7 @@
 import { INotification } from '@magicbell/react-headless';
 import React, { ComponentProps, Dispatch, SetStateAction, useState } from 'react';
 
+import { useMagicBellContext } from '../../context/MagicBellContext';
 import { NotificationListItem } from '../NotificationList/NotificationList';
 import Layout from './Layout';
 import NotificationsView, { NotificationsViewProps } from './private/NotificationsView';
@@ -38,6 +39,8 @@ export default function NotificationInbox({
   ...props
 }: NotificationInboxProps) {
   const [view, setView] = useState<'inbox' | 'preferences'>('inbox');
+  const { isFetchingConfig } = useMagicBellContext();
+  if (isFetchingConfig) return null;
 
   return (
     <StyledContainer height={height} layout={layout}>

--- a/packages/react/src/context/MagicBellContext.ts
+++ b/packages/react/src/context/MagicBellContext.ts
@@ -4,6 +4,7 @@ export interface IMagicBellContext {
   images?: Partial<{
     emptyInboxUrl: string;
   }>;
+  isFetchingConfig: boolean;
 }
 
 const MagicBellContext = createContext<IMagicBellContext>({} as IMagicBellContext);

--- a/packages/react/tests/__utils__/render.tsx
+++ b/packages/react/tests/__utils__/render.tsx
@@ -1,37 +1,30 @@
 import { render as TLRender } from '@testing-library/react';
-import React, { ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 
 import MagicBellProvider from '../../src/components/MagicBellProvider';
-import { MagicBellThemeProvider } from '../../src/context/MagicBellThemeContext';
 import { defaultTheme, IMagicBellTheme } from '../../src/context/Theme';
-import { TranslationsProvider } from '../../src/context/TranslationsContext';
-import de from '../../src/lib/translations/de';
-import es from '../../src/lib/translations/es';
-import pt_br from '../../src/lib/translations/pt-br';
-
-const locales = { es, pt_br, de } as const;
 
 type RenderWithProvidersOptions = {
-  locale: keyof typeof locales | 'en';
+  locale: 'en' | 'es' | 'pt_br' | 'de';
   apiKey: string;
   theme: IMagicBellTheme;
   stores?: any;
+  images?: { emptyInboxUrl?: string };
 };
 
 const defaultOptions: RenderWithProvidersOptions = {
   locale: 'en',
   apiKey: 'fake-api-key',
   theme: defaultTheme,
+  images: {},
 };
 
-export function renderWithProviders(node: ReactNode, options?: Partial<RenderWithProvidersOptions>) {
-  const { apiKey, locale, theme, stores } = Object.assign(defaultOptions, options);
+export function renderWithProviders(node: ReactElement, options?: Partial<RenderWithProvidersOptions>) {
+  const { apiKey, locale, theme, images, stores } = Object.assign(defaultOptions, options);
 
   return TLRender(
-    <MagicBellProvider apiKey={apiKey} userEmail="-" stores={stores}>
-      <TranslationsProvider value={locales[locale]}>
-        <MagicBellThemeProvider value={theme}>{node}</MagicBellThemeProvider>
-      </TranslationsProvider>
+    <MagicBellProvider apiKey={apiKey} userEmail="-" stores={stores} images={images} locale={locale} theme={theme}>
+      {node}
     </MagicBellProvider>,
   );
 }

--- a/packages/react/tests/src/components/Bell/Bell.spec.tsx
+++ b/packages/react/tests/src/components/Bell/Bell.spec.tsx
@@ -12,14 +12,14 @@ import { sampleNotification } from '../../../factories/NotificationFactory';
 
 setupMockServer(...mockHandlers);
 
-test('renders the notification button', () => {
+test('renders the notification button', async () => {
   render(<Bell onClick={jest.fn()} />);
-  screen.getByRole('button', { name: /notifications/i });
+  await screen.findByRole('button', { name: /notifications/i });
 });
 
-test('the notification button has a namespaced data attribute', () => {
+test('the notification button has a namespaced data attribute', async () => {
   render(<Bell onClick={jest.fn()} />);
-  const button = screen.getByRole('button', { name: /notifications/i });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   expect(button).toHaveAttribute('data-magicbell-bell');
 });
 
@@ -33,17 +33,21 @@ test('does not render the notification count if there are no notifications', () 
 test('renders the number of notifications if there are some', async () => {
   render(<Bell onClick={jest.fn()} />);
 
+  await screen.findByRole('status');
+
   act(() => {
     useNotificationStoresCollection.setState({
       stores: { default: buildStore({ unseenCount: 1 }) },
     });
   });
 
-  await waitFor(() => screen.getByRole('status', { name: /1 unread items/i }));
+  await screen.findByRole('status', { name: /1 unread items/i });
 });
 
 test('shows the number of unread notifications if counter is set to unread', async () => {
   render(<Bell onClick={jest.fn()} counter="unread" />);
+
+  await screen.findByRole('status');
 
   act(() => {
     useNotificationStoresCollection.setState({
@@ -54,10 +58,10 @@ test('shows the number of unread notifications if counter is set to unread', asy
   await waitFor(() => screen.getByRole('status', { name: /2 unread items/i }));
 });
 
-test('can render the bell icon with the custom color and size', () => {
+test('can render the bell icon with the custom color and size', async () => {
   const theme = { ...defaultTheme, icon: { borderColor: 'red', width: '14px' } };
   render(<Bell onClick={jest.fn()} />, { theme });
-  const button = screen.getByRole('button', { name: /notifications/i });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   const icon = button.querySelector('path');
   expect(icon).toHaveAttribute('fill', 'red');
 });
@@ -66,7 +70,7 @@ test('calls the onClick callback when the button is clicked', async () => {
   const onClick = jest.fn();
   render(<Bell onClick={onClick} />);
 
-  const button = screen.getByRole('button', { name: /notifications/i });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   await userEvent.click(button);
 
   expect(onClick).toHaveBeenCalledTimes(1);
@@ -77,7 +81,7 @@ test('marks all notifications as seen', async () => {
   const onClick = jest.fn();
   render(<Bell onClick={onClick} />);
 
-  const button = screen.getByRole('button', { name: /notifications/i });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   await userEvent.click(button);
 
   const { result } = renderHook(() => useNotification({ ...sampleNotification, seenAt: null }));

--- a/packages/react/tests/src/components/FloatingNotificationInbox/FloatingNotificationInbox.spec.tsx
+++ b/packages/react/tests/src/components/FloatingNotificationInbox/FloatingNotificationInbox.spec.tsx
@@ -86,7 +86,7 @@ test('can render the inbox with a custom layout', async () => {
     { stores },
   );
 
-  screen.getByRole('heading', {
+  await screen.findByRole('heading', {
     name: /notifications/i,
   });
 

--- a/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -4,8 +4,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as faker from 'faker';
 import * as React from 'react';
+import { ComponentProps } from 'react';
 
-import MagicBell from '../../../../src';
+import MagicBellProvider from '../../../../src';
 import Text from '../../../../src/components/Text';
 import NotificationFactory from '../../../../tests/factories/NotificationFactory';
 
@@ -22,17 +23,22 @@ const server = setupMockServer(
   }),
 );
 
+function MagicBell(props: ComponentProps<typeof MagicBellProvider>) {
+  // apply defaults to disable theme fetching
+  return <MagicBellProvider theme={{}} locale="en" images={{}} {...props} />;
+}
+
 test("renders the notification bell, but not it's default children", async () => {
   render(<MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey} />);
 
-  screen.getByRole('button', { name: 'Notifications' });
+  await screen.findByRole('button', { name: /notifications/i });
   expect(screen.queryByRole('button', { name: /mark all read/i })).not.toBeInTheDocument();
 });
 
 test('clicking the bell opens the default inbox', async () => {
   render(<MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey} />);
 
-  const button = screen.getByRole('button');
+  const button = await screen.findByRole('button');
   await userEvent.click(button);
   await screen.findByRole('button', { name: /Mark All Read/i });
 });
@@ -44,7 +50,7 @@ test("renders the notification bell, but not it's custom children", async () => 
     </MagicBell>,
   );
 
-  screen.getByRole('button', { name: 'Notifications' });
+  await screen.findByRole('button', { name: /notifications/i });
   expect(screen.queryByTestId('children')).not.toBeInTheDocument();
 });
 
@@ -55,7 +61,7 @@ test('clicking the bell opens the custom inbox', async () => {
     </MagicBell>,
   );
 
-  const button = screen.getByRole('button');
+  const button = await screen.findByRole('button');
   await userEvent.click(button);
   await waitFor(() => screen.getByTestId('children'));
 });
@@ -69,7 +75,7 @@ test('can render a custom bell icon', async () => {
     </MagicBell>,
   );
 
-  screen.getByTestId('custom-icon');
+  await screen.findByTestId('custom-icon');
 });
 
 test('renders the children when it is mounted with defaultIsOpen', () => {
@@ -133,7 +139,7 @@ test('can close the inbox when defaultIsOpen is provided', async () => {
     </MagicBell>,
   );
 
-  const button = screen.getByRole('button', { name: 'Notifications' });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   await userEvent.click(button);
   await waitFor(() => expect(screen.queryByTestId('children')).not.toBeInTheDocument());
 });
@@ -147,7 +153,7 @@ test('calls the onToggle callback when the button is clicked', async () => {
     </MagicBell>,
   );
 
-  const button = screen.getByRole('button', { name: 'Notifications' });
+  const button = await screen.findByRole('button', { name: /notifications/i });
   await userEvent.click(button);
 
   expect(onToggle).toHaveBeenCalledTimes(1);
@@ -174,7 +180,7 @@ test('supports controlled state', async () => {
         </button>
 
         <MagicBell apiKey="__API_KEY__" userEmail="__USER_EMAIL__" onToggle={toggle} isOpen={isOpen}>
-          {(props) => <div data-testid="children" {...props} />}
+          {() => <div data-testid="children" />}
         </MagicBell>
       </>
     );
@@ -260,6 +266,6 @@ test('supports a custom notification Badge', async () => {
     </MagicBell>,
   );
 
-  const badge = screen.getByTestId('custom-badge');
+  const badge = await screen.findByTestId('custom-badge');
   await waitFor(() => expect(badge).toHaveTextContent('4'));
 });

--- a/packages/react/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
+++ b/packages/react/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
@@ -29,7 +29,7 @@ test('renders a header, the list of notifications and a footer if the notificati
   render(<NotificationInbox height={300} />);
 
   // header
-  screen.getByRole('heading', { name: /Notifications/ });
+  await screen.findByRole('heading', { name: /Notifications/ });
 
   // notification
   await waitFor(() => screen.getByText(/This is a good content/));
@@ -40,7 +40,7 @@ test('renders a header, the list of notifications and a footer if the notificati
 
 test('renders nothing if the notification store does not exist', () => {
   const { container } = render(
-    <MagicBellProvider apiKey="-" userEmail="-">
+    <MagicBellProvider theme={{}} locale="en" images={{}} apiKey="-" userEmail="-">
       <NotificationInbox height={300} storeId="non-existing" />
     </MagicBellProvider>,
   );
@@ -89,7 +89,7 @@ test('can render with a custom no-notifications placeholder if there are no noti
 
 test('can render the inbox in Spanish', async () => {
   render(<NotificationInbox />, { locale: 'es' });
-  screen.getByRole('heading', { name: /Notificaciones/ });
+  await screen.findByRole('heading', { name: /Notificaciones/ });
   screen.getByRole('button', { name: /Preferencias/ });
   await screen.findByRole('button', { name: /Marcar todo como leído/ });
 });
@@ -119,7 +119,7 @@ test('shows the user preferences panel when the preferences button is clicked', 
   useNotificationPreferences.setState({ lastFetchedAt: undefined });
 
   render(<NotificationInbox />, { locale: 'en' });
-  const preferencesButton = screen.getByRole('button', { name: /Notification preferences/ });
+  const preferencesButton = await screen.findByRole('button', { name: /Notification preferences/ });
   await userEvent.click(preferencesButton);
 
   const checkboxes = await waitFor(() => screen.getAllByRole('checkbox'));
@@ -134,7 +134,7 @@ test('the notifications panel contains a close button', async () => {
   useNotificationPreferences.setState({ lastFetchedAt: undefined });
 
   render(<NotificationInbox />, { locale: 'en' });
-  const preferencesButton = screen.getByRole('button', { name: /Notification preferences/ });
+  const preferencesButton = await screen.findByRole('button', { name: /Notification preferences/ });
   await userEvent.click(preferencesButton);
 
   const checkboxes = await waitFor(() => screen.getAllByRole('checkbox'));
@@ -150,7 +150,7 @@ test('can render with a custom notification preferences component', async () => 
   const NotificationPreferences = () => <div data-testid="notification-preferences" />;
 
   render(<NotificationInbox NotificationPreferences={NotificationPreferences} />, { locale: 'en' });
-  const button = screen.getByRole('button', { name: /Notification preferences/ });
+  const button = await screen.findByRole('button', { name: /Notification preferences/ });
   await userEvent.click(button);
 
   await waitFor(() => screen.getByTestId('notification-preferences'));
@@ -170,7 +170,7 @@ test('can render with multiple inbox tabs, and active tab changes when clicked',
   ];
 
   render(<NotificationInbox tabs={tabs} />, { stores });
-  const feedTab = screen.getByRole('tab', { name: /feed/i });
+  const feedTab = await screen.findByRole('tab', { name: /feed/i });
   const commentsTab = screen.getByRole('tab', { name: /comments/i });
 
   expect(feedTab).toHaveAttribute('aria-selected', 'true');
@@ -204,7 +204,7 @@ test('renders notifications matching selected tab', async () => {
   }));
 
   render(<NotificationInbox tabs={tabs} />, { stores });
-  const feedTab = screen.getByRole('tab', { name: /feed/i });
+  const feedTab = await screen.findByRole('tab', { name: /feed/i });
   const commentsTab = screen.getByRole('tab', { name: /comments/i });
 
   // navigate to feed tab


### PR DESCRIPTION
Theme, locale, and image settings can now be published from the MagicBell dashboard, and will be automatically used by the inbox. This means you can now change the look and feel of the inbox without needing to change code.

The behavior is backward compatible. Config is only applied after publishing from the dashboard, and properties provided to the MagicBell provider precede the published settings.

In other words, to enable this new behavior for a current integration, you'll need to remove the `theme`, `locale`, and/or `images` properties from the `MagicBell` component and publish the settings from the dashboard.

When all three props are provided, remote settings will not be fetched.

```tsx
<MagicBell
  apiKey="..."
  userEmail="..."
  locale={customLocale}
  theme={{
    header: {
      backgroundColor: 'lightblue',
    },
  }}
  images={{}}
>
  {(props) => <FloatingNotificationInbox height={450} {...props} isOpen />}
</MagicBell>
```