### PR TITLE
feat: move fields to url params for get requests

### DIFF
--- a/.changeset/beige-mugs-sit.md
+++ b/.changeset/beige-mugs-sit.md
@@ -1,0 +1,17 @@
+---
+'@magicbell/cli': minor
+---
+
+Move `fields` to query params for `api` get requests. This makes it just slightly easier to form urls for GET request when using the `api` escape hatch in our cli.
+
+```shell
+mb api '/notifications' -f seen=false -X get -c user -r curl
+
+curl --url 'https://api.magicbell.com/notifications?seen=false' \
+  --request 'GET' \
+  --header 'accept: application/json' \
+  --header 'accept-version: v2' \
+  --header 'x-magicbell-api-key: 8cd...c70' \
+  --header 'x-magicbell-user-email: stephan@example.com' \
+  --header 'x-magicbell-user-hmac: uaZ...hU='
+```

--- a/packages/cli/scripts/generate-resources.ts
+++ b/packages/cli/scripts/generate-resources.ts
@@ -27,7 +27,7 @@ import fs from 'fs/promises';
 import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 
-const SPEC_URL = argv.spec || 'https://public.magicbell.com/specs/openapi.json';
+const SPEC_URL = argv.spec || process.env.SPEC_URL || 'https://public.magicbell.com/specs/openapi.json';
 
 const initError = !argv.help && !argv.dest && !argv.docs;
 

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -60,7 +60,6 @@ export const api = createCommand('api')
     }
 
     let data = parseJsonLikes(opts.data) || {};
-
     for (const field of opts.field || []) {
       const [key, value] = field.split('=');
       data[key] = parseJsonLikes(value);
@@ -90,11 +89,12 @@ export const api = createCommand('api')
     });
 
     try {
+      const dataKey = method === 'GET' ? 'params' : 'data';
       const result = await client.request({
         method,
         path,
         headers,
-        data,
+        [dataKey]: data,
       });
 
       if (opts.include) printResponse(response);

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -62,7 +62,17 @@ export const api = createCommand('api')
     let data = parseJsonLikes(opts.data) || {};
     for (const field of opts.field || []) {
       const [key, value] = field.split('=');
-      data[key] = parseJsonLikes(value);
+
+      if (!(key in data)) {
+        data[key] = parseJsonLikes(value);
+        continue;
+      }
+
+      if (!Array.isArray(data[key])) {
+        data[key] = [data[key]];
+      }
+
+      data[key].push(parseJsonLikes(value));
     }
 
     if (!Object.keys(data).length) {

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -98,6 +98,7 @@
     "debug": "^4.3.4",
     "fetch-addons": "^1.2.0",
     "json-schema-to-ts": "3.1.0",
-    "ky": "npm:@smeijer/ky@^0.33.3"
+    "ky": "npm:@smeijer/ky@^0.33.3",
+    "url-join": "^4.0.1"
   }
 }

--- a/packages/magicbell/scripts/generate-resources.ts
+++ b/packages/magicbell/scripts/generate-resources.ts
@@ -30,7 +30,7 @@ import fs from 'fs/promises';
 import { stringify } from 'json5';
 import path from 'path';
 
-const SPEC_URL = argv.spec || 'https://public.magicbell.com/specs/openapi.json';
+const SPEC_URL = argv.spec || process.env.SPEC_URL || 'https://public.magicbell.com/specs/openapi.json';
 
 const initError = !argv.help && !argv.dest && !argv.docs;
 

--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -1,4 +1,5 @@
 import ky from 'ky';
+import urlJoin from 'url-join';
 
 import { tryParse } from '../lib/utils';
 import { createError } from './error';
@@ -40,8 +41,7 @@ export class Client {
     };
 
     // don't just use `new URL(path, host)` as that will strip the path from the host
-    const url = new URL(requestOptions.host);
-    url.pathname = url.pathname.replace(/\/$/, '') + path;
+    const url = new URL(urlJoin(requestOptions.host, path));
 
     for (const [key, value] of Object.entries(params || {})) {
       url.searchParams.append(key, Array.isArray(value) ? value.join(',') : value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17539,6 +17539,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
 
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
 url-loader@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"


### PR DESCRIPTION
Move `fields` to query params for `api` get requests. This makes it just slightly easier to form urls for GET request when using the `api` escape hatch in our cli.

```shell
mb api '/notifications' -f seen=false -X get -c user -r curl

curl --url 'https://api.magicbell.com/notifications?seen=false' \
 --request 'GET' \
 --header 'accept: application/json' \
 --header 'accept-version: v2' \
 --header 'x-magicbell-api-key: 8cd...c70' \
 --header 'x-magicbell-user-email: stephan@example.com' \
 --header 'x-magicbell-user-hmac: uaZ...hU='
```