### PR TITLE
feat: use magicbell integrations

### DIFF
--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -1,0 +1,118 @@
+---
+'@magicbell/webpush': major
+---
+
+BREAKING CHANGE!: This is a complete revamp of how we're registering client push notifications, but given that the API surface is small, migrating should be easy enough.
+
+```ts
+import { WebPushClient } from '@magicbell/webpush';
+
+const client = new WebPushClient({
+  apiKey: '024…0bd',
+  userEmail: 'person@example.com',
+  userHmac: 'NCI…I6M',
+});
+
+await client.isSubscribed();
+await client.subscribe();
+await client.unsubscribe();
+```
+
+**Verify browser support**
+
+This function is unchanged.
+
+```ts
+import { isSupported } from '@magicbell/webpush';
+isSupported();
+```
+
+**Service worker registration**
+
+We still attempt to lazily register a service worker during other methods if you don't have one registered, but we no longer expose a utility for you to do so. When you do have your own service worker, and used our util, please update your initialization as follows:
+
+```diff
+- import { registerServiceWorker } from '@magicbell/webpush';
+- registerServiceWorker({ path: '/sw.js' });
+
++ navigator.serviceWorker.register('/sw.js');
+```
+
+When you prefer to lazily register the service worker using this client, simply provide the `serviceWorkerPath` to the client constructor.
+
+```ts
+import { WebPushClient } from '@magicbell/webpush';
+
+const client = new WebPushClient({
+  // ...
+  serviceWorkerPath: '/sw.js',
+});
+```
+
+For completeness, your service worker file should include:
+
+```ts
+importScripts('https://assets.magicbell.io/web-push-notifications/sw.js');
+```
+
+**Subscribe to push notifications:**
+
+Subscribing to push notifications is now a single call on the client, instead of the two-step flow from v1.
+
+```diff
+- import { getAuthToken, subscribe } from '@magicbell/webpush';
++ import { WebPushClient } from '@magicbell/webpush';
+
+- const token = await getAuthToken({
++ const client = new WebPushClient({
+  apiKey: '024…0bd',
+  userEmail: 'person@example.com',
+  userHmac: 'NCI…I6M',
+});
+
+- await subscribe({
+-   token: token.token,
+-   project: token.project,
+- });
+
++ await client.subscribe();
+```
+
+**Unsubscribe from push notifications.**
+
+This is a new method that wasn't exposed in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" push notifications.
+
+```ts
+import { WebPushClient } from '@magicbell/webpush';
+
+const client = new WebPushClient({
+  apiKey: '024…0bd',
+  userEmail: 'person@example.com',
+  userHmac: 'NCI…I6M',
+});
+
+await client.unsubscribe();
+```
+
+**Get subscription status**
+
+Verifying subscription status is now a single call on the client, instead of the two-step flow from v1.
+
+```diff
+- import { getAuthToken, isSubscribed } from '@magicbell/webpush';
++ import { WebPushClient } from '@magicbell/webpush';
+
+- const token = await getAuthToken({
++ const client = new WebPushClient({
+  apiKey: '024…0bd',
+  userEmail: 'person@example.com',
+  userHmac: 'NCI…I6M',
+});
+
+- const subscribed = await subscribe({
+-   token: token.token,
+-   project: token.project,
+- });
+
++ const subscribed = await client.isSubscribed();
+```

--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -2,7 +2,9 @@
 '@magicbell/webpush': major
 ---
 
-BREAKING CHANGE!: This is a complete revamp of how we're registering client push notifications, but given that the API surface is small, migrating should be easy enough.
+**BREAKING CHANGE!**
+
+This is a complete revamp of how we're registering client push notifications, but given that the API surface is small, migrating should be easy enough.
 
 ```ts
 import { WebPushClient } from '@magicbell/webpush';

--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -18,43 +18,6 @@ await client.subscribe();
 await client.unsubscribe();
 ```
 
-**Verify browser support**
-
-This function is unchanged.
-
-```ts
-import { isSupported } from '@magicbell/webpush';
-isSupported();
-```
-
-**Service worker registration**
-
-We still attempt to lazily register a service worker during other methods if you don't have one registered, but we no longer expose a utility for you to do so. When you do have your own service worker, and used our util, please update your initialization as follows:
-
-```diff
-- import { registerServiceWorker } from '@magicbell/webpush';
-- registerServiceWorker({ path: '/sw.js' });
-
-+ navigator.serviceWorker.register('/sw.js');
-```
-
-When you prefer to lazily register the service worker using this client, simply provide the `serviceWorkerPath` to the client constructor.
-
-```ts
-import { WebPushClient } from '@magicbell/webpush';
-
-const client = new WebPushClient({
-  // ...
-  serviceWorkerPath: '/sw.js',
-});
-```
-
-For completeness, your service worker file should include:
-
-```ts
-importScripts('https://assets.magicbell.io/web-push-notifications/sw.js');
-```
-
 **Subscribe to push notifications:**
 
 Subscribing to push notifications is now a single call on the client, instead of the two-step flow from v1.
@@ -80,7 +43,7 @@ Subscribing to push notifications is now a single call on the client, instead of
 
 **Unsubscribe from push notifications.**
 
-This is a new method that wasn't exposed in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" push notifications.
+This is a new method that didn't exist in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" push notifications.
 
 ```ts
 import { WebPushClient } from '@magicbell/webpush';
@@ -109,10 +72,28 @@ Verifying subscription status is now a single call on the client, instead of the
   userHmac: 'NCI…I6M',
 });
 
-- const subscribed = await subscribe({
+- const subscribed = await isSubscribed({
 -   token: token.token,
 -   project: token.project,
 - });
 
 + const subscribed = await client.isSubscribed();
+```
+
+**Get authentication token**
+
+The authentication token is no longer required for basic functionality, but can still be used to for example transfer the session to a popup.
+
+```diff
+- import { getAuthToken } from '@magicbell/webpush';
++ import { WebPushClient } from '@magicbell/webpush';
+
+- const token = await getAuthToken({
++ const client = new WebPushClient({
+  apiKey: '024…0bd',
+  userEmail: 'person@example.com',
+  userHmac: 'NCI…I6M',
+});
+
++ client.getAuthToken();
 ```

--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -4,7 +4,7 @@
 
 **BREAKING CHANGE!**
 
-This is a complete revamp of how we're registering client push notifications, but given that the API surface is small, migrating should be easy enough.
+This is a complete revamp of how we're registering client push notification subscriptions, but given that the API surface is small, migrating should be easy enough.
 
 ```ts
 import { WebPushClient } from '@magicbell/webpush';
@@ -45,7 +45,7 @@ Subscribing to push notifications is now a single call on the client, instead of
 
 **Unsubscribe from push notifications.**
 
-This is a new method that didn't exist in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" push notifications.
+This is a new method that didn't exist in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" the push notifications.
 
 ```ts
 import { WebPushClient } from '@magicbell/webpush';

--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -4,7 +4,11 @@
 
 **BREAKING CHANGE!**
 
-This is a complete revamp of how we're registering client push notification subscriptions, but given that the API surface is small, migrating should be easy enough.
+This is a complete revamp of how we're registering client push notification subscriptions, but given that the v1 API surface is small, migrating should be easy enough. You can find [the migration guide on our site](https://magicbell.com/docs/guides/migrations/upgrade-magicbell-webpush-to-v2).
+
+The methods mentioned here are the breaking ones that you use when interacting with the browser directly. We've also added a bunch of functions to interact with the MagicBell API directly, leaving all browser interaction for you to implement. Think of use cases where you already have a service worker, and just want to push the channel tokens to our backend, or because you need to list all the currently active channel tokens so the user can unsubscribe from a device they no longer control.
+
+Please read more about those methods in [the docs for @magicbell/webpush](https://magicbell.com/docs/libraries/webpush#api-methods)
 
 ```ts
 import { WebPushClient } from '@magicbell/webpush';
@@ -99,3 +103,7 @@ The authentication token is no longer required for basic functionality, but can 
 
 + const token = await client.getAuthToken();
 ```
+
+**API Methods**
+
+We've added a bunch of useful methods to work with our api directly. Please read more about those methods in [the docs for @magicbell/webpush](https://magicbell.com/docs/libraries/webpush#api-methods).

--- a/.changeset/quiet-wasps-cheat.md
+++ b/.changeset/quiet-wasps-cheat.md
@@ -97,5 +97,5 @@ The authentication token is no longer required for basic functionality, but can 
   userHmac: 'NCI…I6M',
 });
 
-+ client.getAuthToken();
++ const token = await client.getAuthToken();
 ```

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -1,11 +1,11 @@
 import { ClientOptions, IntegrationClient } from './internal/client';
 
-type Installation = {
+export type Installation = {
   public_key: string;
   auth_token: string;
 };
 
-type Token = {
+export type Token = {
   id: string;
   created_at: string;
   updated_at: string;
@@ -14,10 +14,12 @@ type Token = {
   keys?: Record<string, string>;
 };
 
+export type WebPushClientOptions = ClientOptions & { serviceWorkerPath?: string };
+
 export class WebPushClient extends IntegrationClient<Installation, Token> {
   #serviceWorkerPath: string;
 
-  constructor(options: ClientOptions & { serviceWorkerPath?: string }) {
+  constructor(options: WebPushClientOptions) {
     super('web_push', options);
     this.#serviceWorkerPath = options.serviceWorkerPath || '/sw.js';
   }

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -1,15 +1,11 @@
-import { ClientOptions, IntegrationClient } from './internal/client';
+import { ChannelToken, ClientOptions, IntegrationClient } from './internal/client';
 
 export type Installation = {
   public_key: string;
   auth_token: string;
 };
 
-export type Token = {
-  id: string;
-  created_at: string;
-  updated_at: string;
-  discarded_at: string | null;
+export type Token = ChannelToken & {
   endpoint?: string;
   keys?: Record<string, string>;
 };

--- a/packages/webpush/src/index.ts
+++ b/packages/webpush/src/index.ts
@@ -1,203 +1,126 @@
-type RequestOptions = {
-  token: string;
-  project: string;
-  baseURL: string;
+import { ClientOptions, IntegrationClient } from './internal/client';
+
+type Installation = {
+  public_key: string;
+  auth_token: string;
 };
 
-type Config = {
-  user: { id: string; email?: string | null; external_id?: string | null; hmac?: string | null };
-  project: { id: number; subdomain: string; api_key: string; vapid_public_key: string };
-  website_push_id: string;
-};
-
-type SubscribeOptions = {
-  token: string;
-  project: string;
-  serviceWorkerPath?: string;
-  host?: string;
-};
-
-type Subscription = {
-  created_at: string;
-  device_token: string;
-  discarded_at: string | null;
+type Token = {
   id: string;
-  platform: string;
-  user_id: string;
+  created_at: string;
+  updated_at: string;
+  discarded_at: string | null;
+  endpoint?: string;
+  keys?: Record<string, string>;
 };
 
-type AuthTokenOptions = {
-  host?: string;
-  apiKey: string;
-} & ({ userEmail: string; userHmac?: string } | { userExternalId: string; userHmac?: string });
+export class WebPushClient extends IntegrationClient<Installation, Token> {
+  #serviceWorkerPath: string;
 
-let _config: Config | null = null;
-let _cacheKey = '';
+  constructor(options: ClientOptions & { serviceWorkerPath?: string }) {
+    super('web_push', options);
+    this.#serviceWorkerPath = options.serviceWorkerPath || '/sw.js';
+  }
 
-const DEFAULT_HOST = 'https://api.magicbell.com';
+  /**
+   * Gets the registered service worker, and attempts to create one if no registration exists
+   */
+  async #getServiceWorker() {
+    return registerServiceWorker(this.#serviceWorkerPath);
+  }
 
-const api = {
-  async getAuthToken(options: AuthTokenOptions): Promise<Pick<SubscribeOptions, 'token' | 'project' | 'host'>> {
-    const headers: Record<string, string> = {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      'x-magicbell-api-key': options.apiKey,
-    };
+  /**
+   * Checks if the current user has an active push subscription that is registered by MagicBell.
+   */
+  async isSubscribed(): Promise<boolean> {
+    const subscriptions = await this.getTokens();
+    const registration = await this.#getServiceWorker();
+    const activeSubscription = await registration?.pushManager?.getSubscription();
 
-    if ('userExternalId' in options && options.userExternalId) {
-      headers['x-magicbell-user-external-id'] = options.userExternalId;
-    } else if ('userEmail' in options && options.userEmail) {
-      headers['x-magicbell-user-email'] = options.userEmail;
-    } else {
-      throw new Error('Missing user email or external ID');
-    }
-
-    if (options.userHmac) {
-      headers['x-magicbell-user-hmac'] = options.userHmac;
-    }
-
-    return fetch(`${options.host || DEFAULT_HOST}/config`, {
-      method: 'GET',
-      headers: headers,
-    })
-      .then((x) => x.json())
-      .then((x) => {
-        const url = new URL(x.web_push_notifications.subscribe_url);
-
-        return {
-          host: options.host || DEFAULT_HOST,
-          token: url.searchParams.get('access_token') || null,
-          project: url.searchParams.get('project') || null,
-        };
+    if (!activeSubscription?.endpoint) return false;
+    return subscriptions
+      .filter((x) => !x.discarded_at)
+      .some((subscription) => {
+        return subscription.endpoint === activeSubscription.endpoint;
       });
-  },
+  }
 
-  async getConfig({ token, project, baseURL }: RequestOptions) {
-    const cacheKey = [token, project, baseURL].join('-');
-    if (_config && _cacheKey === cacheKey) return _config;
-
-    return fetch(`${baseURL}/web_push_subscriptions?access_token=${token}&project=${project}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-    })
-      .then((x) => x.json() as Promise<{ push_subscription: Config }>)
-      .then((x) => {
-        _config = x.push_subscription;
-        _cacheKey = cacheKey;
-        return _config;
-      });
-  },
-
-  async getSubscriptions({ token, project, baseURL }: RequestOptions): Promise<Array<Subscription>> {
-    const config = await this.getConfig({ token, project, baseURL });
-    if (!config.project.api_key) throw new Error('Missing API key');
-    const headers: Record<string, string> = {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      'x-magicbell-api-key': config.project.api_key,
-    };
-    if (config.user.email) {
-      headers['x-magicbell-user-email'] = config.user.email;
-    } else if (config.user.external_id) {
-      headers['x-magicbell-user-external-id'] = config.user.external_id;
+  /**
+   * Request permission to send push notifications and post the subscription to the MagicBell API.
+   */
+  async subscribe(): Promise<void> {
+    if (!isSupported()) {
+      throw new Error('Push notifications are not supported in this browser');
     }
-    if (config.user.hmac) {
-      headers['x-magicbell-user-hmac'] = config.user.hmac;
+
+    const registration = await this.#getServiceWorker();
+    if (!registration?.pushManager) {
+      throw new Error('Push notifications are not supported in this browser');
     }
-    return fetch(`${baseURL}/push_subscriptions`, {
-      method: 'GET',
-      headers,
-    })
-      .then((result) => result.json())
-      .then((result) => result?.push_subscriptions || []);
-  },
 
-  async updateSubscription({ token, project, baseURL }: RequestOptions, subscription: PushSubscriptionJSON) {
-    return fetch(`${baseURL}/web_push_subscriptions?access_token=${token}&project=${project}`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json',
-      },
-      body: JSON.stringify({
-        web_push_subscription: {
-          data: subscription,
-        },
-      }),
-    })
-      .then((x) => x.json() as Promise<{ web_push_subscription: { id: string } }>)
-      .then((x) => x.web_push_subscription);
-  },
-};
+    // remove active subscription if there's any
+    await this.unsubscribe();
 
+    const config = await this.startInstallation();
+
+    // strip the base64 padding, it's either that or convert to uint8array
+    const applicationServerKey = config.public_key.replace(/=/g, '');
+
+    const subscription = await registration.pushManager
+      .subscribe({ userVisibleOnly: true, applicationServerKey })
+      .then((x) => x.toJSON());
+
+    if (!('endpoint' in subscription)) {
+      throw new Error('Failed to subscribe to push notifications, browser did not return an subscription endpoint.');
+    }
+
+    await this.createToken(subscription);
+  }
+
+  async unsubscribe(): Promise<void> {
+    const registration = await this.#getServiceWorker();
+    if (!registration?.pushManager) return;
+
+    const activeSubscription = await registration.pushManager.getSubscription();
+    if (!activeSubscription) return;
+
+    const endpoint = activeSubscription.endpoint;
+
+    // we're just purging an old subscription, MagicBell backend will also do that on the next broadcast
+    // so any error here, is non-critical
+    void this.getTokens()
+      .then((tokens: Token[]) => {
+        const token = tokens.find((token) => token.endpoint === endpoint);
+        if (!token) return;
+        return this.deleteToken(token.id);
+      })
+      .catch(() => void 0);
+
+    await activeSubscription.unsubscribe().catch(() => void 0);
+  }
+
+  async getAuthToken(): Promise<string> {
+    const installation = await this.startInstallation();
+    return installation.auth_token;
+  }
+}
+
+/**
+ * Check if service workers and push notifications are supported in this browser
+ */
 export function isSupported() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
   return 'PushManager' in window && 'serviceWorker' in navigator;
 }
 
-export async function prefetchConfig(options: SubscribeOptions) {
-  await api.getConfig({ ...options, baseURL: options.host || DEFAULT_HOST });
-}
+/**
+ * Gets the registered service worker, and attempts to create one if no registration exists
+ */
+export async function registerServiceWorker(options?: { path?: string } | string) {
+  const scriptUrl = (typeof options === 'string' ? options : options?.path) || '/sw.js';
 
-export async function registerServiceWorker({ path = '/sw.js' }: { path?: string } = {}) {
   // don't register a service-worker if there's already one
   if (navigator.serviceWorker.controller) return navigator.serviceWorker.ready;
-  await navigator.serviceWorker.register(path);
+  await navigator.serviceWorker.register(scriptUrl);
   return navigator.serviceWorker.ready;
-}
-
-/**
- * Checks if the current user has an active push subscription that is registered by MagicBell.
- */
-export async function isSubscribed(options: SubscribeOptions): Promise<boolean> {
-  const baseURL = options.host || DEFAULT_HOST;
-  const subscriptions = await api.getSubscriptions({ ...options, baseURL });
-  const registration = await registerServiceWorker({ path: options.serviceWorkerPath });
-  const activeSubscription = await registration?.pushManager?.getSubscription();
-
-  if (!activeSubscription?.endpoint) return false;
-  return subscriptions.some((subscription) => subscription.device_token === activeSubscription.endpoint);
-}
-
-/**
- * Request permission to send push notifications and post the subscription to the MagicBell API.
- */
-export async function subscribe(options: SubscribeOptions) {
-  if (!isSupported()) {
-    throw new Error('Push notifications are not supported in this browser');
-  }
-
-  const baseURL = options.host || DEFAULT_HOST;
-  const config = await api.getConfig({ ...options, baseURL });
-  const registration = await registerServiceWorker({ path: options.serviceWorkerPath });
-
-  if (!registration?.pushManager) {
-    throw new Error('Push notifications are not supported in this browser');
-  }
-
-  // remove active subscription if there's any
-  const activeSubscription = await registration.pushManager.getSubscription();
-  if (activeSubscription) {
-    await activeSubscription.unsubscribe().catch(() => void 0);
-  }
-
-  // strip the base64 padding, it's either that or convert to uint8array
-  const applicationServerKey = config.project.vapid_public_key.replace(/=/g, '');
-
-  const subscription = await registration.pushManager
-    .subscribe({ userVisibleOnly: true, applicationServerKey })
-    .then((x) => x.toJSON());
-
-  if (!('endpoint' in subscription)) {
-    throw new Error('Failed to subscribe to push notifications, browser did not return an subscription endpoint.');
-  }
-
-  await api.updateSubscription({ ...options, baseURL }, subscription);
-}
-
-export async function getAuthToken(options: AuthTokenOptions) {
-  return api.getAuthToken(options);
 }

--- a/packages/webpush/src/internal/client.ts
+++ b/packages/webpush/src/internal/client.ts
@@ -7,14 +7,14 @@ export type ClientOptions = {
   host?: string;
 } & UserCredentials;
 
-export type BaseToken = {
+export type ChannelToken = {
   id: string;
   created_at: string;
   updated_at: string;
   discarded_at: string | null;
 };
 
-export class IntegrationClient<Installation, Token extends BaseToken> {
+export class IntegrationClient<Installation, Token extends ChannelToken> {
   #host: string;
   #credentials: UserCredentials;
   #key: string;
@@ -91,7 +91,7 @@ export class IntegrationClient<Installation, Token extends BaseToken> {
     return this.#fetch<void>('DELETE', `/channels/${this.#key}/tokens/${id}`);
   }
 
-  async createToken(token: Partial<Token>) {
+  async createToken(token: Partial<Omit<Token, keyof ChannelToken>>) {
     return this.#fetch<Token>('POST', `/channels/${this.#key}/tokens`, token);
   }
 }

--- a/packages/webpush/src/internal/client.ts
+++ b/packages/webpush/src/internal/client.ts
@@ -1,0 +1,97 @@
+export type UserCredentials =
+  | { apiKey: string; userExternalId?: never; userEmail: string; userHmac?: string; authToken?: never }
+  | { apiKey: string; userExternalId: string; userEmail?: never; userHmac?: string; authToken?: never }
+  | { apiKey: string; userExternalId?: never; userEmail?: never; userHmac?: never; authToken: string };
+
+export type ClientOptions = {
+  host?: string;
+} & UserCredentials;
+
+export type BaseToken = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  discarded_at: string | null;
+};
+
+export class IntegrationClient<Installation, Token extends BaseToken> {
+  #host: string;
+  #credentials: UserCredentials;
+  #key: string;
+
+  constructor(key: string, { host, ...auth }: ClientOptions) {
+    this.#key = key;
+    this.#host = (host || 'https://api.magicbell.com').replace(/\/$/g, '');
+    this.#credentials = auth;
+
+    if (!this.#key) {
+      throw new Error('Please provide the integration key');
+    }
+  }
+
+  #getHeaders() {
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'x-magicbell-api-key': this.#credentials.apiKey,
+    };
+
+    if ('authToken' in this.#credentials && this.#credentials.authToken) {
+      headers['authorization'] = `Bearer ${this.#credentials.authToken}`;
+    } else if ('userExternalId' in this.#credentials && this.#credentials.userExternalId) {
+      headers['x-magicbell-user-external-id'] = this.#credentials.userExternalId;
+    } else if ('userEmail' in this.#credentials && this.#credentials.userEmail) {
+      headers['x-magicbell-user-email'] = this.#credentials.userEmail;
+    } else {
+      throw new Error('Missing userExternalId or userEmail');
+    }
+
+    if (this.#credentials.userHmac) {
+      headers['x-magicbell-user-hmac'] = this.#credentials.userHmac;
+    }
+
+    return headers;
+  }
+
+  async #fetch<T = unknown>(method: string, path: string, data?: unknown): Promise<T> {
+    if (path.startsWith('/')) {
+      path = path.slice(1);
+    }
+
+    const url = `${this.#host}/${path}`;
+
+    const init: RequestInit = {
+      method,
+      headers: this.#getHeaders(),
+      body: data ? JSON.stringify({ [this.#key]: data }) : undefined,
+    };
+
+    const response = await fetch(url, init);
+    if (response.status > 299) throw new Error(`request failed with ${response.status} - ${response.statusText}`);
+    if (response.status === 204) return;
+
+    const body = await response.json();
+    if (this.#key in body) return body[this.#key];
+    return body as T;
+  }
+
+  async startInstallation() {
+    return this.#fetch<Installation>('POST', `/integrations/${this.#key}/installations/start`);
+  }
+
+  async getToken(id: string) {
+    return this.#fetch<Token>('GET', `/channels/${this.#key}/tokens/${id}`);
+  }
+
+  async getTokens() {
+    return this.#fetch<Array<Token>>('GET', `/channels/${this.#key}/tokens`);
+  }
+
+  async deleteToken(id: string) {
+    return this.#fetch<void>('DELETE', `/channels/${this.#key}/tokens/${id}`);
+  }
+
+  async createToken(token: Partial<Token>) {
+    return this.#fetch<Token>('POST', `/channels/${this.#key}/tokens`, token);
+  }
+}


### PR DESCRIPTION

**BREAKING CHANGE!**

This is a complete revamp of how we're registering client push notification subscriptions, but given that the v1 API surface is small, migrating should be easy enough. You can find [the migration guide on our site](https://magicbell.com/docs/guides/migrations/upgrade-magicbell-webpush-to-v2).

The methods mentioned here are the breaking ones that you use when interacting with the browser directly. We've also added a bunch of functions to interact with the MagicBell API directly, leaving all browser interaction for you to implement. Think of use cases where you already have a service worker, and just want to push the channel tokens to our backend, or because you need to list all the currently active channel tokens so the user can unsubscribe from a device they no longer control.

Please read more about those methods in [the docs for @magicbell/webpush](https://magicbell.com/docs/libraries/webpush#api-methods)

```ts
import { WebPushClient } from '@magicbell/webpush';

const client = new WebPushClient({
  apiKey: '024…0bd',
  userEmail: 'person@example.com',
  userHmac: 'NCI…I6M',
});

await client.isSubscribed();
await client.subscribe();
await client.unsubscribe();
```

**Subscribe to push notifications:**

Subscribing to push notifications is now a single call on the client, instead of the two-step flow from v1.

```diff
- import { getAuthToken, subscribe } from '@magicbell/webpush';
+ import { WebPushClient } from '@magicbell/webpush';

- const token = await getAuthToken({
+ const client = new WebPushClient({
  apiKey: '024…0bd',
  userEmail: 'person@example.com',
  userHmac: 'NCI…I6M',
});

- await subscribe({
-   token: token.token,
-   project: token.project,
- });

+ await client.subscribe();
```

**Unsubscribe from push notifications.**

This is a new method that didn't exist in previous versions. Unsubscribing and resubscribing is now trivial, giving your users the option to "pause" the push notifications.

```ts
import { WebPushClient } from '@magicbell/webpush';

const client = new WebPushClient({
  apiKey: '024…0bd',
  userEmail: 'person@example.com',
  userHmac: 'NCI…I6M',
});

await client.unsubscribe();
```

**Get subscription status**

Verifying subscription status is now a single call on the client, instead of the two-step flow from v1.

```diff
- import { getAuthToken, isSubscribed } from '@magicbell/webpush';
+ import { WebPushClient } from '@magicbell/webpush';

- const token = await getAuthToken({
+ const client = new WebPushClient({
  apiKey: '024…0bd',
  userEmail: 'person@example.com',
  userHmac: 'NCI…I6M',
});

- const subscribed = await isSubscribed({
-   token: token.token,
-   project: token.project,
- });

+ const subscribed = await client.isSubscribed();
```

**Get authentication token**

The authentication token is no longer required for basic functionality, but can still be used to for example transfer the session to a popup.

```diff
- import { getAuthToken } from '@magicbell/webpush';
+ import { WebPushClient } from '@magicbell/webpush';

- const token = await getAuthToken({
+ const client = new WebPushClient({
  apiKey: '024…0bd',
  userEmail: 'person@example.com',
  userHmac: 'NCI…I6M',
});

+ const token = await client.getAuthToken();
```

**API Methods**

We've added a bunch of useful methods to work with our api directly. Please read more about those methods in [the docs for @magicbell/webpush](https://magicbell.com/docs/libraries/webpush#api-methods).
