### PR TITLE
fix: restore `magicbell config unset`

### DIFF
--- a/.changeset/many-wombats-obey.md
+++ b/.changeset/many-wombats-obey.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+Restore `magicbell config unset {key}`.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -51,7 +51,7 @@ config
   .command('unset')
   .description('Remove the given key from the configuration.')
   .argument('<key>', 'The configuration key to remove.')
-  .action((key, cmd) => {
+  .action((key, opts, cmd) => {
     const { profile } = cmd.optsWithGlobals();
     configStore.delete(`projects.${profile}.${key}`);
   });


### PR DESCRIPTION
This fixes `magicbell config unset`, such as:

```shell
magicbell config set userEmail stephan@example.com
magicbell config unset userExternalId 1
```