### PR TITLE
fix: only include `user-email` header when no `external-id` is provided

### DIFF
--- a/.changeset/purple-dogs-pull.md
+++ b/.changeset/purple-dogs-pull.md
@@ -1,0 +1,5 @@
+---
+'magicbell': patch
+---
+
+Only include `user-email` header when no `external-id` is provided

--- a/packages/magicbell/src/client/headers.ts
+++ b/packages/magicbell/src/client/headers.ts
@@ -40,9 +40,10 @@ function setRequestHeaders(options: ClientOptions, request: Request) {
   request.headers.set('x-magicbell-api-key', options.apiKey);
   request.headers.set('x-magicbell-api-secret', options.apiSecret);
   request.headers.set('x-magicbell-client-user-agent', getClientUserAgent(options.appInfo));
-  request.headers.set('x-magicbell-user-email', options.userEmail);
-  request.headers.set('x-magicbell-user-external-id', options.userExternalId);
   request.headers.set('x-magicbell-user-hmac', options.userHmac);
+
+  if (options.userExternalId) request.headers.set('x-magicbell-user-external-id', options.userExternalId);
+  else if (options.userEmail) request.headers.set('x-magicbell-user-email', options.userEmail);
 
   // remove empty headers, they can cause unexpected behavior
   deleteEmptyHeaders(request.headers);


### PR DESCRIPTION
Only include `user-email` header when no `external-id` is provided, as the `external-id` is always leading for MagicBell.