### PR TITLE
fix: don't parse response body when it's empty

### DIFF
--- a/.changeset/gorgeous-ducks-tell.md
+++ b/.changeset/gorgeous-ducks-tell.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+don't parse response body when it's empty

--- a/packages/cli/src/lib/printer.ts
+++ b/packages/cli/src/lib/printer.ts
@@ -13,6 +13,9 @@ export function printKeyValue(key: string, value: unknown, color = true) {
 }
 
 export function printJson(data: any, color = true): void {
+  // some commands don't have a return value
+  if (typeof data === 'undefined') return;
+
   const json = JSON.stringify(data, null, 2);
   color = color && configStore.color;
   console.log(color ? colorize(json) : json);


### PR DESCRIPTION
Commands that invoked API endpoints that don't return data, printed an error as they were trying to parse the absent response json. This is now fixed.