### PR TITLE
feat: support reading --email or --id from profile

### DIFF
--- a/.changeset/fair-papayas-matter.md
+++ b/.changeset/fair-papayas-matter.md
@@ -1,0 +1,21 @@
+---
+'@magicbell/cli': minor
+---
+
+Support reading email or external id for user commands from profile. With this change, instead of running `magicbell user notifications list --user-email person@example.com`, one can run also run:
+
+```shell
+# magicbell user notifications list --user-email person@example.com
+magicbell config set userEmail person@example.com
+magicbell user notifications list
+```
+
+or
+
+```shell
+# magicbell user notifications list --user-external-id abc
+magicbell config set userExternalId abc
+magicbell user notifications list
+```
+
+Note that the arguments still take precedence when provided.

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -38,10 +38,16 @@ function getConfig(cmd: Command, options?: Partial<ProjectClientOptions | UserCl
   const defaultOptions = {
     apiKey: project?.apiKey,
     apiSecret: project?.apiSecret,
-    userEmail: userEmail || project?.userEmail,
-    userExternalId: userExternalId || project?.userExternalId,
+    userEmail: userEmail,
+    userExternalId: userExternalId,
     host: host || project?.host,
   };
+
+  // only load userEmail and userExternalId from config when not provided via args
+  if (!defaultOptions.userEmail && !defaultOptions.userExternalId) {
+    defaultOptions.userEmail = project?.userEmail;
+    defaultOptions.userExternalId = project?.userExternalId;
+  }
 
   for (const key in defaultOptions) {
     if (defaultOptions[key] == null || defaultOptions[key] === '') {

--- a/packages/cli/src/user.ts
+++ b/packages/cli/src/user.ts
@@ -1,17 +1,27 @@
 import { createCommand } from './lib/commands';
+import { configStore } from './lib/config';
 import { printError } from './lib/printer';
 import { listen } from './listen';
 import * as userResources from './user-resources';
 
 export const user = createCommand('user')
-  .description("Manage a users' notifications & preferences")
+  .summary("Manage a users' notifications & preferences")
+  .description(
+    `Manage users for user notifications & preferences.
+  
+  If you're primarily using this api with your own account, it's also possible to
+  persist the \`userEmail\` or \`userExternalId\` via \`magicbell config set\`.
+  `,
+  )
   .option('--email, --user-email <string>', 'Email of the user')
   .option('--id, --user-external-id <string>', 'External ID of the user')
   .option('--hmac, --user-hmac <string>', 'User HMAC key')
   .hook('preAction', function (thisCommand) {
     const options = thisCommand.opts();
+    const { profile } = thisCommand.optsWithGlobals();
+    const project = configStore.getProject(profile);
 
-    if (!options.userEmail && !options.userExternalId) {
+    if (!options.userEmail && !options.userExternalId && !project.userEmail && !project.userExternalId) {
       printError('You must specify either --user-email or --user-external-id', true);
     }
 


### PR DESCRIPTION
Support reading email or external id for user commands from profile. With this change, instead of running `magicbell user notifications list --user-email person@example.com`, one can run also run:

```shell
# magicbell user notifications list --user-email person@example.com
magicbell config set userEmail person@example.com
magicbell user notifications list
```

or

```shell
# magicbell user notifications list --user-external-id abc
magicbell config set userExternalId abc
magicbell user notifications list
```

Note that the arguments still take precedence when provided.
