### PR TITLE
fix: use addEventListener instead of onmessage

### DIFF
--- a/.changeset/afraid-coins-type.md
+++ b/.changeset/afraid-coins-type.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+use `eventSource.addEventListener` instead of `eventSource.onmessage` to maximize compatibility with different environments.

--- a/.changeset/wise-bears-fetch.md
+++ b/.changeset/wise-bears-fetch.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+ensure listeners use node native https module

--- a/packages/cli/vite.config.js
+++ b/packages/cli/vite.config.js
@@ -8,6 +8,6 @@ export default defineConfig(async (configEnv) => {
   base.build.lib.fileName = () => 'index.cjs';
   base.build.sourcemap = false;
 
-  base.build.rollupOptions.external = ['fs', 'path', 'url', 'os', 'crypto', 'readline', 'process'];
+  base.build.rollupOptions.external = ['fs', 'http', 'https', 'path', 'url', 'os', 'crypto', 'readline', 'process'];
   return base;
 });


### PR DESCRIPTION
- use `eventsource.addEventListener('message'` instead of `eventsource.onmessage`. The latter works in browsers, but has bad support in (react-native) polyfills. 
- skip empty events; in normal world scenarios, there shouldn't be such a thing, but there is in react strict mode.
- mark HTTP and HTTPs as external, this fixes an issue where `(http || https).request` isn't defined.