### PR TITLE
chore: add entry point for unpkg

### DIFF
--- a/.changeset/spotty-deers-move.md
+++ b/.changeset/spotty-deers-move.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/webpush': patch
+---
+
+add entry point for unpkg

--- a/packages/webpush/package.json
+++ b/packages/webpush/package.json
@@ -10,6 +10,7 @@
   "source": "./src/index.ts",
   "main": "dist/index.js",
   "module": "dist/magicbell-webpush.esm.js",
+  "unpkg": "dist/magicbell-webpush.esm.min.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Adds an entry point to `webpush` for unpkg, so we can import from `https://unpkg.com/@magicbell/webpush`.