### PR TITLE
fix: support `api --request GET` for curl compat

### DIFF
--- a/.changeset/chilly-turtles-teach.md
+++ b/.changeset/chilly-turtles-teach.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+support `api --request GET` for curl compat

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -53,7 +53,7 @@ export const api = createCommand('api')
   .action(async (endpoint, opts, cmd) => {
     const path = '/' + (endpoint || '').replace(/^\/+/, '');
     const headers = Object.fromEntries((opts.header || []).map((h) => h.split(':')));
-    const method = opts.method?.toUpperCase() || (opts.data || opts.field ? 'POST' : 'GET');
+    const method = (opts.method || opts.request || (opts.data || opts.field ? 'POST' : 'GET')).toUpperCase();
 
     if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
       printError(`Invalid method: ${method}`, true);


### PR DESCRIPTION
Support `api --request GET` for curl compat