### PR TITLE
feat: accept lowercase method names for `magicbell api` command

### DIFF
--- a/.changeset/young-hairs-thank.md
+++ b/.changeset/young-hairs-thank.md
@@ -1,0 +1,12 @@
+---
+'@magicbell/cli': minor
+---
+
+Also accept lowercase method names in the `magicbell api -X {method}` command.
+
+These commands are now the same:
+
+```shell
+magicbell api /integrations -X POST -d '{ ... }'
+magicbell api /integrations -X post -d '{ ... }'
+```

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -48,7 +48,7 @@ export const api = createCommand('api')
   .action(async (endpoint, opts, cmd) => {
     const path = '/' + (endpoint || '').replace(/^\/+/, '');
     const headers = Object.fromEntries((opts.header || []).map((h) => h.split(':')));
-    const method = opts.method || opts.request || (opts.data || opts.field ? 'POST' : 'GET');
+    const method = opts.method?.toUpperCase() || (opts.data || opts.field ? 'POST' : 'GET');
 
     if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
       printError(`Invalid method: ${method}`, true);


### PR DESCRIPTION
Also accept lowercase method names in the `magicbell api -X {method}` command.

These commands are now the same:

```shell
magicbell api /integrations -X POST -d '{ ... }'
magicbell api /integrations -X post -d '{ ... }'
```