### PR TITLE
feat: add credential option to `magicbell api` command

### DIFF
--- a/.changeset/rotten-grapes-beam.md
+++ b/.changeset/rotten-grapes-beam.md
@@ -1,0 +1,15 @@
+---
+'@magicbell/cli': minor
+---
+
+Add credential option to switch authentication scope for `magicbell api` requests
+
+```shell
+# include user credential headers (x-magicbell-user-email)
+magicbell api /some-endpoint -r curl -c user
+magicbell api /some-endpoint -r curl --credentials user
+
+# include project credential headers (x-magicbell-api-secret)
+magicbell api /some-endpoint -r curl -c project
+magicbell api /some-endpoint -r curl --credentials project
+```


### PR DESCRIPTION
Add credential option to switch authentication scope for `magicbell api` requests

```shell
# include user credential headers (x-magicbell-user-email)
magicbell api /some-endpoint -r curl -c user
magicbell api /some-endpoint -r curl --credentials user

# include project credential headers (x-magicbell-api-secret)
magicbell api /some-endpoint -r curl -c project
magicbell api /some-endpoint -r curl --credentials project
```