### PR TITLE
chore: rename magicbell-io to magicbell

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "magicbell-io/magicbell-js" }
-  ],
+  "changelog": ["@changesets/changelog-github", { "repo": "magicbell/magicbell-js" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release-to-discussion.yml
+++ b/.github/workflows/release-to-discussion.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - name: publish discussion
-        uses: magicbell-io/release-discussion-action@main
+        uses: magicbell/release-discussion-action@main
         with:
-          repo: magicbell-io/community
+          repo: magicbell/community
           category: product-changelog
           cycle: week
         env:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You'll need TypeScript 4.5 or higher for our bundled type definitions.
 Run the following commands in your terminal to get a copy of this repo, and install required dependencies.
 
 ```
-git clone git@github.com:magicbell-io/magicbell-js.git
+git clone git@github.com:magicbell/magicbell-js.git
 cd magicbell-js
 yarn
 ```

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -29,14 +29,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c16e604`](https://github.com/magicbell-io/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189)]:
+- Updated dependencies [[`c16e604`](https://github.com/magicbell/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189)]:
   - magicbell@3.1.4
 
 ## 3.4.0
 
 ### Minor Changes
 
-- [#276](https://github.com/magicbell-io/magicbell-js/pull/276) [`702ee27`](https://github.com/magicbell-io/magicbell-js/commit/702ee27f7309666c98dc6804e9b152599d357e4c) Thanks [@smeijer](https://github.com/smeijer)! - Support reading email or external id for user commands from profile. With this change, instead of running `magicbell user notifications list --user-email person@example.com`, one can run also run:
+- [#276](https://github.com/magicbell/magicbell-js/pull/276) [`702ee27`](https://github.com/magicbell/magicbell-js/commit/702ee27f7309666c98dc6804e9b152599d357e4c) Thanks [@smeijer](https://github.com/smeijer)! - Support reading email or external id for user commands from profile. With this change, instead of running `magicbell user notifications list --user-email person@example.com`, one can run also run:
 
   ```shell
   # magicbell user notifications list --user-email person@example.com
@@ -54,25 +54,25 @@
 
   Note that the arguments still take precedence when provided.
 
-- [#277](https://github.com/magicbell-io/magicbell-js/pull/277) [`8f20dec`](https://github.com/magicbell-io/magicbell-js/commit/8f20decaebaf02c426335a8d072cc0e9980ced63) Thanks [@smeijer](https://github.com/smeijer)! - Show command description in the help for that specific command.
+- [#277](https://github.com/magicbell/magicbell-js/pull/277) [`8f20dec`](https://github.com/magicbell/magicbell-js/commit/8f20decaebaf02c426335a8d072cc0e9980ced63) Thanks [@smeijer](https://github.com/smeijer)! - Show command description in the help for that specific command.
 
 ### Patch Changes
 
-- [#278](https://github.com/magicbell-io/magicbell-js/pull/278) [`feea558`](https://github.com/magicbell-io/magicbell-js/commit/feea55883db7725ee4f861a4814db21d248aff86) Thanks [@smeijer](https://github.com/smeijer)! - support `api --request GET` for curl compat
+- [#278](https://github.com/magicbell/magicbell-js/pull/278) [`feea558`](https://github.com/magicbell/magicbell-js/commit/feea55883db7725ee4f861a4814db21d248aff86) Thanks [@smeijer](https://github.com/smeijer)! - support `api --request GET` for curl compat
 
-- [#274](https://github.com/magicbell-io/magicbell-js/pull/274) [`34a4fd7`](https://github.com/magicbell-io/magicbell-js/commit/34a4fd7655e537857913fe386a76e9012974c340) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config unset {key}`.
+- [#274](https://github.com/magicbell/magicbell-js/pull/274) [`34a4fd7`](https://github.com/magicbell/magicbell-js/commit/34a4fd7655e537857913fe386a76e9012974c340) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config unset {key}`.
 
 ## 3.3.1
 
 ### Patch Changes
 
-- [#271](https://github.com/magicbell-io/magicbell-js/pull/271) [`f57ed5e`](https://github.com/magicbell-io/magicbell-js/commit/f57ed5e0ddfaa22d60338973843c5a039772ebc0) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config unset {key}`.
+- [#271](https://github.com/magicbell/magicbell-js/pull/271) [`f57ed5e`](https://github.com/magicbell/magicbell-js/commit/f57ed5e0ddfaa22d60338973843c5a039772ebc0) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config unset {key}`.
 
 ## 3.3.0
 
 ### Minor Changes
 
-- [#266](https://github.com/magicbell-io/magicbell-js/pull/266) [`3ba8477`](https://github.com/magicbell-io/magicbell-js/commit/3ba84779599f1c6e10e3e09c0dae634c6187ace2) Thanks [@smeijer](https://github.com/smeijer)! - Add credential option to switch authentication scope for `magicbell api` requests
+- [#266](https://github.com/magicbell/magicbell-js/pull/266) [`3ba8477`](https://github.com/magicbell/magicbell-js/commit/3ba84779599f1c6e10e3e09c0dae634c6187ace2) Thanks [@smeijer](https://github.com/smeijer)! - Add credential option to switch authentication scope for `magicbell api` requests
 
   ```shell
   # include user credential headers (x-magicbell-user-email)
@@ -84,7 +84,7 @@
   magicbell api /some-endpoint -r curl --credentials project
   ```
 
-- [#267](https://github.com/magicbell-io/magicbell-js/pull/267) [`9b41a69`](https://github.com/magicbell-io/magicbell-js/commit/9b41a69a63832f878f266d84768cb806ed9514b5) Thanks [@smeijer](https://github.com/smeijer)! - Also accept lowercase method names in the `magicbell api -X {method}` command.
+- [#267](https://github.com/magicbell/magicbell-js/pull/267) [`9b41a69`](https://github.com/magicbell/magicbell-js/commit/9b41a69a63832f878f266d84768cb806ed9514b5) Thanks [@smeijer](https://github.com/smeijer)! - Also accept lowercase method names in the `magicbell api -X {method}` command.
 
   These commands are now the same:
 
@@ -95,64 +95,64 @@
 
 ### Patch Changes
 
-- [#269](https://github.com/magicbell-io/magicbell-js/pull/269) [`ccc6ee7`](https://github.com/magicbell-io/magicbell-js/commit/ccc6ee7a08195c7f08a473f7d572977e8ffb6491) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config set {key} {value}`.
+- [#269](https://github.com/magicbell/magicbell-js/pull/269) [`ccc6ee7`](https://github.com/magicbell/magicbell-js/commit/ccc6ee7a08195c7f08a473f7d572977e8ffb6491) Thanks [@smeijer](https://github.com/smeijer)! - Restore `magicbell config set {key} {value}`.
 
-- Updated dependencies [[`3982658`](https://github.com/magicbell-io/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60)]:
+- Updated dependencies [[`3982658`](https://github.com/magicbell/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60)]:
   - magicbell@3.1.3
 
 ## 3.2.4
 
 ### Patch Changes
 
-- Updated dependencies [[`30ed933`](https://github.com/magicbell-io/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245)]:
+- Updated dependencies [[`30ed933`](https://github.com/magicbell/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245)]:
   - magicbell@3.1.2
 
 ## 3.2.3
 
 ### Patch Changes
 
-- [#241](https://github.com/magicbell-io/magicbell-js/pull/241) [`1afb5b1`](https://github.com/magicbell-io/magicbell-js/commit/1afb5b104c518e8927f416af9602a1e2ab6210a6) Thanks [@smeijer](https://github.com/smeijer)! - don't parse response body when it's empty
+- [#241](https://github.com/magicbell/magicbell-js/pull/241) [`1afb5b1`](https://github.com/magicbell/magicbell-js/commit/1afb5b104c518e8927f416af9602a1e2ab6210a6) Thanks [@smeijer](https://github.com/smeijer)! - don't parse response body when it's empty
 
-- [#242](https://github.com/magicbell-io/magicbell-js/pull/242) [`840263b`](https://github.com/magicbell-io/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675) Thanks [@smeijer](https://github.com/smeijer)! - ensure listeners use node native https module
+- [#242](https://github.com/magicbell/magicbell-js/pull/242) [`840263b`](https://github.com/magicbell/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675) Thanks [@smeijer](https://github.com/smeijer)! - ensure listeners use node native https module
 
-- Updated dependencies [[`840263b`](https://github.com/magicbell-io/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675), [`aee799d`](https://github.com/magicbell-io/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4)]:
+- Updated dependencies [[`840263b`](https://github.com/magicbell/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675), [`aee799d`](https://github.com/magicbell/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4)]:
   - magicbell@3.1.1
 
 ## 3.2.2
 
 ### Patch Changes
 
-- Updated dependencies [[`8bee76e`](https://github.com/magicbell-io/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e), [`1041cdf`](https://github.com/magicbell-io/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183)]:
+- Updated dependencies [[`8bee76e`](https://github.com/magicbell/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e), [`1041cdf`](https://github.com/magicbell/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183)]:
   - magicbell@3.1.0
 
 ## 3.2.1
 
 ### Patch Changes
 
-- [`33d2cab`](https://github.com/magicbell-io/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`33d2cab`](https://github.com/magicbell/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tsx` to `^3.14.0`.
 
-- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`5a3443f`](https://github.com/magicbell-io/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0), [`33d2cab`](https://github.com/magicbell-io/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6), [`444e653`](https://github.com/magicbell-io/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8)]:
+- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`5a3443f`](https://github.com/magicbell/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0), [`33d2cab`](https://github.com/magicbell/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6), [`444e653`](https://github.com/magicbell/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8)]:
   - magicbell@3.0.1
 
 ## 3.2.0
 
 ### Minor Changes
 
-- [`a044146`](https://github.com/magicbell-io/magicbell-js/commit/a0441465e0dd0faa850dad4aa81df91a48484a17) Thanks [@smeijer](https://github.com/smeijer)! - only show cli help when invalid arguments were provided
+- [`a044146`](https://github.com/magicbell/magicbell-js/commit/a0441465e0dd0faa850dad4aa81df91a48484a17) Thanks [@smeijer](https://github.com/smeijer)! - only show cli help when invalid arguments were provided
 
 ## 3.1.1
 
 ### Patch Changes
 
-- [`d813bac`](https://github.com/magicbell-io/magicbell-js/commit/d813bac4c050ab5c2540734717394c94fe81cb50) Thanks [@smeijer](https://github.com/smeijer)! - fix issue when no hooks were provided
+- [`d813bac`](https://github.com/magicbell/magicbell-js/commit/d813bac4c050ab5c2540734717394c94fe81cb50) Thanks [@smeijer](https://github.com/smeijer)! - fix issue when no hooks were provided
 
 ## 3.1.0
 
 ### Minor Changes
 
-- [#218](https://github.com/magicbell-io/magicbell-js/pull/218) [`943a52b`](https://github.com/magicbell-io/magicbell-js/commit/943a52be4208d2b6ab843d76fcaf4dee9e428b01) Thanks [@smeijer](https://github.com/smeijer)! - Add `magicbell api` method to make an authenticated HTTP request to the MagicBell API and print the response. This will be useful for debugging purposes or advanced users, though other existing commands are recommended for day-to-day use.
+- [#218](https://github.com/magicbell/magicbell-js/pull/218) [`943a52b`](https://github.com/magicbell/magicbell-js/commit/943a52be4208d2b6ab843d76fcaf4dee9e428b01) Thanks [@smeijer](https://github.com/smeijer)! - Add `magicbell api` method to make an authenticated HTTP request to the MagicBell API and print the response. This will be useful for debugging purposes or advanced users, though other existing commands are recommended for day-to-day use.
 
   **Examples**
 
@@ -182,17 +182,17 @@
 
 ### Patch Changes
 
-- [#213](https://github.com/magicbell-io/magicbell-js/pull/213) [`0f2ae1a`](https://github.com/magicbell-io/magicbell-js/commit/0f2ae1a71b125d77edf0497e3fd0345902186a3f) Thanks [@smeijer](https://github.com/smeijer)! - Add more info to login error messages, in case login fails.
+- [#213](https://github.com/magicbell/magicbell-js/pull/213) [`0f2ae1a`](https://github.com/magicbell/magicbell-js/commit/0f2ae1a71b125d77edf0497e3fd0345902186a3f) Thanks [@smeijer](https://github.com/smeijer)! - Add more info to login error messages, in case login fails.
 
 ## 3.0.0
 
 ### Major Changes
 
-- [#208](https://github.com/magicbell-io/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - We've removed `magicbell notifications create`, please use `broadcasts create` instead.
+- [#208](https://github.com/magicbell/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - We've removed `magicbell notifications create`, please use `broadcasts create` instead.
 
 ### Minor Changes
 
-- [#208](https://github.com/magicbell-io/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - Add `magicbell broadcasts create` command.
+- [#208](https://github.com/magicbell/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - Add `magicbell broadcasts create` command.
 
   ```shell
   magicbell broadcasts create  \
@@ -205,57 +205,57 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722), [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722)]:
+- Updated dependencies [[`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722), [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722)]:
   - magicbell@3.0.0
 
 ## 2.2.4
 
 ### Patch Changes
 
-- Updated dependencies [[`5c8f4c9`](https://github.com/magicbell-io/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c)]:
+- Updated dependencies [[`5c8f4c9`](https://github.com/magicbell/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c)]:
   - magicbell@2.4.1
 
 ## 2.2.3
 
 ### Patch Changes
 
-- Updated dependencies [[`725ab1a`](https://github.com/magicbell-io/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e)]:
+- Updated dependencies [[`725ab1a`](https://github.com/magicbell/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e)]:
   - magicbell@2.4.0
 
 ## 2.2.2
 
 ### Patch Changes
 
-- Updated dependencies [[`c6054af`](https://github.com/magicbell-io/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
+- Updated dependencies [[`c6054af`](https://github.com/magicbell/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
   - magicbell@2.3.1
 
 ## 2.2.1
 
 ### Patch Changes
 
-- [`b29dc74`](https://github.com/magicbell-io/magicbell-js/commit/b29dc7480f855913060257f692f786c563d4598e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`b29dc74`](https://github.com/magicbell/magicbell-js/commit/b29dc7480f855913060257f692f786c563d4598e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `commander` to `^9.5.0`.
 
-- Updated dependencies [[`3f7ab5a`](https://github.com/magicbell-io/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca)]:
+- Updated dependencies [[`3f7ab5a`](https://github.com/magicbell/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca)]:
   - magicbell@2.3.0
 
 ## 2.2.0
 
 ### Minor Changes
 
-- [#173](https://github.com/magicbell-io/magicbell-js/pull/173) [`1f40263`](https://github.com/magicbell-io/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858) Thanks [@smeijer](https://github.com/smeijer)! - Add [EventSource](https://www.npmjs.com/package/eventsource) polyfill for the `listen` methods. This polyfill is removed from the `magicbell` package, to avoid bundling it in the browser SDKs.
+- [#173](https://github.com/magicbell/magicbell-js/pull/173) [`1f40263`](https://github.com/magicbell/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858) Thanks [@smeijer](https://github.com/smeijer)! - Add [EventSource](https://www.npmjs.com/package/eventsource) polyfill for the `listen` methods. This polyfill is removed from the `magicbell` package, to avoid bundling it in the browser SDKs.
 
 ### Patch Changes
 
-- Updated dependencies [[`1f40263`](https://github.com/magicbell-io/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858)]:
+- Updated dependencies [[`1f40263`](https://github.com/magicbell/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858)]:
   - magicbell@2.2.0
 
 ## 2.1.0
 
 ### Minor Changes
 
-- [#171](https://github.com/magicbell-io/magicbell-js/pull/171) [`666d2bb`](https://github.com/magicbell-io/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248) Thanks [@smeijer](https://github.com/smeijer)! - We've added a method to list the registered push subscriptions for a given user using user credentials.
+- [#171](https://github.com/magicbell/magicbell-js/pull/171) [`666d2bb`](https://github.com/magicbell/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248) Thanks [@smeijer](https://github.com/smeijer)! - We've added a method to list the registered push subscriptions for a given user using user credentials.
 
   ```shell
   magicbell user push-subscriptions list \
@@ -266,34 +266,34 @@
 
 ### Patch Changes
 
-- [#170](https://github.com/magicbell-io/magicbell-js/pull/170) [`87d84e8`](https://github.com/magicbell-io/magicbell-js/commit/87d84e8bf934bcf3a176f08a3129ce91e18d3da3) Thanks [@smeijer](https://github.com/smeijer)! - Improve `--help` by being more specific about the json type some arguments expect. For example, we used to show `--overrides <json>`, but json can also be an array, while we do expect an object. Now, those arguments are shown as `<object>`.
+- [#170](https://github.com/magicbell/magicbell-js/pull/170) [`87d84e8`](https://github.com/magicbell/magicbell-js/commit/87d84e8bf934bcf3a176f08a3129ce91e18d3da3) Thanks [@smeijer](https://github.com/smeijer)! - Improve `--help` by being more specific about the json type some arguments expect. For example, we used to show `--overrides <json>`, but json can also be an array, while we do expect an object. Now, those arguments are shown as `<object>`.
 
-- Updated dependencies [[`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`24c00f4`](https://github.com/magicbell-io/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68), [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`666d2bb`](https://github.com/magicbell-io/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248)]:
+- Updated dependencies [[`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`24c00f4`](https://github.com/magicbell/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68), [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`666d2bb`](https://github.com/magicbell/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248)]:
   - magicbell@2.1.0
 
 ## 2.0.3
 
 ### Patch Changes
 
-- [#161](https://github.com/magicbell-io/magicbell-js/pull/161) [`4ef2b07`](https://github.com/magicbell-io/magicbell-js/commit/4ef2b07e31922ebe83a443b1732390b79b7af141) Thanks [@smeijer](https://github.com/smeijer)! - Use a fork of ky that includes commonjs support
+- [#161](https://github.com/magicbell/magicbell-js/pull/161) [`4ef2b07`](https://github.com/magicbell/magicbell-js/commit/4ef2b07e31922ebe83a443b1732390b79b7af141) Thanks [@smeijer](https://github.com/smeijer)! - Use a fork of ky that includes commonjs support
 
 ## 2.0.2
 
 ### Patch Changes
 
-- [#158](https://github.com/magicbell-io/magicbell-js/pull/158) [`d0121d9`](https://github.com/magicbell-io/magicbell-js/commit/d0121d9eb85528604e6765b679a896570eaee3ee) Thanks [@smeijer](https://github.com/smeijer)! - inject ky during build for a dep free install
+- [#158](https://github.com/magicbell/magicbell-js/pull/158) [`d0121d9`](https://github.com/magicbell/magicbell-js/commit/d0121d9eb85528604e6765b679a896570eaee3ee) Thanks [@smeijer](https://github.com/smeijer)! - inject ky during build for a dep free install
 
 ## 2.0.1
 
 ### Patch Changes
 
-- [`125c9d2`](https://github.com/magicbell-io/magicbell-js/commit/125c9d238dfb088b5482fd5fa8447b8a0c990da8) Thanks [@smeijer](https://github.com/smeijer)! - - updated `magicbell` to `2.0.1`
+- [`125c9d2`](https://github.com/magicbell/magicbell-js/commit/125c9d238dfb088b5482fd5fa8447b8a0c990da8) Thanks [@smeijer](https://github.com/smeijer)! - - updated `magicbell` to `2.0.1`
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#154](https://github.com/magicbell-io/magicbell-js/pull/154) [`da22233`](https://github.com/magicbell-io/magicbell-js/commit/da22233fca83398cc33e4732172eebde96ad1140) Thanks [@smeijer](https://github.com/smeijer)! - **Breaking Changes** - please read carefully.
+- [#154](https://github.com/magicbell/magicbell-js/pull/154) [`da22233`](https://github.com/magicbell/magicbell-js/commit/da22233fca83398cc33e4732172eebde96ad1140) Thanks [@smeijer](https://github.com/smeijer)! - **Breaking Changes** - please read carefully.
 
   We've separated the project from user resources. All user resources have been moved under the `user` namespace. This is a virtual path, that does not translate one-on-one to the REST api. All user resources require a `--user-email` or `--user-external-id` option to be provided.
 
@@ -323,14 +323,14 @@
 
 ### Minor Changes
 
-- [#149](https://github.com/magicbell-io/magicbell-js/pull/149) [`3cd329b`](https://github.com/magicbell-io/magicbell-js/commit/3cd329bd76377d144dd8dd79a66f8b909591533c) Thanks [@smeijer](https://github.com/smeijer)! - The CLI now accepts the global `--print-request curl` option that prints the request object to the console. When that option is provided, the request will be printed in the requested format, and no network requests will be made. We'll add more formats in the future.
+- [#149](https://github.com/magicbell/magicbell-js/pull/149) [`3cd329b`](https://github.com/magicbell/magicbell-js/commit/3cd329bd76377d144dd8dd79a66f8b909591533c) Thanks [@smeijer](https://github.com/smeijer)! - The CLI now accepts the global `--print-request curl` option that prints the request object to the console. When that option is provided, the request will be printed in the requested format, and no network requests will be made. We'll add more formats in the future.
 
   ```shell
   magicbell notifications list --print-request curl
   magicbell notifications create --title hi --print-request curl
   ```
 
-- [#152](https://github.com/magicbell-io/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell-io/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We now use [debug] for logging, and have dropped support for the `debug` property that could be provided to `Client`. Debugging can be enabled via the `DEBUG` environment variable.
+- [#152](https://github.com/magicbell/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We now use [debug] for logging, and have dropped support for the `debug` property that could be provided to `Client`. Debugging can be enabled via the `DEBUG` environment variable.
 
   We're using the namespaces `magicbell:debug`, `magicbell:log` and `magicbell:error`.
 
@@ -343,7 +343,7 @@
 
 ### Patch Changes
 
-- [#148](https://github.com/magicbell-io/magicbell-js/pull/148) [`f6558fb`](https://github.com/magicbell-io/magicbell-js/commit/f6558fb04fbcfbdea14839f9c6e3972eed60a65e) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#148](https://github.com/magicbell/magicbell-js/pull/148) [`f6558fb`](https://github.com/magicbell/magicbell-js/commit/f6558fb04fbcfbdea14839f9c6e3972eed60a65e) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `esbuild` to `^0.18.11`.
 
@@ -351,7 +351,7 @@
 
 ### Minor Changes
 
-- [#147](https://github.com/magicbell-io/magicbell-js/pull/147) [`b2f240a`](https://github.com/magicbell-io/magicbell-js/commit/b2f240ad00b71261f8133ffd1612826b26b14f7d) Thanks [@smeijer](https://github.com/smeijer)! - add `--host` flag so the cli can be used against other environments, such as localhost, staging and review.
+- [#147](https://github.com/magicbell/magicbell-js/pull/147) [`b2f240a`](https://github.com/magicbell/magicbell-js/commit/b2f240ad00b71261f8133ffd1612826b26b14f7d) Thanks [@smeijer](https://github.com/smeijer)! - add `--host` flag so the cli can be used against other environments, such as localhost, staging and review.
 
   ```shell
   magicbell --host localhost:3000
@@ -371,13 +371,13 @@
 
 ### Patch Changes
 
-- [#145](https://github.com/magicbell-io/magicbell-js/pull/145) [`871c9f4`](https://github.com/magicbell-io/magicbell-js/commit/871c9f4e7a6d9f5e289a2ff32e7498a072e34dbd) Thanks [@smeijer](https://github.com/smeijer)! - remove `-v` and `-h` alias. Use `--version` and `--help` instead.
+- [#145](https://github.com/magicbell/magicbell-js/pull/145) [`871c9f4`](https://github.com/magicbell/magicbell-js/commit/871c9f4e7a6d9f5e289a2ff32e7498a072e34dbd) Thanks [@smeijer](https://github.com/smeijer)! - remove `-v` and `-h` alias. Use `--version` and `--help` instead.
 
 ## 1.2.0
 
 ### Minor Changes
 
-- [#143](https://github.com/magicbell-io/magicbell-js/pull/143) [`26e9e1a`](https://github.com/magicbell-io/magicbell-js/commit/26e9e1a737d946d4fc42b81a126f9b2c794cb8f4) Thanks [@smeijer](https://github.com/smeijer)! - Add `--max-items` to methods supporting `--paginate`. This way it's trivial to auto paginate over records at MagicBell, till a certain reasonable limit is reached. By default, `--paginate` iterates over every single record potentially hitting, but respecting, API rate limits.
+- [#143](https://github.com/magicbell/magicbell-js/pull/143) [`26e9e1a`](https://github.com/magicbell/magicbell-js/commit/26e9e1a737d946d4fc42b81a126f9b2c794cb8f4) Thanks [@smeijer](https://github.com/smeijer)! - Add `--max-items` to methods supporting `--paginate`. This way it's trivial to auto paginate over records at MagicBell, till a certain reasonable limit is reached. By default, `--paginate` iterates over every single record potentially hitting, but respecting, API rate limits.
 
   ```shell
   $ magicbell broadcasts list --paginate --max-items 1000
@@ -387,7 +387,7 @@
 
 ### Minor Changes
 
-- [`963fcc1`](https://github.com/magicbell-io/magicbell-js/commit/963fcc1030f1cbcb621a19dc0b446558fedee790) Thanks [@smeijer](https://github.com/smeijer)! - feat: add user options to listen
+- [`963fcc1`](https://github.com/magicbell/magicbell-js/commit/963fcc1030f1cbcb621a19dc0b446558fedee790) Thanks [@smeijer](https://github.com/smeijer)! - feat: add user options to listen
 
   ```shell
   magicbell listen --user-email person@example.com
@@ -398,7 +398,7 @@
 
 ### Major Changes
 
-- [#139](https://github.com/magicbell-io/magicbell-js/pull/139) [`22f7267`](https://github.com/magicbell-io/magicbell-js/commit/22f72679b65405e79a5a4a80d112678c3080ddc5) Thanks [@smeijer](https://github.com/smeijer)! - Work with MagicBell from the command line!
+- [#139](https://github.com/magicbell/magicbell-js/pull/139) [`22f7267`](https://github.com/magicbell/magicbell-js/commit/22f72679b65405e79a5a4a80d112678c3080ddc5) Thanks [@smeijer](https://github.com/smeijer)! - Work with MagicBell from the command line!
 
   ```shell
   npm i -g @magicbell/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ npm install -g @magicbell/cli
 or brew:
 
 ```shell
-brew tap magicbell-io/magicbell
+brew tap magicbell/magicbell
 brew install magicbell-cli
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,11 +25,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git",
+    "url": "git@github.com:magicbell/magicbell-js.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`65a386e`](https://github.com/magicbell-io/magicbell-js/commit/65a386e5459e0e66b080d27950f1e7ecb4f3c97d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`65a386e`](https://github.com/magicbell/magicbell-js/commit/65a386e5459e0e66b080d27950f1e7ecb4f3c97d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `eslint` to `^8.57.0`.
 
@@ -12,17 +12,17 @@
 
 ### Patch Changes
 
-- [`892a8c0`](https://github.com/magicbell-io/magicbell-js/commit/892a8c09607cf84fa62ed6ee89d228e9a259ee6f) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`892a8c0`](https://github.com/magicbell/magicbell-js/commit/892a8c09607cf84fa62ed6ee89d228e9a259ee6f) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `prettier` to `^2.8.8`.
 
-- [`e76980d`](https://github.com/magicbell-io/magicbell-js/commit/e76980db29934f3983f3143cf55cab01befbce8e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`e76980d`](https://github.com/magicbell/magicbell-js/commit/e76980db29934f3983f3143cf55cab01befbce8e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `eslint` to `^8.56.0`.
   - updated `eslint-config-next` to `12.3.4`.
   - updated `eslint-plugin-jsx-a11y` to `^6.8.0`.
 
-- [#247](https://github.com/magicbell-io/magicbell-js/pull/247) [`9e55676`](https://github.com/magicbell-io/magicbell-js/commit/9e55676f6c252728e941c224f4dd3a486bb646cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#247](https://github.com/magicbell/magicbell-js/pull/247) [`9e55676`](https://github.com/magicbell/magicbell-js/commit/9e55676f6c252728e941c224f4dd3a486bb646cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `axios` to `^0.28.0`.
 
@@ -30,11 +30,11 @@
 
 ### Patch Changes
 
-- [`5a3443f`](https://github.com/magicbell-io/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`5a3443f`](https://github.com/magicbell/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `openapi-types` to `^12.1.3`.
 
-- [#222](https://github.com/magicbell-io/magicbell-js/pull/222) [`444e653`](https://github.com/magicbell-io/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#222](https://github.com/magicbell/magicbell-js/pull/222) [`444e653`](https://github.com/magicbell/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `recast` to `^0.23.4`.
 
@@ -42,7 +42,7 @@
 
 ### Patch Changes
 
-- [#215](https://github.com/magicbell-io/magicbell-js/pull/215) [`bae9fe9`](https://github.com/magicbell-io/magicbell-js/commit/bae9fe9d9a4c1ff7f49f9d9cee137824ac089abb) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#215](https://github.com/magicbell/magicbell-js/pull/215) [`bae9fe9`](https://github.com/magicbell/magicbell-js/commit/bae9fe9d9a4c1ff7f49f9d9cee137824ac089abb) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/json-schema-merge-allof` to `^0.6.5`.
 
@@ -50,7 +50,7 @@
 
 ### Patch Changes
 
-- [#209](https://github.com/magicbell-io/magicbell-js/pull/209) [`5deb948`](https://github.com/magicbell-io/magicbell-js/commit/5deb94806d5e76f5e387cf6c77c1042770259c2a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#209](https://github.com/magicbell/magicbell-js/pull/209) [`5deb948`](https://github.com/magicbell/magicbell-js/commit/5deb94806d5e76f5e387cf6c77c1042770259c2a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/json-schema-merge-allof` to `^0.6.4`.
 
@@ -58,7 +58,7 @@
 
 ### Patch Changes
 
-- [#181](https://github.com/magicbell-io/magicbell-js/pull/181) [`4bae82e`](https://github.com/magicbell-io/magicbell-js/commit/4bae82e676f88b049243017b9e470cfbeddfb6ad) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#181](https://github.com/magicbell/magicbell-js/pull/181) [`4bae82e`](https://github.com/magicbell/magicbell-js/commit/4bae82e676f88b049243017b9e470cfbeddfb6ad) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/json-schema-merge-allof` to `^0.6.2`.
 
@@ -66,7 +66,7 @@
 
 ### Minor Changes
 
-- [#139](https://github.com/magicbell-io/magicbell-js/pull/139) [`22f7267`](https://github.com/magicbell-io/magicbell-js/commit/22f72679b65405e79a5a4a80d112678c3080ddc5) Thanks [@smeijer](https://github.com/smeijer)! - Small changes to the (internal) codegen package.
+- [#139](https://github.com/magicbell/magicbell-js/pull/139) [`22f7267`](https://github.com/magicbell/magicbell-js/commit/22f72679b65405e79a5a4a80d112678c3080ddc5) Thanks [@smeijer](https://github.com/smeijer)! - Small changes to the (internal) codegen package.
 
   - Fix hyphen-case
   - Don't crash on missing `pagination` properties
@@ -77,13 +77,13 @@
 
 ### Minor Changes
 
-- [#137](https://github.com/magicbell-io/magicbell-js/pull/137) [`8818e8b`](https://github.com/magicbell-io/magicbell-js/commit/8818e8bcefa06081d9a082387f6f18cbc2500dd6) Thanks [@smeijer](https://github.com/smeijer)! - support scenarios where we don't have beta methods
+- [#137](https://github.com/magicbell/magicbell-js/pull/137) [`8818e8b`](https://github.com/magicbell/magicbell-js/commit/8818e8bcefa06081d9a082387f6f18cbc2500dd6) Thanks [@smeijer](https://github.com/smeijer)! - support scenarios where we don't have beta methods
 
 ## 0.0.2
 
 ### Patch Changes
 
-- [`e78af04`](https://github.com/magicbell-io/magicbell-js/commit/e78af04eb97aebffe8fa41e088890364cb5367ad) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`e78af04`](https://github.com/magicbell/magicbell-js/commit/e78af04eb97aebffe8fa41e088890364cb5367ad) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `json5` to `^2.2.3`.
 
@@ -91,4 +91,4 @@
 
 ### Patch Changes
 
-- [#27](https://github.com/magicbell-io/magicbell-js/pull/27) [`bad5f13`](https://github.com/magicbell-io/magicbell-js/commit/bad5f13e9f61c4f4be08d48d84755d87bb0551e5) Thanks [@smeijer](https://github.com/smeijer)! - Extract codegen out of `magicbell` into its own package.
+- [#27](https://github.com/magicbell/magicbell-js/pull/27) [`bad5f13`](https://github.com/magicbell/magicbell-js/commit/bad5f13e9f61c4f4be08d48d84755d87bb0551e5) Thanks [@smeijer](https://github.com/smeijer)! - Extract codegen out of `magicbell` into its own package.

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`40601b6`](https://github.com/magicbell-io/magicbell-js/commit/40601b647b90736f30f6945b5b8c6066f4e26c44) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`40601b6`](https://github.com/magicbell/magicbell-js/commit/40601b647b90736f30f6945b5b8c6066f4e26c44) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `dompurify` to `^3.1.3`.
 
@@ -12,7 +12,7 @@
 
 ### Patch Changes
 
-- [#256](https://github.com/magicbell-io/magicbell-js/pull/256) [`816be82`](https://github.com/magicbell-io/magicbell-js/commit/816be82fc1296f2ee27e2e650a94b04cdc527987) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#256](https://github.com/magicbell/magicbell-js/pull/256) [`816be82`](https://github.com/magicbell/magicbell-js/commit/816be82fc1296f2ee27e2e650a94b04cdc527987) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `dompurify` to `^3.0.11`.
 
@@ -20,11 +20,11 @@
 
 ### Patch Changes
 
-- [#247](https://github.com/magicbell-io/magicbell-js/pull/247) [`9e55676`](https://github.com/magicbell-io/magicbell-js/commit/9e55676f6c252728e941c224f4dd3a486bb646cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#247](https://github.com/magicbell/magicbell-js/pull/247) [`9e55676`](https://github.com/magicbell/magicbell-js/commit/9e55676f6c252728e941c224f4dd3a486bb646cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `axios` to `^0.28.0`.
 
-- [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tslib` to `^2.6.2`.
 
@@ -32,7 +32,7 @@
 
 ### Patch Changes
 
-- [`f3c4ce3`](https://github.com/magicbell-io/magicbell-js/commit/f3c4ce30b65352e3ae312faedf04ad8a05a66c1b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`f3c4ce3`](https://github.com/magicbell/magicbell-js/commit/f3c4ce30b65352e3ae312faedf04ad8a05a66c1b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `ably` to `^1.2.48`.
 
@@ -40,15 +40,15 @@
 
 ### Patch Changes
 
-- [#216](https://github.com/magicbell-io/magicbell-js/pull/216) [`6b97a7c`](https://github.com/magicbell-io/magicbell-js/commit/6b97a7c6076185c9e8f995745a69f3c5da5952b1) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#216](https://github.com/magicbell/magicbell-js/pull/216) [`6b97a7c`](https://github.com/magicbell/magicbell-js/commit/6b97a7c6076185c9e8f995745a69f3c5da5952b1) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `miragejs` to `^0.1.48`.
 
-- [`9be10f5`](https://github.com/magicbell-io/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`9be10f5`](https://github.com/magicbell/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.202`.
 
-- [`d29b034`](https://github.com/magicbell-io/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d29b034`](https://github.com/magicbell/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `rosie` to `^2.1.1`.
 
@@ -56,15 +56,15 @@
 
 ### Patch Changes
 
-- [#210](https://github.com/magicbell-io/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell-io/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#210](https://github.com/magicbell/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.45`.
 
-- [`d199c74`](https://github.com/magicbell-io/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d199c74`](https://github.com/magicbell/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.201`.
 
-- [`8649613`](https://github.com/magicbell-io/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`8649613`](https://github.com/magicbell/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.20`.
 
@@ -72,7 +72,7 @@
 
 ### Patch Changes
 
-- [#191](https://github.com/magicbell-io/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell-io/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#191](https://github.com/magicbell/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.43`.
 
@@ -80,7 +80,7 @@
 
 ### Patch Changes
 
-- [#188](https://github.com/magicbell-io/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell-io/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#188](https://github.com/magicbell/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.10`.
 
@@ -88,31 +88,31 @@
 
 ### Patch Changes
 
-- [`0a40f2d`](https://github.com/magicbell-io/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`0a40f2d`](https://github.com/magicbell/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.198`.
 
-- [`ffb1b21`](https://github.com/magicbell-io/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`ffb1b21`](https://github.com/magicbell/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `sinon` to `^13.0.2`.
 
-- [#183](https://github.com/magicbell-io/magicbell-js/pull/183) [`e1e7518`](https://github.com/magicbell-io/magicbell-js/commit/e1e7518564378b39a5bc2848d329f7f4236b2ea3) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#183](https://github.com/magicbell/magicbell-js/pull/183) [`e1e7518`](https://github.com/magicbell/magicbell-js/commit/e1e7518564378b39a5bc2848d329f7f4236b2ea3) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `miragejs` to `^0.1.47`.
 
-- [`f83b52c`](https://github.com/magicbell-io/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`f83b52c`](https://github.com/magicbell/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `mitt` to `^3.0.1`.
 
-- [#179](https://github.com/magicbell-io/magicbell-js/pull/179) [`cda7f21`](https://github.com/magicbell-io/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#179](https://github.com/magicbell/magicbell-js/pull/179) [`cda7f21`](https://github.com/magicbell/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `ably` to `^1.2.44`.
 
-- [`0b63278`](https://github.com/magicbell-io/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`0b63278`](https://github.com/magicbell/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.16`.
 
-- [`5088009`](https://github.com/magicbell-io/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`5088009`](https://github.com/magicbell/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.9`.
 
@@ -120,7 +120,7 @@
 
 ### Patch Changes
 
-- [#153](https://github.com/magicbell-io/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell-io/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#153](https://github.com/magicbell/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.195`.
 
@@ -128,11 +128,11 @@
 
 ### Patch Changes
 
-- [#113](https://github.com/magicbell-io/magicbell-js/pull/113) [`6e5297e`](https://github.com/magicbell-io/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#113](https://github.com/magicbell/magicbell-js/pull/113) [`6e5297e`](https://github.com/magicbell/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.15`.
 
-- [#111](https://github.com/magicbell-io/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell-io/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#111](https://github.com/magicbell/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.194`.
 
@@ -140,4 +140,4 @@
 
 ### Patch Changes
 
-- [`fbbbae7`](https://github.com/magicbell-io/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529) Thanks [@smeijer](https://github.com/smeijer)! - deps: bump ably to 1.2.39 to fix CVE-2022-33987
+- [`fbbbae7`](https://github.com/magicbell/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529) Thanks [@smeijer](https://github.com/smeijer)! - deps: bump ably to 1.2.39 to fix CVE-2022-33987

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/magicbell-io/magicbell-node/branch/main/graph/badge.svg?token=Z2EV4QVGHY)](https://codecov.io/gh/magicbell-io/magicbell-node)
+[![codecov](https://codecov.io/gh/magicbell/magicbell-node/branch/main/graph/badge.svg?token=Z2EV4QVGHY)](https://codecov.io/gh/magicbell/magicbell-node)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![minified](https://badgen.net/bundlephobia/min/@magicbell/core@latest)](https://bundlephobia.com/result?p=@magicbell/core)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "keywords": [
     "bell",
@@ -63,6 +63,6 @@
   ],
   "homepage": "https://magicbell.com",
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   }
 }

--- a/packages/embeddable/CHANGELOG.md
+++ b/packages/embeddable/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Patch Changes
 
-- [`11c30e6`](https://github.com/magicbell-io/magicbell-js/commit/11c30e655051c2e2f22ac818b9a20abf260ec7eb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`11c30e6`](https://github.com/magicbell/magicbell-js/commit/11c30e655051c2e2f22ac818b9a20abf260ec7eb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `preact` to `^10.22.0`.
 
@@ -36,15 +36,15 @@
 
 ### Patch Changes
 
-- [#264](https://github.com/magicbell-io/magicbell-js/pull/264) [`2901123`](https://github.com/magicbell-io/magicbell-js/commit/290112311c1a1b4f5b17eecb566c6be74b4cca4e) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#264](https://github.com/magicbell/magicbell-js/pull/264) [`2901123`](https://github.com/magicbell/magicbell-js/commit/290112311c1a1b4f5b17eecb566c6be74b4cca4e) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `idb` to `^8.0.0`.
 
-- [`50551c9`](https://github.com/magicbell-io/magicbell-js/commit/50551c90eb0ad113cdcace75ee04550d07740972) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`50551c9`](https://github.com/magicbell/magicbell-js/commit/50551c90eb0ad113cdcace75ee04550d07740972) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `preact` to `^10.20.1`.
 
-- Updated dependencies [[`7e918d9`](https://github.com/magicbell-io/magicbell-js/commit/7e918d9a609c6300425cd87866db31dfe3e4e937)]:
+- Updated dependencies [[`7e918d9`](https://github.com/magicbell/magicbell-js/commit/7e918d9a609c6300425cd87866db31dfe3e4e937)]:
   - @magicbell/magicbell-react@10.11.0
 
 ## 3.3.18
@@ -65,85 +65,85 @@
 
 ### Patch Changes
 
-- [`772bd16`](https://github.com/magicbell-io/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`772bd16`](https://github.com/magicbell/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@emotion/cache` to `^11.11.0`.
   - updated `@emotion/react` to `^11.11.3`.
 
-- [`805c275`](https://github.com/magicbell-io/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`805c275`](https://github.com/magicbell/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.5.0`.
 
-- [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tslib` to `^2.6.2`.
 
-- Updated dependencies [[`00451d2`](https://github.com/magicbell-io/magicbell-js/commit/00451d2d23cad54480f93ad8e3968921fd491559), [`772bd16`](https://github.com/magicbell-io/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489), [`805c275`](https://github.com/magicbell-io/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca), [`ce7bc6f`](https://github.com/magicbell-io/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079), [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591)]:
+- Updated dependencies [[`00451d2`](https://github.com/magicbell/magicbell-js/commit/00451d2d23cad54480f93ad8e3968921fd491559), [`772bd16`](https://github.com/magicbell/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489), [`805c275`](https://github.com/magicbell/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca), [`ce7bc6f`](https://github.com/magicbell/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079), [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591)]:
   - @magicbell/magicbell-react@10.10.0
 
 ## 3.3.15
 
 ### Patch Changes
 
-- [`a344f04`](https://github.com/magicbell-io/magicbell-js/commit/a344f04f859d6054c55888be14477201f3b1fe29) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`a344f04`](https://github.com/magicbell/magicbell-js/commit/a344f04f859d6054c55888be14477201f3b1fe29) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `preact` to `^10.19.2`.
 
-- [`681ed7b`](https://github.com/magicbell-io/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`681ed7b`](https://github.com/magicbell/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.2`.
 
-- Updated dependencies [[`681ed7b`](https://github.com/magicbell-io/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558), [`fdb6953`](https://github.com/magicbell-io/magicbell-js/commit/fdb695389abc7c881518ea746ad55e84cc90f83d)]:
+- Updated dependencies [[`681ed7b`](https://github.com/magicbell/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558), [`fdb6953`](https://github.com/magicbell/magicbell-js/commit/fdb695389abc7c881518ea746ad55e84cc90f83d)]:
   - @magicbell/magicbell-react@10.9.11
 
 ## 3.3.14
 
 ### Patch Changes
 
-- [`59f5479`](https://github.com/magicbell-io/magicbell-js/commit/59f5479e029ec8886d42a7554526522f5e54c491) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`59f5479`](https://github.com/magicbell/magicbell-js/commit/59f5479e029ec8886d42a7554526522f5e54c491) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `start-server-and-test` to `^1.15.4`.
 
-- [`41b577c`](https://github.com/magicbell-io/magicbell-js/commit/41b577c21ce516ad199a27f3fdf290e9f1e52d8c) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`41b577c`](https://github.com/magicbell/magicbell-js/commit/41b577c21ce516ad199a27f3fdf290e9f1e52d8c) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `cypress` to `8.7.0`.
 
-- [`ab7782a`](https://github.com/magicbell-io/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`ab7782a`](https://github.com/magicbell/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.1`.
 
-- [`1941a44`](https://github.com/magicbell-io/magicbell-js/commit/1941a443adc84c3286b45f497262729ca6f1dc57) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`1941a44`](https://github.com/magicbell/magicbell-js/commit/1941a443adc84c3286b45f497262729ca6f1dc57) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `node` to `>=12.22.12`.
 
-- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`aa44b32`](https://github.com/magicbell-io/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe), [`ec0fb02`](https://github.com/magicbell-io/magicbell-js/commit/ec0fb023e9c59452f5c05d9c1254b764aef98b21), [`184de06`](https://github.com/magicbell-io/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb), [`7dbb225`](https://github.com/magicbell-io/magicbell-js/commit/7dbb225f654995e04eaacce6d67105f825f53857), [`ab7782a`](https://github.com/magicbell-io/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639)]:
+- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`aa44b32`](https://github.com/magicbell/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe), [`ec0fb02`](https://github.com/magicbell/magicbell-js/commit/ec0fb023e9c59452f5c05d9c1254b764aef98b21), [`184de06`](https://github.com/magicbell/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb), [`7dbb225`](https://github.com/magicbell/magicbell-js/commit/7dbb225f654995e04eaacce6d67105f825f53857), [`ab7782a`](https://github.com/magicbell/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639)]:
   - @magicbell/magicbell-react@10.9.10
 
 ## 3.3.13
 
 ### Patch Changes
 
-- Updated dependencies [[`9be10f5`](https://github.com/magicbell-io/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b), [`d29b034`](https://github.com/magicbell-io/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff)]:
+- Updated dependencies [[`9be10f5`](https://github.com/magicbell/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b), [`d29b034`](https://github.com/magicbell/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff)]:
   - @magicbell/magicbell-react@10.9.9
 
 ## 3.3.12
 
 ### Patch Changes
 
-- Updated dependencies [[`9280ca7`](https://github.com/magicbell-io/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656), [`d199c74`](https://github.com/magicbell-io/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9), [`8649613`](https://github.com/magicbell-io/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d)]:
+- Updated dependencies [[`9280ca7`](https://github.com/magicbell/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656), [`d199c74`](https://github.com/magicbell/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9), [`8649613`](https://github.com/magicbell/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d)]:
   - @magicbell/magicbell-react@10.9.8
 
 ## 3.3.11
 
 ### Patch Changes
 
-- [#203](https://github.com/magicbell-io/magicbell-js/pull/203) [`de1be86`](https://github.com/magicbell-io/magicbell-js/commit/de1be86da8aad45ae4b9689ee9bffb85103f39ec) Thanks [@smeijer](https://github.com/smeijer)! - rotate rollbar token
+- [#203](https://github.com/magicbell/magicbell-js/pull/203) [`de1be86`](https://github.com/magicbell/magicbell-js/commit/de1be86da8aad45ae4b9689ee9bffb85103f39ec) Thanks [@smeijer](https://github.com/smeijer)! - rotate rollbar token
 
-- [#206](https://github.com/magicbell-io/magicbell-js/pull/206) [`22a17bb`](https://github.com/magicbell-io/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#206](https://github.com/magicbell/magicbell-js/pull/206) [`22a17bb`](https://github.com/magicbell/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.0`.
 
-- Updated dependencies [[`22a17bb`](https://github.com/magicbell-io/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5), [`f694679`](https://github.com/magicbell-io/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8), [`430ea0b`](https://github.com/magicbell-io/magicbell-js/commit/430ea0b48adf863a8a1abd19cc5575bb5397624c)]:
+- Updated dependencies [[`22a17bb`](https://github.com/magicbell/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5), [`f694679`](https://github.com/magicbell/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8), [`430ea0b`](https://github.com/magicbell/magicbell-js/commit/430ea0b48adf863a8a1abd19cc5575bb5397624c)]:
   - @magicbell/magicbell-react@10.9.7
 
 ## 3.3.10
@@ -164,14 +164,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`9c30c22`](https://github.com/magicbell-io/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d)]:
+- Updated dependencies [[`9c30c22`](https://github.com/magicbell/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d)]:
   - @magicbell/magicbell-react@10.9.4
 
 ## 3.3.7
 
 ### Patch Changes
 
-- Updated dependencies [[`12dbaed`](https://github.com/magicbell-io/magicbell-js/commit/12dbaed2ce4d8b19d7090b568a1ce0e9e510b1e6)]:
+- Updated dependencies [[`12dbaed`](https://github.com/magicbell/magicbell-js/commit/12dbaed2ce4d8b19d7090b568a1ce0e9e510b1e6)]:
   - @magicbell/magicbell-react@10.9.3
 
 ## 3.3.6
@@ -185,29 +185,29 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c6054af`](https://github.com/magicbell-io/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
+- Updated dependencies [[`c6054af`](https://github.com/magicbell/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
   - @magicbell/magicbell-react@10.9.1
 
 ## 3.3.4
 
 ### Patch Changes
 
-- Updated dependencies [[`78b62cb`](https://github.com/magicbell-io/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8), [`f12d410`](https://github.com/magicbell-io/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a)]:
+- Updated dependencies [[`78b62cb`](https://github.com/magicbell/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8), [`f12d410`](https://github.com/magicbell/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a)]:
   - @magicbell/magicbell-react@10.9.0
 
 ## 3.3.3
 
 ### Patch Changes
 
-- [`a6d54b5`](https://github.com/magicbell-io/magicbell-js/commit/a6d54b5e47fea0b41e3ee1a02926bc7e15849ec1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`a6d54b5`](https://github.com/magicbell/magicbell-js/commit/a6d54b5e47fea0b41e3ee1a02926bc7e15849ec1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-frame-component` to `^5.2.6`.
 
-- [`47b6dde`](https://github.com/magicbell-io/magicbell-js/commit/47b6ddeafe6b77a4457a17aecffa963b9c127b47) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`47b6dde`](https://github.com/magicbell/magicbell-js/commit/47b6ddeafe6b77a4457a17aecffa963b9c127b47) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `error-stack-parser` to `^2.1.4`.
 
-- Updated dependencies [[`79d3019`](https://github.com/magicbell-io/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49), [`0a40f2d`](https://github.com/magicbell-io/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2), [`ffb1b21`](https://github.com/magicbell-io/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68), [`39ad36e`](https://github.com/magicbell-io/magicbell-js/commit/39ad36ed59f0949f7b06810534560a61e27f3d25), [`0b63278`](https://github.com/magicbell-io/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3), [`5088009`](https://github.com/magicbell-io/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d)]:
+- Updated dependencies [[`79d3019`](https://github.com/magicbell/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49), [`0a40f2d`](https://github.com/magicbell/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2), [`ffb1b21`](https://github.com/magicbell/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68), [`39ad36e`](https://github.com/magicbell/magicbell-js/commit/39ad36ed59f0949f7b06810534560a61e27f3d25), [`0b63278`](https://github.com/magicbell/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3), [`5088009`](https://github.com/magicbell/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d)]:
   - @magicbell/magicbell-react@10.8.3
 
 ## 3.3.2
@@ -228,25 +228,25 @@
 
 ### Minor Changes
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
 
 ### Patch Changes
 
-- Updated dependencies [[`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5)]:
+- Updated dependencies [[`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5)]:
   - @magicbell/magicbell-react@10.8.0
 
 ## 3.2.18
 
 ### Patch Changes
 
-- Updated dependencies [[`cb7c02a`](https://github.com/magicbell-io/magicbell-js/commit/cb7c02aaf3f1f22e43367b3a10e29393a36827a6)]:
+- Updated dependencies [[`cb7c02a`](https://github.com/magicbell/magicbell-js/commit/cb7c02aaf3f1f22e43367b3a10e29393a36827a6)]:
   - @magicbell/magicbell-react@10.7.5
 
 ## 3.2.17
 
 ### Patch Changes
 
-- Updated dependencies [[`6aa5cee`](https://github.com/magicbell-io/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8)]:
+- Updated dependencies [[`6aa5cee`](https://github.com/magicbell/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8)]:
   - @magicbell/magicbell-react@10.7.4
 
 ## 3.2.16
@@ -260,28 +260,28 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`6e5297e`](https://github.com/magicbell-io/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80), [`8987a92`](https://github.com/magicbell-io/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716), [`9e98288`](https://github.com/magicbell-io/magicbell-js/commit/9e982889f37e70702f24dcc87296406d25623a8c)]:
+- Updated dependencies [[`6e5297e`](https://github.com/magicbell/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80), [`8987a92`](https://github.com/magicbell/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716), [`9e98288`](https://github.com/magicbell/magicbell-js/commit/9e982889f37e70702f24dcc87296406d25623a8c)]:
   - @magicbell/magicbell-react@10.7.2
 
 ## 3.2.14
 
 ### Patch Changes
 
-- Updated dependencies [[`eb256a1`](https://github.com/magicbell-io/magicbell-js/commit/eb256a1d0bc11f628975d5ce1e40e20c97fc0d47)]:
+- Updated dependencies [[`eb256a1`](https://github.com/magicbell/magicbell-js/commit/eb256a1d0bc11f628975d5ce1e40e20c97fc0d47)]:
   - @magicbell/magicbell-react@10.7.1
 
 ## 3.2.13
 
 ### Patch Changes
 
-- Updated dependencies [[`e83a694`](https://github.com/magicbell-io/magicbell-js/commit/e83a694e3f681e3edd6aeb7708e430811e14bc15)]:
+- Updated dependencies [[`e83a694`](https://github.com/magicbell/magicbell-js/commit/e83a694e3f681e3edd6aeb7708e430811e14bc15)]:
   - @magicbell/magicbell-react@10.7.0
 
 ## 3.2.12
 
 ### Patch Changes
 
-- Updated dependencies [[`7f9ecbc`](https://github.com/magicbell-io/magicbell-js/commit/7f9ecbc3594af2035b4fa063adc593a7fe4c722c)]:
+- Updated dependencies [[`7f9ecbc`](https://github.com/magicbell/magicbell-js/commit/7f9ecbc3594af2035b4fa063adc593a7fe4c722c)]:
   - @magicbell/magicbell-react@10.6.0
 
 ## 3.2.11
@@ -302,61 +302,61 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`2d96a3d`](https://github.com/magicbell-io/magicbell-js/commit/2d96a3d5426f62dd3a89c286f0c6c2d7195de612)]:
+- Updated dependencies [[`2d96a3d`](https://github.com/magicbell/magicbell-js/commit/2d96a3d5426f62dd3a89c286f0c6c2d7195de612)]:
   - @magicbell/magicbell-react@10.5.0
 
 ## 3.2.8
 
 ### Patch Changes
 
-- Updated dependencies [[`4347cf3`](https://github.com/magicbell-io/magicbell-js/commit/4347cf322d7b057769771fd3f06dad60b98d18aa)]:
+- Updated dependencies [[`4347cf3`](https://github.com/magicbell/magicbell-js/commit/4347cf322d7b057769771fd3f06dad60b98d18aa)]:
   - @magicbell/magicbell-react@10.4.0
 
 ## 3.2.7
 
 ### Patch Changes
 
-- Updated dependencies [[`017b0cd`](https://github.com/magicbell-io/magicbell-js/commit/017b0cd52ed004de24d98d3a99ac5503031d4e66)]:
+- Updated dependencies [[`017b0cd`](https://github.com/magicbell/magicbell-js/commit/017b0cd52ed004de24d98d3a99ac5503031d4e66)]:
   - @magicbell/magicbell-react@10.3.5
 
 ## 3.2.6
 
 ### Patch Changes
 
-- [#33](https://github.com/magicbell-io/magicbell-js/pull/33) [`c2eb349`](https://github.com/magicbell-io/magicbell-js/commit/c2eb349734f659e237ce9984414dd44acf98c19c) Thanks [@smeijer](https://github.com/smeijer)! - Declare widget `theme` and `store` props as optional.
+- [#33](https://github.com/magicbell/magicbell-js/pull/33) [`c2eb349`](https://github.com/magicbell/magicbell-js/commit/c2eb349734f659e237ce9984414dd44acf98c19c) Thanks [@smeijer](https://github.com/smeijer)! - Declare widget `theme` and `store` props as optional.
 
 ## 3.2.5
 
 ### Patch Changes
 
-- Updated dependencies [[`2f295b0`](https://github.com/magicbell-io/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7)]:
+- Updated dependencies [[`2f295b0`](https://github.com/magicbell/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7)]:
   - @magicbell/magicbell-react@10.3.4
 
 ## 3.2.4
 
 ### Patch Changes
 
-- [#15](https://github.com/magicbell-io/magicbell-js/pull/15) [`7767b69`](https://github.com/magicbell-io/magicbell-js/commit/7767b69ed20539c4ccf2ba7cdc53bd5783a36d12) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the minified esm bundle is imported when importing from unpkg.
+- [#15](https://github.com/magicbell/magicbell-js/pull/15) [`7767b69`](https://github.com/magicbell/magicbell-js/commit/7767b69ed20539c4ccf2ba7cdc53bd5783a36d12) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the minified esm bundle is imported when importing from unpkg.
 
-- Updated dependencies [[`1cb984c`](https://github.com/magicbell-io/magicbell-js/commit/1cb984cfac485254c286385d8a750bc3c62cfbbb)]:
+- Updated dependencies [[`1cb984c`](https://github.com/magicbell/magicbell-js/commit/1cb984cfac485254c286385d8a750bc3c62cfbbb)]:
   - @magicbell/magicbell-react@10.3.3
 
 ## 3.2.3
 
 ### Patch Changes
 
-- Updated dependencies [[`08f4abb`](https://github.com/magicbell-io/magicbell-js/commit/08f4abb6605de603688e970c49218e5aa41ebc08)]:
+- Updated dependencies [[`08f4abb`](https://github.com/magicbell/magicbell-js/commit/08f4abb6605de603688e970c49218e5aa41ebc08)]:
   - @magicbell/magicbell-react@10.3.2
 
 ## 3.2.2
 
 ### Patch Changes
 
-- [`bae93af`](https://github.com/magicbell-io/magicbell-js/commit/bae93af0f4720888c30206b4fb302b28320a3841) Thanks [@smeijer](https://github.com/smeijer)! - treeshake process.env.NODE_ENV checks from minified builds.
+- [`bae93af`](https://github.com/magicbell/magicbell-js/commit/bae93af0f4720888c30206b4fb302b28320a3841) Thanks [@smeijer](https://github.com/smeijer)! - treeshake process.env.NODE_ENV checks from minified builds.
 
 ## 3.2.1
 
 ### Patch Changes
 
-- Updated dependencies [[`36d7ef7`](https://github.com/magicbell-io/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5)]:
+- Updated dependencies [[`36d7ef7`](https://github.com/magicbell/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5)]:
   - @magicbell/magicbell-react@10.3.1

--- a/packages/embeddable/README.md
+++ b/packages/embeddable/README.md
@@ -4,7 +4,7 @@ This package contains a notification inbox for your site powered by [MagicBell](
 
 > **Note**
 >
-> Don't use this package when you're using React. Use [@magicbell/magicbell-react](https://github.com/magicbell-io/magicbell-js/tree/main/packages/react) or [@magicbell/react-headless](https://github.com/magicbell-io/magicbell-js/tree/main/packages/react-headless) instead.
+> Don't use this package when you're using React. Use [@magicbell/magicbell-react](https://github.com/magicbell/magicbell-js/tree/main/packages/react) or [@magicbell/react-headless](https://github.com/magicbell/magicbell-js/tree/main/packages/react-headless) instead.
 
 ## Quick Start
 

--- a/packages/embeddable/package.json
+++ b/packages/embeddable/package.json
@@ -6,7 +6,7 @@
   "esmodule": "dist/magicbell.esm.js",
   "module": "dist/magicbell.esm.js",
   "unpkg": "dist/magicbell.esm.min.js",
-  "repository": "git@github.com:magicbell-io/embeddable-web.git",
+  "repository": "git@github.com:magicbell/embeddable-web.git",
   "author": "MagicBell <bot@magicbell.io> (https://magicbell.com/)",
   "contributors": [
     "Josue Montano <josuemontanoa@gmail.com>",

--- a/packages/magicbell/CHANGELOG.md
+++ b/packages/magicbell/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Patch Changes
 
-- [#281](https://github.com/magicbell-io/magicbell-js/pull/281) [`c16e604`](https://github.com/magicbell-io/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#281](https://github.com/magicbell/magicbell-js/pull/281) [`c16e604`](https://github.com/magicbell/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `json-schema-to-ts` to `3.1.0`.
 
@@ -18,21 +18,21 @@
 
 ### Patch Changes
 
-- [#265](https://github.com/magicbell-io/magicbell-js/pull/265) [`3982658`](https://github.com/magicbell-io/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60) Thanks [@smeijer](https://github.com/smeijer)! - Don't mix headers for different authentication scopes.
+- [#265](https://github.com/magicbell/magicbell-js/pull/265) [`3982658`](https://github.com/magicbell/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60) Thanks [@smeijer](https://github.com/smeijer)! - Don't mix headers for different authentication scopes.
 
 ## 3.1.2
 
 ### Patch Changes
 
-- [#259](https://github.com/magicbell-io/magicbell-js/pull/259) [`30ed933`](https://github.com/magicbell-io/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245) Thanks [@smeijer](https://github.com/smeijer)! - Only include `user-email` header when no `external-id` is provided
+- [#259](https://github.com/magicbell/magicbell-js/pull/259) [`30ed933`](https://github.com/magicbell/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245) Thanks [@smeijer](https://github.com/smeijer)! - Only include `user-email` header when no `external-id` is provided
 
 ## 3.1.1
 
 ### Patch Changes
 
-- [#242](https://github.com/magicbell-io/magicbell-js/pull/242) [`840263b`](https://github.com/magicbell-io/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675) Thanks [@smeijer](https://github.com/smeijer)! - use `eventSource.addEventListener` instead of `eventSource.onmessage` to maximize compatibility with different environments.
+- [#242](https://github.com/magicbell/magicbell-js/pull/242) [`840263b`](https://github.com/magicbell/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675) Thanks [@smeijer](https://github.com/smeijer)! - use `eventSource.addEventListener` instead of `eventSource.onmessage` to maximize compatibility with different environments.
 
-- [`aee799d`](https://github.com/magicbell-io/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`aee799d`](https://github.com/magicbell/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `json-schema-to-ts` to `2.12.0`.
 
@@ -40,7 +40,7 @@
 
 ### Minor Changes
 
-- [#233](https://github.com/magicbell-io/magicbell-js/pull/233) [`8bee76e`](https://github.com/magicbell-io/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e) Thanks [@smeijer](https://github.com/smeijer)! - Add support for nested paths in `host` option.
+- [#233](https://github.com/magicbell/magicbell-js/pull/233) [`8bee76e`](https://github.com/magicbell/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e) Thanks [@smeijer](https://github.com/smeijer)! - Add support for nested paths in `host` option.
 
   ```ts
   import { ProjectClient } from 'magicbell/project-client';
@@ -54,7 +54,7 @@
 
 ### Patch Changes
 
-- [`1041cdf`](https://github.com/magicbell-io/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`1041cdf`](https://github.com/magicbell/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `json-schema-to-ts` to `2.9.2`.
 
@@ -62,19 +62,19 @@
 
 ### Patch Changes
 
-- [`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@size-limit/preset-small-lib` to `^8.2.6`.
 
-- [`5a3443f`](https://github.com/magicbell-io/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`5a3443f`](https://github.com/magicbell/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `openapi-types` to `^12.1.3`.
 
-- [`33d2cab`](https://github.com/magicbell-io/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`33d2cab`](https://github.com/magicbell/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tsx` to `^3.14.0`.
 
-- [#222](https://github.com/magicbell-io/magicbell-js/pull/222) [`444e653`](https://github.com/magicbell-io/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#222](https://github.com/magicbell/magicbell-js/pull/222) [`444e653`](https://github.com/magicbell/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `recast` to `^0.23.4`.
 
@@ -82,11 +82,11 @@
 
 ### Major Changes
 
-- [#208](https://github.com/magicbell-io/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - We've removed `magicbell.notifications.create`, please use `magicbell.broadcasts.create` instead.
+- [#208](https://github.com/magicbell/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - We've removed `magicbell.notifications.create`, please use `magicbell.broadcasts.create` instead.
 
 ### Minor Changes
 
-- [#208](https://github.com/magicbell-io/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - Add `broadcasts.create` method to the project client.
+- [#208](https://github.com/magicbell/magicbell-js/pull/208) [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722) Thanks [@smeijer](https://github.com/smeijer)! - Add `broadcasts.create` method to the project client.
 
   ```js
   await magicbell.broadcasts.create({
@@ -117,13 +117,13 @@
 
 ### Patch Changes
 
-- [#201](https://github.com/magicbell-io/magicbell-js/pull/201) [`5c8f4c9`](https://github.com/magicbell-io/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c) Thanks [@smeijer](https://github.com/smeijer)! - ensure request uses custom timeout
+- [#201](https://github.com/magicbell/magicbell-js/pull/201) [`5c8f4c9`](https://github.com/magicbell/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c) Thanks [@smeijer](https://github.com/smeijer)! - ensure request uses custom timeout
 
 ## 2.4.0
 
 ### Minor Changes
 
-- [#192](https://github.com/magicbell-io/magicbell-js/pull/192) [`725ab1a`](https://github.com/magicbell-io/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e) Thanks [@smeijer](https://github.com/smeijer)! - Custom errors now include a `responseBody` property that holds the returned response
+- [#192](https://github.com/magicbell/magicbell-js/pull/192) [`725ab1a`](https://github.com/magicbell/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e) Thanks [@smeijer](https://github.com/smeijer)! - Custom errors now include a `responseBody` property that holds the returned response
   from the API, when available. Custom errors are now also exported so they can be
   used with comparisons like `err instanceof MagicBellError`. Note that all errors
   extend the `MagicBellError` base class.
@@ -140,25 +140,25 @@
 
 ### Patch Changes
 
-- [#189](https://github.com/magicbell-io/magicbell-js/pull/189) [`c6054af`](https://github.com/magicbell-io/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043) Thanks [@smeijer](https://github.com/smeijer)! - support react strict mode
+- [#189](https://github.com/magicbell/magicbell-js/pull/189) [`c6054af`](https://github.com/magicbell/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043) Thanks [@smeijer](https://github.com/smeijer)! - support react strict mode
 
 ## 2.3.0
 
 ### Minor Changes
 
-- [#182](https://github.com/magicbell-io/magicbell-js/pull/182) [`3f7ab5a`](https://github.com/magicbell-io/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca) Thanks [@smeijer](https://github.com/smeijer)! - move uuidv4 helper function to different file for better tree shaking
+- [#182](https://github.com/magicbell/magicbell-js/pull/182) [`3f7ab5a`](https://github.com/magicbell/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca) Thanks [@smeijer](https://github.com/smeijer)! - move uuidv4 helper function to different file for better tree shaking
 
 ## 2.2.0
 
 ### Minor Changes
 
-- [#173](https://github.com/magicbell-io/magicbell-js/pull/173) [`1f40263`](https://github.com/magicbell-io/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858) Thanks [@smeijer](https://github.com/smeijer)! - Remove [EventSource](https://www.npmjs.com/package/eventsource) polyfill to avoid bundling it in the browser SDKs. If you're using the `listen` methods in an environment that does not support `eventsource`, you'll need to include the polyfill yourself.
+- [#173](https://github.com/magicbell/magicbell-js/pull/173) [`1f40263`](https://github.com/magicbell/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858) Thanks [@smeijer](https://github.com/smeijer)! - Remove [EventSource](https://www.npmjs.com/package/eventsource) polyfill to avoid bundling it in the browser SDKs. If you're using the `listen` methods in an environment that does not support `eventsource`, you'll need to include the polyfill yourself.
 
 ## 2.1.0
 
 ### Minor Changes
 
-- [#171](https://github.com/magicbell-io/magicbell-js/pull/171) [`666d2bb`](https://github.com/magicbell-io/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248) Thanks [@smeijer](https://github.com/smeijer)! - We've added a method to the `UserClient` to list the registered push notifications for the authenticated user.
+- [#171](https://github.com/magicbell/magicbell-js/pull/171) [`666d2bb`](https://github.com/magicbell/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248) Thanks [@smeijer](https://github.com/smeijer)! - We've added a method to the `UserClient` to list the registered push notifications for the authenticated user.
 
   ```js
   const magicbell = new UserClient({ ... });
@@ -169,7 +169,7 @@
 
 ### Patch Changes
 
-- [#165](https://github.com/magicbell-io/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - Optional client options can now be `undefined` or `null`, rather than enforced to be absent. This eases initialization where options come from other configuration sources.
+- [#165](https://github.com/magicbell/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - Optional client options can now be `undefined` or `null`, rather than enforced to be absent. This eases initialization where options come from other configuration sources.
 
   ```ts
   const client = new UserClient({
@@ -179,35 +179,35 @@
   });
   ```
 
-- [#172](https://github.com/magicbell-io/magicbell-js/pull/172) [`24c00f4`](https://github.com/magicbell-io/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68) Thanks [@smeijer](https://github.com/smeijer)! - Fixed a few misconfigured types:
+- [#172](https://github.com/magicbell/magicbell-js/pull/172) [`24c00f4`](https://github.com/magicbell/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68) Thanks [@smeijer](https://github.com/smeijer)! - Fixed a few misconfigured types:
 
   - import `status` is now an enum with the values `enqueued | processing | processed`
   - import `failures` now has the users array items typed as `object` with the properties `email` and `external_id` and `errors`
   - the `total` and `total_pages` props are removed from the `users.pushSubscriptions.list` response.
 
-- [#165](https://github.com/magicbell-io/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - The EventSource polyfill is now only applied when the `EventSource` is not supported in your environment.
+- [#165](https://github.com/magicbell/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - The EventSource polyfill is now only applied when the `EventSource` is not supported in your environment.
 
-- [#165](https://github.com/magicbell-io/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - A bug where the eventsource was closed before opened is now fixed. This race condition occurred when closing the stream while the token request was still pending.
+- [#165](https://github.com/magicbell/magicbell-js/pull/165) [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa) Thanks [@smeijer](https://github.com/smeijer)! - A bug where the eventsource was closed before opened is now fixed. This race condition occurred when closing the stream while the token request was still pending.
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - don't throw on empty response
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - don't throw on empty response
 
 ## 2.0.2
 
 ### Patch Changes
 
-- [#161](https://github.com/magicbell-io/magicbell-js/pull/161) [`4ef2b07`](https://github.com/magicbell-io/magicbell-js/commit/4ef2b07e31922ebe83a443b1732390b79b7af141) Thanks [@smeijer](https://github.com/smeijer)! - Use a fork of ky that includes commonjs support
+- [#161](https://github.com/magicbell/magicbell-js/pull/161) [`4ef2b07`](https://github.com/magicbell/magicbell-js/commit/4ef2b07e31922ebe83a443b1732390b79b7af141) Thanks [@smeijer](https://github.com/smeijer)! - Use a fork of ky that includes commonjs support
 
 ## 2.0.1
 
 ### Patch Changes
 
-- [#156](https://github.com/magicbell-io/magicbell-js/pull/156) [`16016dc`](https://github.com/magicbell-io/magicbell-js/commit/16016dc5d3cd69d86c28e3e9920fe8e41e123406) Thanks [@smeijer](https://github.com/smeijer)! - declare exports in package.json
+- [#156](https://github.com/magicbell/magicbell-js/pull/156) [`16016dc`](https://github.com/magicbell/magicbell-js/commit/16016dc5d3cd69d86c28e3e9920fe8e41e123406) Thanks [@smeijer](https://github.com/smeijer)! - declare exports in package.json
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#154](https://github.com/magicbell-io/magicbell-js/pull/154) [`da22233`](https://github.com/magicbell-io/magicbell-js/commit/da22233fca83398cc33e4732172eebde96ad1140) Thanks [@smeijer](https://github.com/smeijer)! - **Breaking Changes** - please read carefully.
+- [#154](https://github.com/magicbell/magicbell-js/pull/154) [`da22233`](https://github.com/magicbell/magicbell-js/commit/da22233fca83398cc33e4732172eebde96ad1140) Thanks [@smeijer](https://github.com/smeijer)! - **Breaking Changes** - please read carefully.
 
   We've separated the project from user resources. There are now two API clients exposed that can be used independently. A `ProjectClient` and a `UserClient`.
 
@@ -276,7 +276,7 @@
   const userHmac = createHmac('secret-key', { email: 'value' });
   ```
 
-- [#152](https://github.com/magicbell-io/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell-io/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We're now using [ky] instead of [axios] for making HTTP requests. This is a breaking change, as ky is build around the fetch module. Fetch is natively supported in all modern browsers, and is also available in Node.js since version 18.13.0.
+- [#152](https://github.com/magicbell/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We're now using [ky] instead of [axios] for making HTTP requests. This is a breaking change, as ky is build around the fetch module. Fetch is natively supported in all modern browsers, and is also available in Node.js since version 18.13.0.
 
   If you're using an older version of node, we recommend you to upgrade to the latest LTS version. Alternatively, include a fetch polyfill such as [isomorphic-fetch].
 
@@ -286,7 +286,7 @@
 
 ### Minor Changes
 
-- [#152](https://github.com/magicbell-io/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell-io/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - The magicbell client now supports lifecycle hooks. This way you can add custom logic to the client when certain events occur. For example to add logging, or to wrap requests with timing information.
+- [#152](https://github.com/magicbell/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - The magicbell client now supports lifecycle hooks. This way you can add custom logic to the client when certain events occur. For example to add logging, or to wrap requests with timing information.
 
   Your hooks will be passed directly to ky, so please see [ky/hooks] for more information.
 
@@ -303,7 +303,7 @@
 
   [ky/hooks]: https://github.com/sindresorhus/ky#hooks
 
-- [#152](https://github.com/magicbell-io/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell-io/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We now use [debug] for logging, and have dropped support for the `debug` property that could be provided to `Client`. Debugging can be enabled via the `DEBUG` environment variable.
+- [#152](https://github.com/magicbell/magicbell-js/pull/152) [`035b9e8`](https://github.com/magicbell/magicbell-js/commit/035b9e851951379dbea82dbc2380d6e9d500198a) Thanks [@smeijer](https://github.com/smeijer)! - We now use [debug] for logging, and have dropped support for the `debug` property that could be provided to `Client`. Debugging can be enabled via the `DEBUG` environment variable.
 
   We're using the namespaces `magicbell:debug`, `magicbell:log` and `magicbell:error`.
 
@@ -318,7 +318,7 @@
 
 ### Minor Changes
 
-- [#131](https://github.com/magicbell-io/magicbell-js/pull/131) [`ac58966`](https://github.com/magicbell-io/magicbell-js/commit/ac589661e0035aca4345c7d10dfed9f53028188a) Thanks [@smeijer](https://github.com/smeijer)! - Added a `users.notifications` resource which can be used to iterate notifications for a given user.
+- [#131](https://github.com/magicbell/magicbell-js/pull/131) [`ac58966`](https://github.com/magicbell/magicbell-js/commit/ac589661e0035aca4345c7d10dfed9f53028188a) Thanks [@smeijer](https://github.com/smeijer)! - Added a `users.notifications` resource which can be used to iterate notifications for a given user.
 
   ```ts
   const notifications = magicbell.users.notifications.list(userId, { per_page: 10 });
@@ -328,7 +328,7 @@
   }
   ```
 
-- [#134](https://github.com/magicbell-io/magicbell-js/pull/134) [`66dae2e`](https://github.com/magicbell-io/magicbell-js/commit/66dae2ee1fb2a6cb043b8160f918dc1be1c0e0b7) Thanks [@smeijer](https://github.com/smeijer)! - Added the `metrics` resource. The metrics resource contains a collection of endpoints that return metrics about the sent Notifications. All metrics are for the last 30 days. The following endpoints are available:
+- [#134](https://github.com/magicbell/magicbell-js/pull/134) [`66dae2e`](https://github.com/magicbell/magicbell-js/commit/66dae2ee1fb2a6cb043b8160f918dc1be1c0e0b7) Thanks [@smeijer](https://github.com/smeijer)! - Added the `metrics` resource. The metrics resource contains a collection of endpoints that return metrics about the sent Notifications. All metrics are for the last 30 days. The following endpoints are available:
 
   ```ts
   const notificationCounts = await magicbell.metrics.get();
@@ -338,7 +338,7 @@
   const countsPerTopic = await magicbell.metrics.topics.get();
   ```
 
-- [#136](https://github.com/magicbell-io/magicbell-js/pull/136) [`0e08df7`](https://github.com/magicbell-io/magicbell-js/commit/0e08df7a8fc7c36f44aa7f83101673c72f6d12f6) Thanks [@smeijer](https://github.com/smeijer)! - Release the [users.pushSubscriptions resource](https://www.magicbell.com/docs/rest-api/reference#fetch-user's-push-subscriptions) as stable. This includes the following apis:
+- [#136](https://github.com/magicbell/magicbell-js/pull/136) [`0e08df7`](https://github.com/magicbell/magicbell-js/commit/0e08df7a8fc7c36f44aa7f83101673c72f6d12f6) Thanks [@smeijer](https://github.com/smeijer)! - Release the [users.pushSubscriptions resource](https://www.magicbell.com/docs/rest-api/reference#fetch-user's-push-subscriptions) as stable. This includes the following apis:
 
   **Fetch user's push subscriptions**
 
@@ -359,7 +359,7 @@
   await magicbell.users.pushSubscriptions.delete('{user_id}', '{subscription_id}');
   ```
 
-- [#138](https://github.com/magicbell-io/magicbell-js/pull/138) [`18e0e49`](https://github.com/magicbell-io/magicbell-js/commit/18e0e497d52f8a70b474983b1d7d330e2400aa16) Thanks [@smeijer](https://github.com/smeijer)! - Release the [imports resource](https://www.magicbell.com/docs/rest-api/reference#imports-create) as stable. This includes the following apis:
+- [#138](https://github.com/magicbell/magicbell-js/pull/138) [`18e0e49`](https://github.com/magicbell/magicbell-js/commit/18e0e497d52f8a70b474983b1d7d330e2400aa16) Thanks [@smeijer](https://github.com/smeijer)! - Release the [imports resource](https://www.magicbell.com/docs/rest-api/reference#imports-create) as stable. This includes the following apis:
 
   **Create a import**
 
@@ -390,7 +390,7 @@
   await magicbell.imports.get('{import_id}');
   ```
 
-- [#130](https://github.com/magicbell-io/magicbell-js/pull/130) [`0491ba2`](https://github.com/magicbell-io/magicbell-js/commit/0491ba255b4010f91944cecde639fb14c100a6b7) Thanks [@smeijer](https://github.com/smeijer)! - Added support for per-request header overrides
+- [#130](https://github.com/magicbell/magicbell-js/pull/130) [`0491ba2`](https://github.com/magicbell/magicbell-js/commit/0491ba255b4010f91944cecde639fb14c100a6b7) Thanks [@smeijer](https://github.com/smeijer)! - Added support for per-request header overrides
 
   ```js
   const magicbell = new Client({
@@ -411,7 +411,7 @@
   //   x-custom-header-two: two
   ```
 
-- [#135](https://github.com/magicbell-io/magicbell-js/pull/135) [`7038d80`](https://github.com/magicbell-io/magicbell-js/commit/7038d80e619cfd8a9c7b06bcc5a111452a0dc203) Thanks [@smeijer](https://github.com/smeijer)! - Release [broadcasts resource](https://www.magicbell.com/docs/rest-api/reference#list-notification-broadcasts) as stable. This includes the following apis:
+- [#135](https://github.com/magicbell/magicbell-js/pull/135) [`7038d80`](https://github.com/magicbell/magicbell-js/commit/7038d80e619cfd8a9c7b06bcc5a111452a0dc203) Thanks [@smeijer](https://github.com/smeijer)! - Release [broadcasts resource](https://www.magicbell.com/docs/rest-api/reference#list-notification-broadcasts) as stable. This includes the following apis:
 
   **List notification broadcasts**
 
@@ -441,7 +441,7 @@
 
 ### Patch Changes
 
-- [`e78af04`](https://github.com/magicbell-io/magicbell-js/commit/e78af04eb97aebffe8fa41e088890364cb5367ad) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`e78af04`](https://github.com/magicbell/magicbell-js/commit/e78af04eb97aebffe8fa41e088890364cb5367ad) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `json5` to `^2.2.3`.
 
@@ -449,25 +449,25 @@
 
 ### Patch Changes
 
-- [#97](https://github.com/magicbell-io/magicbell-js/pull/97) [`9af0890`](https://github.com/magicbell-io/magicbell-js/commit/9af0890bae5668f24e69ef167aea5dfa413cede9) Thanks [@smeijer](https://github.com/smeijer)! - fix: correct response type for `users.list()` by renaming `user` prop to `users`.
+- [#97](https://github.com/magicbell/magicbell-js/pull/97) [`9af0890`](https://github.com/magicbell/magicbell-js/commit/9af0890bae5668f24e69ef167aea5dfa413cede9) Thanks [@smeijer](https://github.com/smeijer)! - fix: correct response type for `users.list()` by renaming `user` prop to `users`.
 
 ## 1.7.0
 
 ### Minor Changes
 
-- [#95](https://github.com/magicbell-io/magicbell-js/pull/95) [`87b781b`](https://github.com/magicbell-io/magicbell-js/commit/87b781be77fd66d89ae46567d0f8a5788acd588e) Thanks [@smeijer](https://github.com/smeijer)! - The `total` and `total_pages` props are removed from the following method return types:
+- [#95](https://github.com/magicbell/magicbell-js/pull/95) [`87b781b`](https://github.com/magicbell/magicbell-js/commit/87b781be77fd66d89ae46567d0f8a5788acd588e) Thanks [@smeijer](https://github.com/smeijer)! - The `total` and `total_pages` props are removed from the following method return types:
 
   - `magicbell.broadcasts.list()`
   - `magicbell.broadcasts.notifications.list()`
   - `magicbell.users.list()`
 
-  The [auto pagination](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#using-promises) methods are updated to support the paginated responses that do not have those fields. Thereby, pagination helpers like `.list().forEach()`, `.list().toArray()` and the iterator in `for await (const node of method.list())` keep working as before.
+  The [auto pagination](https://github.com/magicbell/magicbell-js/tree/main/packages/magicbell#using-promises) methods are updated to support the paginated responses that do not have those fields. Thereby, pagination helpers like `.list().forEach()`, `.list().toArray()` and the iterator in `for await (const node of method.list())` keep working as before.
 
 ## 1.6.0
 
 ### Minor Changes
 
-- [#90](https://github.com/magicbell-io/magicbell-js/pull/90) [`ea0a9ca`](https://github.com/magicbell-io/magicbell-js/commit/ea0a9ca456cb9c82f6e6d4b9d0add512bce22a0e) Thanks [@smeijer](https://github.com/smeijer)! - update broadcast > notification response schema to include the fields:
+- [#90](https://github.com/magicbell/magicbell-js/pull/90) [`ea0a9ca`](https://github.com/magicbell/magicbell-js/commit/ea0a9ca456cb9c82f6e6d4b9d0add512bce22a0e) Thanks [@smeijer](https://github.com/smeijer)! - update broadcast > notification response schema to include the fields:
 
   - `created_at`; datetime when notification was created
   - `updated_at`; datetime when notification was last updated
@@ -480,13 +480,13 @@
   - `recipient`; is marked as non-nullable
   - `deliveries`; is marked as non-nullable
 
-- [#92](https://github.com/magicbell-io/magicbell-js/pull/92) [`530476e`](https://github.com/magicbell-io/magicbell-js/commit/530476e3d8f79c8c5176661316d2cdb46e424236) Thanks [@smeijer](https://github.com/smeijer)! - Rename `users.fetch` to `users.get`. Tho it's in theory a breaking change, the users api is relatively new, and the convention in this sdk is to use `get` for single entity retrieval, and not `fetch`. So we're going with a `minor` instead to get this fixed.
+- [#92](https://github.com/magicbell/magicbell-js/pull/92) [`530476e`](https://github.com/magicbell/magicbell-js/commit/530476e3d8f79c8c5176661316d2cdb46e424236) Thanks [@smeijer](https://github.com/smeijer)! - Rename `users.fetch` to `users.get`. Tho it's in theory a breaking change, the users api is relatively new, and the convention in this sdk is to use `get` for single entity retrieval, and not `fetch`. So we're going with a `minor` instead to get this fixed.
 
 ## 1.5.0
 
 ### Minor Changes
 
-- [#83](https://github.com/magicbell-io/magicbell-js/pull/83) [`94cbb92`](https://github.com/magicbell-io/magicbell-js/commit/94cbb927bbc88791100dbb10c5be519d1f598a72) Thanks [@smeijer](https://github.com/smeijer)! - feat: add broadcasts.list method to the client.
+- [#83](https://github.com/magicbell/magicbell-js/pull/83) [`94cbb92`](https://github.com/magicbell/magicbell-js/commit/94cbb927bbc88791100dbb10c5be519d1f598a72) Thanks [@smeijer](https://github.com/smeijer)! - feat: add broadcasts.list method to the client.
 
   ```ts
   const broadcasts = magicbell.broadcasts.list({ per_page: 10 });
@@ -496,14 +496,14 @@
   });
   ```
 
-- [#84](https://github.com/magicbell-io/magicbell-js/pull/84) [`b0a809d`](https://github.com/magicbell-io/magicbell-js/commit/b0a809db0fbc074a5a10b011bc84561285def6c4) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `broadcasts.get` method to the client.
+- [#84](https://github.com/magicbell/magicbell-js/pull/84) [`b0a809d`](https://github.com/magicbell/magicbell-js/commit/b0a809db0fbc074a5a10b011bc84561285def6c4) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `broadcasts.get` method to the client.
 
   ```ts
   const broadcasts = await magicbell.broadcasts.get(broadcastId);
   console.log(broadcast.id);
   ```
 
-- [#86](https://github.com/magicbell-io/magicbell-js/pull/86) [`073e3f8`](https://github.com/magicbell-io/magicbell-js/commit/073e3f840932ccad8a63ba390c1ebaf59e95903e) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `broadcasts.notifications.list` method to the client.
+- [#86](https://github.com/magicbell/magicbell-js/pull/86) [`073e3f8`](https://github.com/magicbell/magicbell-js/commit/073e3f840932ccad8a63ba390c1ebaf59e95903e) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `broadcasts.notifications.list` method to the client.
 
   ```ts
   const notifications = magicbell.broadcasts.notifications.list(broadcastId, { per_page: 10 });
@@ -513,7 +513,7 @@
   });
   ```
 
-- [#87](https://github.com/magicbell-io/magicbell-js/pull/87) [`f0ec9a5`](https://github.com/magicbell-io/magicbell-js/commit/f0ec9a5258d2053a0f9d87108308808b6f1f1411) Thanks [@smeijer](https://github.com/smeijer)! - Update schemas for broadcast methods.
+- [#87](https://github.com/magicbell/magicbell-js/pull/87) [`f0ec9a5`](https://github.com/magicbell/magicbell-js/commit/f0ec9a5258d2053a0f9d87108308808b6f1f1411) Thanks [@smeijer](https://github.com/smeijer)! - Update schemas for broadcast methods.
 
   - dropped `broadcast.recipients_count`, use `broadcast.status.summary.total` instead.
   - broadcast notification `status` is now an enum string.
@@ -525,33 +525,33 @@
 
 ### Patch Changes
 
-- [#76](https://github.com/magicbell-io/magicbell-js/pull/76) [`fe450c8`](https://github.com/magicbell-io/magicbell-js/commit/fe450c884900e1d42b8ae868710742c2fea61256) Thanks [@smeijer](https://github.com/smeijer)! - Feature flags are now typed, making it easier to enable beta features, and harder to forget removing flags when beta features turned stable.
+- [#76](https://github.com/magicbell/magicbell-js/pull/76) [`fe450c8`](https://github.com/magicbell/magicbell-js/commit/fe450c884900e1d42b8ae868710742c2fea61256) Thanks [@smeijer](https://github.com/smeijer)! - Feature flags are now typed, making it easier to enable beta features, and harder to forget removing flags when beta features turned stable.
 
-- [#77](https://github.com/magicbell-io/magicbell-js/pull/77) [`9f4be9a`](https://github.com/magicbell-io/magicbell-js/commit/9f4be9ace0123ce8de710b8af4683d5a3c0b27fe) Thanks [@smeijer](https://github.com/smeijer)! - return the full response data from users.push_subscriptions.list()
+- [#77](https://github.com/magicbell/magicbell-js/pull/77) [`9f4be9a`](https://github.com/magicbell/magicbell-js/commit/9f4be9ace0123ce8de710b8af4683d5a3c0b27fe) Thanks [@smeijer](https://github.com/smeijer)! - return the full response data from users.push_subscriptions.list()
 
 ## 1.4.3
 
 ### Patch Changes
 
-- [#75](https://github.com/magicbell-io/magicbell-js/pull/75) [`14c30fe`](https://github.com/magicbell-io/magicbell-js/commit/14c30fe7855adf55096f4a9f8a63f1f4240f6dac) Thanks [@smeijer](https://github.com/smeijer)! - fix: handle network level request errors
+- [#75](https://github.com/magicbell/magicbell-js/pull/75) [`14c30fe`](https://github.com/magicbell/magicbell-js/commit/14c30fe7855adf55096f4a9f8a63f1f4240f6dac) Thanks [@smeijer](https://github.com/smeijer)! - fix: handle network level request errors
 
 ## 1.4.2
 
 ### Patch Changes
 
-- [#70](https://github.com/magicbell-io/magicbell-js/pull/70) [`3590285`](https://github.com/magicbell-io/magicbell-js/commit/3590285471b80559f20308e2bbccfd244f6682fa) Thanks [@smeijer](https://github.com/smeijer)! - fix: add types for listener close method
+- [#70](https://github.com/magicbell/magicbell-js/pull/70) [`3590285`](https://github.com/magicbell/magicbell-js/commit/3590285471b80559f20308e2bbccfd244f6682fa) Thanks [@smeijer](https://github.com/smeijer)! - fix: add types for listener close method
 
 ## 1.4.1
 
 ### Patch Changes
 
-- [#68](https://github.com/magicbell-io/magicbell-js/pull/68) [`8ae8b38`](https://github.com/magicbell-io/magicbell-js/commit/8ae8b38189171188f78b767f63f4e34583abd6fb) Thanks [@smeijer](https://github.com/smeijer)! - fix typescript issue that showed arguments in camelCase vs snake_case.
+- [#68](https://github.com/magicbell/magicbell-js/pull/68) [`8ae8b38`](https://github.com/magicbell/magicbell-js/commit/8ae8b38189171188f78b767f63f4e34583abd6fb) Thanks [@smeijer](https://github.com/smeijer)! - fix typescript issue that showed arguments in camelCase vs snake_case.
 
 ## 1.4.0
 
 ### Minor Changes
 
-- [#59](https://github.com/magicbell-io/magicbell-js/pull/59) [`6d7e434`](https://github.com/magicbell-io/magicbell-js/commit/6d7e4343d997ee845ad54b41cb9ca1171019764b) Thanks [@unamashana](https://github.com/unamashana)!
+- [#59](https://github.com/magicbell/magicbell-js/pull/59) [`6d7e434`](https://github.com/magicbell/magicbell-js/commit/6d7e4343d997ee845ad54b41cb9ca1171019764b) Thanks [@unamashana](https://github.com/unamashana)!
   - remove beta flag from `pushSubscriptions`
   - move `imports` method behind feature flag
   - add `users.list` method to list all users
@@ -564,7 +564,7 @@
 
 ### Minor Changes
 
-- [#64](https://github.com/magicbell-io/magicbell-js/pull/64) [`1676fd3`](https://github.com/magicbell-io/magicbell-js/commit/1676fd3f5a93a8a5f8dd3319f84173e6d0b9df95) Thanks [@smeijer](https://github.com/smeijer)! - feat: support custom request headers
+- [#64](https://github.com/magicbell/magicbell-js/pull/64) [`1676fd3`](https://github.com/magicbell/magicbell-js/commit/1676fd3f5a93a8a5f8dd3319f84173e6d0b9df95) Thanks [@smeijer](https://github.com/smeijer)! - feat: support custom request headers
 
   Custom request headers can be used to decorate requests for logs and metrics or for example to instruct proxy servers.
 
@@ -583,7 +583,7 @@
 
 ### Minor Changes
 
-- [#56](https://github.com/magicbell-io/magicbell-js/pull/56) [`8139792`](https://github.com/magicbell-io/magicbell-js/commit/81397920b118f4d3dd9bda9153f931516f9f712c) Thanks [@smeijer](https://github.com/smeijer)! - feat: add close method to realtime listener
+- [#56](https://github.com/magicbell/magicbell-js/pull/56) [`8139792`](https://github.com/magicbell/magicbell-js/commit/81397920b118f4d3dd9bda9153f931516f9f712c) Thanks [@smeijer](https://github.com/smeijer)! - feat: add close method to realtime listener
 
   ```ts
   const listener = magicbell.listen();
@@ -602,7 +602,7 @@
 
 ### Minor Changes
 
-- [#39](https://github.com/magicbell-io/magicbell-js/pull/39) [`68b2fbd`](https://github.com/magicbell-io/magicbell-js/commit/68b2fbd28fc1a0ca2b182611bc62fdc56a2e3f13) Thanks [@smeijer](https://github.com/smeijer)! - Add support for usage in browsers.
+- [#39](https://github.com/magicbell/magicbell-js/pull/39) [`68b2fbd`](https://github.com/magicbell/magicbell-js/commit/68b2fbd28fc1a0ca2b182611bc62fdc56a2e3f13) Thanks [@smeijer](https://github.com/smeijer)! - Add support for usage in browsers.
 
   - Stop tracking `client-id`. Client id was a random token stored on the filesystem, so we could identify origins across session.
   - Don't generate HMAC if no `api-secret` is provided, or if HMAC is already provided via request options.
@@ -617,25 +617,25 @@
 
 ### Patch Changes
 
-- [#29](https://github.com/magicbell-io/magicbell-js/pull/29) [`1640aef`](https://github.com/magicbell-io/magicbell-js/commit/1640aeff3f6158047883c999fa580202651b067b) Thanks [@smeijer](https://github.com/smeijer)! - fix: be forgiving about `undefined` arguments
+- [#29](https://github.com/magicbell/magicbell-js/pull/29) [`1640aef`](https://github.com/magicbell/magicbell-js/commit/1640aeff3f6158047883c999fa580202651b067b) Thanks [@smeijer](https://github.com/smeijer)! - fix: be forgiving about `undefined` arguments
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#27](https://github.com/magicbell-io/magicbell-js/pull/27) [`c698320`](https://github.com/magicbell-io/magicbell-js/commit/c69832021cba9a0686a14be22dd7f46c613b954d) Thanks [@smeijer](https://github.com/smeijer)! - improve types for `notifications`, `push-subscriptions`, `imports` and `users` resources.
+- [#27](https://github.com/magicbell/magicbell-js/pull/27) [`c698320`](https://github.com/magicbell/magicbell-js/commit/c69832021cba9a0686a14be22dd7f46c613b954d) Thanks [@smeijer](https://github.com/smeijer)! - improve types for `notifications`, `push-subscriptions`, `imports` and `users` resources.
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#22](https://github.com/magicbell-io/magicbell-js/pull/22) [`366adc6`](https://github.com/magicbell-io/magicbell-js/commit/366adc6af3ee2d198f5f9ad3507deee93dd88ebb) Thanks [@smeijer](https://github.com/smeijer)! - Add the `magicbell.imports` resource to import users in bulk, and query the status of import jobs. Methods that have been made available are `magicbell.imports.create` and `magicbell.imports.get`.
+- [#22](https://github.com/magicbell/magicbell-js/pull/22) [`366adc6`](https://github.com/magicbell/magicbell-js/commit/366adc6af3ee2d198f5f9ad3507deee93dd88ebb) Thanks [@smeijer](https://github.com/smeijer)! - Add the `magicbell.imports` resource to import users in bulk, and query the status of import jobs. Methods that have been made available are `magicbell.imports.create` and `magicbell.imports.get`.
 
-  See [#imports](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#imports) for more information.
+  See [#imports](https://github.com/magicbell/magicbell-js/blob/main/packages/magicbell/README.md#imports) for more information.
 
-- [#24](https://github.com/magicbell-io/magicbell-js/pull/24) [`6cf938c`](https://github.com/magicbell-io/magicbell-js/commit/6cf938c384ea4db6e3260f8c35f9af762edc48a7) Thanks [@smeijer](https://github.com/smeijer)! - Released the `.listen` method. With this method you can listen to server sent events in realtime. For example, to do something when new notifications come in, or to trigger an event when a user marks a notification as read.
+- [#24](https://github.com/magicbell/magicbell-js/pull/24) [`6cf938c`](https://github.com/magicbell/magicbell-js/commit/6cf938c384ea4db6e3260f8c35f9af762edc48a7) Thanks [@smeijer](https://github.com/smeijer)! - Released the `.listen` method. With this method you can listen to server sent events in realtime. For example, to do something when new notifications come in, or to trigger an event when a user marks a notification as read.
 
-  The following events are currently emitted. Please note that all events are bound to a specific user. See [#realtime](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#realtime) for more information.
+  The following events are currently emitted. Please note that all events are bound to a specific user. See [#realtime](https://github.com/magicbell/magicbell-js/blob/main/packages/magicbell/README.md#realtime) for more information.
 
   | event.name               | description                                |
   | ------------------------ | ------------------------------------------ |
@@ -646,13 +646,13 @@
   | `notifications/read/all` | all notifications have been marked as read |
   | `notifications/seen/all` | all notifications have been marked as seen |
 
-- [#16](https://github.com/magicbell-io/magicbell-js/pull/16) [`615b2fa`](https://github.com/magicbell-io/magicbell-js/commit/615b2faa558c19a2a50c0cb2b67b95ad3b5e68e3) Thanks [@smeijer](https://github.com/smeijer)! - Loads the axios http adapter when `XMLHttpRequest` is unsupported. This allows `magicbell` to be used in for example vscode extensions.
+- [#16](https://github.com/magicbell/magicbell-js/pull/16) [`615b2fa`](https://github.com/magicbell/magicbell-js/commit/615b2faa558c19a2a50c0cb2b67b95ad3b5e68e3) Thanks [@smeijer](https://github.com/smeijer)! - Loads the axios http adapter when `XMLHttpRequest` is unsupported. This allows `magicbell` to be used in for example vscode extensions.
 
   - Don't persist config if `os.homedir` is unavailable, which is for example the case in vscode extensions.
   - Add support for authentication using `x-magicbell-user-external-id` header.
   - Allow specifying the `userKey`. This allows users to use `magicbell`, without the need to provide the `apiSecret` key to generate the HMAC at runtime.
 
-- [#25](https://github.com/magicbell-io/magicbell-js/pull/25) [`13ee1d2`](https://github.com/magicbell-io/magicbell-js/commit/13ee1d242baddc97c0eabd3bf49867c3280432c5) Thanks [@smeijer](https://github.com/smeijer)! - Add type coverage to all resource methods.
+- [#25](https://github.com/magicbell/magicbell-js/pull/25) [`13ee1d2`](https://github.com/magicbell/magicbell-js/commit/13ee1d242baddc97c0eabd3bf49867c3280432c5) Thanks [@smeijer](https://github.com/smeijer)! - Add type coverage to all resource methods.
 
   - Payload and Response types are driven by json schemas, which are stored under `/schemas`.
   - Requests now use the `accept-version: v2` header, so we use the latest version of our preferences api.
@@ -660,18 +660,18 @@
   - Requests no longer include empty headers.
   - Requests no longer include empty wrapping entities in the body.
 
-- [#23](https://github.com/magicbell-io/magicbell-js/pull/23) [`bb857a7`](https://github.com/magicbell-io/magicbell-js/commit/bb857a738d5abfda805fecdd1154027a8077d3ed) Thanks [@smeijer](https://github.com/smeijer)! - Add the `magicbell.pushSubscriptions` resource to manage mobile devices / push subscriptions. Methods that have been made available are `magicbell.pushSubscriptions.create` and `magicbell.pushSubscriptions.delete`. Note that these methods are currently in beta, and need to be enabled via [feature flags](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell#feature-flags).
+- [#23](https://github.com/magicbell/magicbell-js/pull/23) [`bb857a7`](https://github.com/magicbell/magicbell-js/commit/bb857a738d5abfda805fecdd1154027a8077d3ed) Thanks [@smeijer](https://github.com/smeijer)! - Add the `magicbell.pushSubscriptions` resource to manage mobile devices / push subscriptions. Methods that have been made available are `magicbell.pushSubscriptions.create` and `magicbell.pushSubscriptions.delete`. Note that these methods are currently in beta, and need to be enabled via [feature flags](https://github.com/magicbell/magicbell-js/tree/main/packages/magicbell#feature-flags).
 
-  See [#pushSubscriptions](https://github.com/magicbell-io/magicbell-js/blob/main/packages/magicbell/README.md#pushSubscriptions) for more information.
+  See [#pushSubscriptions](https://github.com/magicbell/magicbell-js/blob/main/packages/magicbell/README.md#pushSubscriptions) for more information.
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [`3c04a70`](https://github.com/magicbell-io/magicbell-js/commit/3c04a70972a4983b5bd07bc62c4aa7ddd2607106) Thanks [@smeijer](https://github.com/smeijer)! - rename `.retrieve()` methods to `.get()` and remove pushSubscriptions for the time being.
+- [`3c04a70`](https://github.com/magicbell/magicbell-js/commit/3c04a70972a4983b5bd07bc62c4aa7ddd2607106) Thanks [@smeijer](https://github.com/smeijer)! - rename `.retrieve()` methods to `.get()` and remove pushSubscriptions for the time being.
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [`29c4bca`](https://github.com/magicbell-io/magicbell-js/commit/29c4bca92847ad5975b03ab006835a2210b2842f) Thanks [@smeijer](https://github.com/smeijer)! - Added the `magicbell` package - an api wrapper for node. Please see the readme at [packages/magicbell](https://github.com/magicbell-io/magicbell-js/tree/main/packages/magicbell) for more.
+- [`29c4bca`](https://github.com/magicbell/magicbell-js/commit/29c4bca92847ad5975b03ab006835a2210b2842f) Thanks [@smeijer](https://github.com/smeijer)! - Added the `magicbell` package - an api wrapper for node. Please see the readme at [packages/magicbell](https://github.com/magicbell/magicbell-js/tree/main/packages/magicbell) for more.

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -57,10 +57,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/magicbell/src/client/paginate.ts
+++ b/packages/magicbell/src/client/paginate.ts
@@ -99,7 +99,7 @@ export function makeForEach(asyncIteratorNext, onDoneCallback?: () => void) {
       function handleIteration(iterResult) {
         // iterResult can be undefined if the iterator is closed and quickly
         // reconnected, this happens when wrapped in <React.StrictMode />.
-        // See github pr for more context: https://github.com/magicbell-io/magicbell-js/pull/189
+        // See github pr for more context: https://github.com/magicbell/magicbell-js/pull/189
         if (iterResult?.done) {
           resolve();
           return;

--- a/packages/magicbell/src/resources/listen.ts
+++ b/packages/magicbell/src/resources/listen.ts
@@ -153,13 +153,13 @@ export function createListener(client: InstanceType<typeof Client>, args: { sseH
     void connect(options);
 
     const asyncIteratorNext = async () => {
-      let event: typeof messages[number] | null = null;
+      let event: (typeof messages)[number] | null = null;
 
       // It's weird that `event` can be undefined? We don't push empty messages
       // This happens when running in <React.StrictMode />. I guess there are
       // two instances resolving the promise above, the second resolve results
       // in no content. See this github pr for more context:
-      // https://github.com/magicbell-io/magicbell-js/pull/189
+      // https://github.com/magicbell/magicbell-js/pull/189
       while (!event) {
         if (!messages.length) await new Promise((r) => (resolve = r));
         event = messages.pop();

--- a/packages/playground/src/pages/[slug].tsx
+++ b/packages/playground/src/pages/[slug].tsx
@@ -93,7 +93,7 @@ export default function Example({ files, dependencies, template, examples, slug 
             <FileTextIcon className="mr-2" /> Docs
           </a>
           <a
-            href="https://github.com/orgs/magicbell-io/discussions"
+            href="https://github.com/orgs/magicbell/discussions"
             className="flex-row fg-body"
             target="_blank"
             rel="noopener nofollow noreferrer"

--- a/packages/react-headless/CHANGELOG.md
+++ b/packages/react-headless/CHANGELOG.md
@@ -15,28 +15,28 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c16e604`](https://github.com/magicbell-io/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189)]:
+- Updated dependencies [[`c16e604`](https://github.com/magicbell/magicbell-js/commit/c16e6040dfe8268f41a592c50a4c1aa2caad7189)]:
   - magicbell@3.1.4
 
 ## 4.5.2
 
 ### Patch Changes
 
-- Updated dependencies [[`3982658`](https://github.com/magicbell-io/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60)]:
+- Updated dependencies [[`3982658`](https://github.com/magicbell/magicbell-js/commit/3982658e38647dccf8e8d1e2c39b44844df74e60)]:
   - magicbell@3.1.3
 
 ## 4.5.1
 
 ### Patch Changes
 
-- Updated dependencies [[`30ed933`](https://github.com/magicbell-io/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245)]:
+- Updated dependencies [[`30ed933`](https://github.com/magicbell/magicbell-js/commit/30ed93388b2b5018bd0224892be69028a7632245)]:
   - magicbell@3.1.2
 
 ## 4.5.0
 
 ### Minor Changes
 
-- [#243](https://github.com/magicbell-io/magicbell-js/pull/243) [`e6f514e`](https://github.com/magicbell-io/magicbell-js/commit/e6f514e008d5300ce8a7ba192dbb3a9aed137206) Thanks [@smeijer](https://github.com/smeijer)! - Add archive and unarchive utilities to the `useNotification` hook.
+- [#243](https://github.com/magicbell/magicbell-js/pull/243) [`e6f514e`](https://github.com/magicbell/magicbell-js/commit/e6f514e008d5300ce8a7ba192dbb3a9aed137206) Thanks [@smeijer](https://github.com/smeijer)! - Add archive and unarchive utilities to the `useNotification` hook.
 
   ```js
   const notification = useNotification(data);
@@ -69,59 +69,59 @@
 
 ### Patch Changes
 
-- [#246](https://github.com/magicbell-io/magicbell-js/pull/246) [`ce7bc6f`](https://github.com/magicbell-io/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#246](https://github.com/magicbell/magicbell-js/pull/246) [`ce7bc6f`](https://github.com/magicbell/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `react` to `>= 18.2.0`.
   - updated `react-dom` to `^18.2.0`.
 
-- [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tslib` to `^2.6.2`.
 
-- Updated dependencies [[`840263b`](https://github.com/magicbell-io/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675), [`aee799d`](https://github.com/magicbell-io/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4)]:
+- Updated dependencies [[`840263b`](https://github.com/magicbell/magicbell-js/commit/840263bd2921abc46d62732d5188c71a9fecf675), [`aee799d`](https://github.com/magicbell/magicbell-js/commit/aee799deebd15f904153cbc4a7c3ff5dca9accc4)]:
   - magicbell@3.1.1
 
 ## 4.4.9
 
 ### Patch Changes
 
-- Updated dependencies [[`8bee76e`](https://github.com/magicbell-io/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e), [`1041cdf`](https://github.com/magicbell-io/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183)]:
+- Updated dependencies [[`8bee76e`](https://github.com/magicbell/magicbell-js/commit/8bee76eff4f35a55c5b50e25c0f143bd49c5ae3e), [`1041cdf`](https://github.com/magicbell/magicbell-js/commit/1041cdf10f7ae87413ca5c00236d8a9ac8d33183)]:
   - magicbell@3.1.0
 
 ## 4.4.8
 
 ### Patch Changes
 
-- [`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@size-limit/preset-small-lib` to `^8.2.6`.
 
-- [`aa44b32`](https://github.com/magicbell-io/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`aa44b32`](https://github.com/magicbell/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/react` to `^18.2.39`.
   - updated `@types/react-dom` to `^18.2.17`.
   - updated `react` to `>= 16.14.0`.
 
-- [`184de06`](https://github.com/magicbell-io/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`184de06`](https://github.com/magicbell/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `size-limit` to `^8.2.6`.
 
-- [`8649b12`](https://github.com/magicbell-io/magicbell-js/commit/8649b122832af97b250471fc2ee54b0977cf0027) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`8649b12`](https://github.com/magicbell/magicbell-js/commit/8649b122832af97b250471fc2ee54b0977cf0027) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `babel-loader` to `^8.3.0`.
 
-- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`5a3443f`](https://github.com/magicbell-io/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0), [`33d2cab`](https://github.com/magicbell-io/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6), [`444e653`](https://github.com/magicbell-io/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8)]:
+- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`5a3443f`](https://github.com/magicbell/magicbell-js/commit/5a3443f814323352b35eab36d87dbf9e3aa1cba0), [`33d2cab`](https://github.com/magicbell/magicbell-js/commit/33d2cabca427e4ea9bc00b2e6304b57d6b7191f6), [`444e653`](https://github.com/magicbell/magicbell-js/commit/444e653a435255d5ffcd10257f595cf496e3d1c8)]:
   - magicbell@3.0.1
 
 ## 4.4.7
 
 ### Patch Changes
 
-- [`9be10f5`](https://github.com/magicbell-io/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`9be10f5`](https://github.com/magicbell/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.202`.
 
-- [`d29b034`](https://github.com/magicbell-io/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d29b034`](https://github.com/magicbell/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `rosie` to `^2.1.1`.
 
@@ -129,11 +129,11 @@
 
 ### Patch Changes
 
-- [#210](https://github.com/magicbell-io/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell-io/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#210](https://github.com/magicbell/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.45`.
 
-- [`d199c74`](https://github.com/magicbell-io/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d199c74`](https://github.com/magicbell/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.201`.
 
@@ -141,29 +141,29 @@
 
 ### Patch Changes
 
-- [#200](https://github.com/magicbell-io/magicbell-js/pull/200) [`ef5248c`](https://github.com/magicbell-io/magicbell-js/commit/ef5248ce58525ac9f7113a5070822945b18a67cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#200](https://github.com/magicbell/magicbell-js/pull/200) [`ef5248c`](https://github.com/magicbell/magicbell-js/commit/ef5248ce58525ac9f7113a5070822945b18a67cc) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/humps` to `^2.0.6`.
 
-- [#207](https://github.com/magicbell-io/magicbell-js/pull/207) [`f694679`](https://github.com/magicbell-io/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#207](https://github.com/magicbell/magicbell-js/pull/207) [`f694679`](https://github.com/magicbell/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `tiny-invariant` to `^1.3.1`.
 
-- Updated dependencies [[`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722), [`62eae8f`](https://github.com/magicbell-io/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722)]:
+- Updated dependencies [[`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722), [`62eae8f`](https://github.com/magicbell/magicbell-js/commit/62eae8f23ac7bbcdc3a600d514969bd7ba459722)]:
   - magicbell@3.0.0
 
 ## 4.4.4
 
 ### Patch Changes
 
-- Updated dependencies [[`5c8f4c9`](https://github.com/magicbell-io/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c)]:
+- Updated dependencies [[`5c8f4c9`](https://github.com/magicbell/magicbell-js/commit/5c8f4c902294c68a002d55c2e3ee340ffb30758c)]:
   - magicbell@2.4.1
 
 ## 4.4.3
 
 ### Patch Changes
 
-- [#191](https://github.com/magicbell-io/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell-io/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#191](https://github.com/magicbell/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.43`.
 
@@ -171,25 +171,25 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`725ab1a`](https://github.com/magicbell-io/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e)]:
+- Updated dependencies [[`725ab1a`](https://github.com/magicbell/magicbell-js/commit/725ab1ad14619341beee9d4422da9ecce27a7e7e)]:
   - magicbell@2.4.0
 
 ## 4.4.1
 
 ### Patch Changes
 
-- Updated dependencies [[`c6054af`](https://github.com/magicbell-io/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
+- Updated dependencies [[`c6054af`](https://github.com/magicbell/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043)]:
   - magicbell@2.3.1
 
 ## 4.4.0
 
 ### Minor Changes
 
-- [#185](https://github.com/magicbell-io/magicbell-js/pull/185) [`78b62cb`](https://github.com/magicbell-io/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8) Thanks [@smeijer](https://github.com/smeijer)! - Listen to realtime events using SSE, and drop the Ably dependency
+- [#185](https://github.com/magicbell/magicbell-js/pull/185) [`78b62cb`](https://github.com/magicbell/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8) Thanks [@smeijer](https://github.com/smeijer)! - Listen to realtime events using SSE, and drop the Ably dependency
 
 ### Patch Changes
 
-- [#188](https://github.com/magicbell-io/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell-io/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#188](https://github.com/magicbell/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.10`.
 
@@ -197,66 +197,66 @@
 
 ### Patch Changes
 
-- [`79d3019`](https://github.com/magicbell-io/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`79d3019`](https://github.com/magicbell/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `immer` to `^9.0.21`.
 
-- [`0a40f2d`](https://github.com/magicbell-io/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`0a40f2d`](https://github.com/magicbell/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.198`.
 
-- [`6159725`](https://github.com/magicbell-io/magicbell-js/commit/6159725eddf22be5787ae1441131ef7aad97632e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`6159725`](https://github.com/magicbell/magicbell-js/commit/6159725eddf22be5787ae1441131ef7aad97632e) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/humps` to `^2.0.4`.
 
-- [`ffb1b21`](https://github.com/magicbell-io/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`ffb1b21`](https://github.com/magicbell/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `sinon` to `^13.0.2`.
 
-- [`f83b52c`](https://github.com/magicbell-io/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`f83b52c`](https://github.com/magicbell/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `mitt` to `^3.0.1`.
 
-- [#179](https://github.com/magicbell-io/magicbell-js/pull/179) [`cda7f21`](https://github.com/magicbell-io/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#179](https://github.com/magicbell/magicbell-js/pull/179) [`cda7f21`](https://github.com/magicbell/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `ably` to `^1.2.44`.
 
-- [`5088009`](https://github.com/magicbell-io/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`5088009`](https://github.com/magicbell/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.9`.
 
-- Updated dependencies [[`3f7ab5a`](https://github.com/magicbell-io/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca)]:
+- Updated dependencies [[`3f7ab5a`](https://github.com/magicbell/magicbell-js/commit/3f7ab5a532ec5c02e7f8ff41261548c0accd78ca)]:
   - magicbell@2.3.0
 
 ## 4.3.1
 
 ### Patch Changes
 
-- Updated dependencies [[`1f40263`](https://github.com/magicbell-io/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858)]:
+- Updated dependencies [[`1f40263`](https://github.com/magicbell/magicbell-js/commit/1f40263c112dcf5a05cac3d59661c7b8ddc41858)]:
   - magicbell@2.2.0
 
 ## 4.3.0
 
 ### Minor Changes
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
 
 ### Patch Changes
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Mark `apiKey` and either `userEmail` or `userExternalId` as required. Note that this is an update in type definitions only, the implementation is not changed.
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Mark `apiKey` and either `userEmail` or `userExternalId` as required. Note that this is an update in type definitions only, the implementation is not changed.
 
-- [#166](https://github.com/magicbell-io/magicbell-js/pull/166) [`b835ff3`](https://github.com/magicbell-io/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770) Thanks [@smeijer](https://github.com/smeijer)! - Removed `apiSecret` from `ClientSettings`.
+- [#166](https://github.com/magicbell/magicbell-js/pull/166) [`b835ff3`](https://github.com/magicbell/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770) Thanks [@smeijer](https://github.com/smeijer)! - Removed `apiSecret` from `ClientSettings`.
 
-- [#166](https://github.com/magicbell-io/magicbell-js/pull/166) [`b835ff3`](https://github.com/magicbell-io/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770) Thanks [@smeijer](https://github.com/smeijer)! - Removed index signature from `QueryParams`, so TypeScript will properly warn about misspelled options.
+- [#166](https://github.com/magicbell/magicbell-js/pull/166) [`b835ff3`](https://github.com/magicbell/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770) Thanks [@smeijer](https://github.com/smeijer)! - Removed index signature from `QueryParams`, so TypeScript will properly warn about misspelled options.
 
-- Updated dependencies [[`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`24c00f4`](https://github.com/magicbell-io/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68), [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`998008a`](https://github.com/magicbell-io/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`666d2bb`](https://github.com/magicbell-io/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248)]:
+- Updated dependencies [[`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`24c00f4`](https://github.com/magicbell/magicbell-js/commit/24c00f400f571ab0518f3ece7601f99360f85f68), [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`998008a`](https://github.com/magicbell/magicbell-js/commit/998008a04f40833954ec9a47bfe447989f7079aa), [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`666d2bb`](https://github.com/magicbell/magicbell-js/commit/666d2bbefe2365b6691607a38514d51d302e8248)]:
   - magicbell@2.1.0
 
 ## 4.2.8
 
 ### Patch Changes
 
-- [#153](https://github.com/magicbell-io/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell-io/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#153](https://github.com/magicbell/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.195`.
 
@@ -264,15 +264,15 @@
 
 ### Patch Changes
 
-- [#110](https://github.com/magicbell-io/magicbell-js/pull/110) [`c030ce4`](https://github.com/magicbell-io/magicbell-js/commit/c030ce41e094c19b62cbabbbe62f8e3b0ceeb31f) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#110](https://github.com/magicbell/magicbell-js/pull/110) [`c030ce4`](https://github.com/magicbell/magicbell-js/commit/c030ce41e094c19b62cbabbbe62f8e3b0ceeb31f) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@faker-js/faker` to `^6.3.1`.
 
-- [#111](https://github.com/magicbell-io/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell-io/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#111](https://github.com/magicbell/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.194`.
 
-- [#117](https://github.com/magicbell-io/magicbell-js/pull/117) [`5bd3ac7`](https://github.com/magicbell-io/magicbell-js/commit/5bd3ac767602d06409dafcd9a144e5c18fbfd55c) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#117](https://github.com/magicbell/magicbell-js/pull/117) [`5bd3ac7`](https://github.com/magicbell/magicbell-js/commit/5bd3ac767602d06409dafcd9a144e5c18fbfd55c) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `twind` to `^0.16.19`.
 
@@ -280,19 +280,19 @@
 
 ### Patch Changes
 
-- [`fbbbae7`](https://github.com/magicbell-io/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529) Thanks [@smeijer](https://github.com/smeijer)! - deps: bump ably to 1.2.39 to fix CVE-2022-33987
+- [`fbbbae7`](https://github.com/magicbell/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529) Thanks [@smeijer](https://github.com/smeijer)! - deps: bump ably to 1.2.39 to fix CVE-2022-33987
 
 ## 4.2.5
 
 ### Patch Changes
 
-- [#73](https://github.com/magicbell-io/magicbell-js/pull/73) [`6eb5705`](https://github.com/magicbell-io/magicbell-js/commit/6eb5705c502ab64caa32ce1d5ffa79d1fd671b06) Thanks [@SuzukiRyuichiro](https://github.com/SuzukiRyuichiro)! - Fix example in docs for `useBell`, to provide `storeId` via an options object.
+- [#73](https://github.com/magicbell/magicbell-js/pull/73) [`6eb5705`](https://github.com/magicbell/magicbell-js/commit/6eb5705c502ab64caa32ce1d5ffa79d1fd671b06) Thanks [@SuzukiRyuichiro](https://github.com/SuzukiRyuichiro)! - Fix example in docs for `useBell`, to provide `storeId` via an options object.
 
 ## 4.2.4
 
 ### Patch Changes
 
-- [#43](https://github.com/magicbell-io/magicbell-js/pull/43) [`d9d2318`](https://github.com/magicbell-io/magicbell-js/commit/d9d23180be66f0487b12c71440eb1cf1bbcb41c9) Thanks [@rollacaster](https://github.com/rollacaster)! - fix: initialize stores in an effect instead of lazy use-state.
+- [#43](https://github.com/magicbell/magicbell-js/pull/43) [`d9d2318`](https://github.com/magicbell/magicbell-js/commit/d9d23180be66f0487b12c71440eb1cf1bbcb41c9) Thanks [@rollacaster](https://github.com/rollacaster)! - fix: initialize stores in an effect instead of lazy use-state.
 
   This solves an "cannot update component" warning that was thrown in development mode.
 
@@ -300,18 +300,18 @@
 
 ### Patch Changes
 
-- [#26](https://github.com/magicbell-io/magicbell-js/pull/26) [`2f295b0`](https://github.com/magicbell-io/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7) Thanks [@smeijer](https://github.com/smeijer)! - Remove react-dom from peer-dependencies, so we don't cause trouble in react-native projects.
+- [#26](https://github.com/magicbell/magicbell-js/pull/26) [`2f295b0`](https://github.com/magicbell/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7) Thanks [@smeijer](https://github.com/smeijer)! - Remove react-dom from peer-dependencies, so we don't cause trouble in react-native projects.
 
 ## 4.2.2
 
 ### Patch Changes
 
-- [#7](https://github.com/magicbell-io/magicbell-js/pull/7) [`7712e28`](https://github.com/magicbell-io/magicbell-js/commit/7712e28911718b9585ebe0bee72d22f14fc137d1) Thanks [@smeijer](https://github.com/smeijer)! - ensure that stores are updated to include or remove notification after an mark-all-read action.
+- [#7](https://github.com/magicbell/magicbell-js/pull/7) [`7712e28`](https://github.com/magicbell/magicbell-js/commit/7712e28911718b9585ebe0bee72d22f14fc137d1) Thanks [@smeijer](https://github.com/smeijer)! - ensure that stores are updated to include or remove notification after an mark-all-read action.
 
-- [#8](https://github.com/magicbell-io/magicbell-js/pull/8) [`6a812ca`](https://github.com/magicbell-io/magicbell-js/commit/6a812ca48dc2e250260cd24967724f560f6415fd) Thanks [@smeijer](https://github.com/smeijer)! - ensure that stores are updated to include or remove notification after an mark-all-seen action.
+- [#8](https://github.com/magicbell/magicbell-js/pull/8) [`6a812ca`](https://github.com/magicbell/magicbell-js/commit/6a812ca48dc2e250260cd24967724f560f6415fd) Thanks [@smeijer](https://github.com/smeijer)! - ensure that stores are updated to include or remove notification after an mark-all-seen action.
 
 ## 4.2.1
 
 ### Patch Changes
 
-- [`36d7ef7`](https://github.com/magicbell-io/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the badge count doesn't drop below zero when clicking unread notifications.
+- [`36d7ef7`](https://github.com/magicbell/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the badge count doesn't drop below zero when clicking unread notifications.

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -34,10 +34,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -15,14 +15,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`2095743`](https://github.com/magicbell-io/magicbell-js/commit/2095743f23e5fe35da335dfaa84e6808616f58f1)]:
+- Updated dependencies [[`2095743`](https://github.com/magicbell/magicbell-js/commit/2095743f23e5fe35da335dfaa84e6808616f58f1)]:
   - @magicbell/webpush@2.0.1
 
 ## 10.11.2
 
 ### Patch Changes
 
-- Updated dependencies [[`7bea88f`](https://github.com/magicbell-io/magicbell-js/commit/7bea88f45389329261843d7b2e0fb8d06fe62078)]:
+- Updated dependencies [[`7bea88f`](https://github.com/magicbell/magicbell-js/commit/7bea88f45389329261843d7b2e0fb8d06fe62078)]:
   - @magicbell/webpush@2.0.0
   - @magicbell/react-headless@4.5.3
 
@@ -37,7 +37,7 @@
 
 ### Minor Changes
 
-- [`7e918d9`](https://github.com/magicbell-io/magicbell-js/commit/7e918d9a609c6300425cd87866db31dfe3e4e937) Thanks [@smeijer](https://github.com/smeijer)! - Include MagicBell as named export. These two are now the same:
+- [`7e918d9`](https://github.com/magicbell/magicbell-js/commit/7e918d9a609c6300425cd87866db31dfe3e4e937) Thanks [@smeijer](https://github.com/smeijer)! - Include MagicBell as named export. These two are now the same:
 
   ```jsx
   import MagicBell from '@magicbell/magicbell-react';
@@ -55,14 +55,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`b37ed53`](https://github.com/magicbell-io/magicbell-js/commit/b37ed530d35dc5060e05d2b588d255f8648cc865)]:
+- Updated dependencies [[`b37ed53`](https://github.com/magicbell/magicbell-js/commit/b37ed530d35dc5060e05d2b588d255f8648cc865)]:
   - @magicbell/webpush@1.4.2
 
 ## 10.10.0
 
 ### Minor Changes
 
-- [#240](https://github.com/magicbell-io/magicbell-js/pull/240) [`00451d2`](https://github.com/magicbell-io/magicbell-js/commit/00451d2d23cad54480f93ad8e3968921fd491559) Thanks [@smeijer](https://github.com/smeijer)! - Theme, locale, and image settings can now be published from the MagicBell dashboard, and will be automatically used by the inbox. This means you can now change the look and feel of the inbox without needing to change code.
+- [#240](https://github.com/magicbell/magicbell-js/pull/240) [`00451d2`](https://github.com/magicbell/magicbell-js/commit/00451d2d23cad54480f93ad8e3968921fd491559) Thanks [@smeijer](https://github.com/smeijer)! - Theme, locale, and image settings can now be published from the MagicBell dashboard, and will be automatically used by the inbox. This means you can now change the look and feel of the inbox without needing to change code.
 
   The behavior is backward compatible. Config is only applied after publishing from the dashboard, and properties provided to the MagicBell provider precede the published settings.
 
@@ -88,36 +88,36 @@
 
 ### Patch Changes
 
-- [`772bd16`](https://github.com/magicbell-io/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`772bd16`](https://github.com/magicbell/magicbell-js/commit/772bd16862c3ae3202eb66f864cde0a66aee1489) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@emotion/cache` to `^11.11.0`.
   - updated `@emotion/react` to `^11.11.3`.
 
-- [`805c275`](https://github.com/magicbell-io/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`805c275`](https://github.com/magicbell/magicbell-js/commit/805c275906c17e7f655722f153ccb991b5d594ca) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.5.0`.
 
-- [#246](https://github.com/magicbell-io/magicbell-js/pull/246) [`ce7bc6f`](https://github.com/magicbell-io/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#246](https://github.com/magicbell/magicbell-js/pull/246) [`ce7bc6f`](https://github.com/magicbell/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `react` to `>= 18.2.0`.
   - updated `react-dom` to `^18.2.0`.
 
-- [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tslib` to `^2.6.2`.
 
-- Updated dependencies [[`ce7bc6f`](https://github.com/magicbell-io/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079), [`464b168`](https://github.com/magicbell-io/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591), [`e6f514e`](https://github.com/magicbell-io/magicbell-js/commit/e6f514e008d5300ce8a7ba192dbb3a9aed137206)]:
+- Updated dependencies [[`ce7bc6f`](https://github.com/magicbell/magicbell-js/commit/ce7bc6fb02e54f68e2f0dbd1545b53af9354a079), [`464b168`](https://github.com/magicbell/magicbell-js/commit/464b168994ab8927f1d79e2c8c75d7c496608591), [`e6f514e`](https://github.com/magicbell/magicbell-js/commit/e6f514e008d5300ce8a7ba192dbb3a9aed137206)]:
   - @magicbell/react-headless@4.5.0
 
 ## 10.9.11
 
 ### Patch Changes
 
-- [`681ed7b`](https://github.com/magicbell-io/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`681ed7b`](https://github.com/magicbell/magicbell-js/commit/681ed7b45380812c3627baeb090d4d97b4ab2558) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.2`.
 
-- [`fdb6953`](https://github.com/magicbell-io/magicbell-js/commit/fdb695389abc7c881518ea746ad55e84cc90f83d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`fdb6953`](https://github.com/magicbell/magicbell-js/commit/fdb695389abc7c881518ea746ad55e84cc90f83d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `tinycolor2` to `^1.6.0`.
 
@@ -128,67 +128,67 @@
 
 ### Patch Changes
 
-- [`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@size-limit/preset-small-lib` to `^8.2.6`.
 
-- [`aa44b32`](https://github.com/magicbell-io/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`aa44b32`](https://github.com/magicbell/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/react` to `^18.2.39`.
   - updated `@types/react-dom` to `^18.2.17`.
   - updated `react` to `>= 16.14.0`.
 
-- [#223](https://github.com/magicbell-io/magicbell-js/pull/223) [`ec0fb02`](https://github.com/magicbell-io/magicbell-js/commit/ec0fb023e9c59452f5c05d9c1254b764aef98b21) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#223](https://github.com/magicbell/magicbell-js/pull/223) [`ec0fb02`](https://github.com/magicbell/magicbell-js/commit/ec0fb023e9c59452f5c05d9c1254b764aef98b21) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `typescript` to `^4.9.5`.
 
-- [`184de06`](https://github.com/magicbell-io/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`184de06`](https://github.com/magicbell/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `size-limit` to `^8.2.6`.
 
-- [`7dbb225`](https://github.com/magicbell-io/magicbell-js/commit/7dbb225f654995e04eaacce6d67105f825f53857) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`7dbb225`](https://github.com/magicbell/magicbell-js/commit/7dbb225f654995e04eaacce6d67105f825f53857) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@babel/core` to `^7.23.5`.
 
-- [`ab7782a`](https://github.com/magicbell-io/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`ab7782a`](https://github.com/magicbell/magicbell-js/commit/ab7782a7373fadd647bca138fa164b2a84d53639) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.1`.
 
-- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell-io/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`aa44b32`](https://github.com/magicbell-io/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe), [`184de06`](https://github.com/magicbell-io/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb), [`8649b12`](https://github.com/magicbell-io/magicbell-js/commit/8649b122832af97b250471fc2ee54b0977cf0027)]:
+- Updated dependencies [[`1ed7ce5`](https://github.com/magicbell/magicbell-js/commit/1ed7ce52f27569e06878d6fcac42531055b57fc1), [`aa44b32`](https://github.com/magicbell/magicbell-js/commit/aa44b32184e05526a5b0b1af6fa5f580d322aefe), [`184de06`](https://github.com/magicbell/magicbell-js/commit/184de06495eeb2643916246c31ea25250da3fabb), [`8649b12`](https://github.com/magicbell/magicbell-js/commit/8649b122832af97b250471fc2ee54b0977cf0027)]:
   - @magicbell/react-headless@4.4.8
 
 ## 10.9.9
 
 ### Patch Changes
 
-- [`9be10f5`](https://github.com/magicbell-io/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`9be10f5`](https://github.com/magicbell/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.202`.
 
-- [`d29b034`](https://github.com/magicbell-io/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d29b034`](https://github.com/magicbell/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `rosie` to `^2.1.1`.
 
-- Updated dependencies [[`9be10f5`](https://github.com/magicbell-io/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b), [`d29b034`](https://github.com/magicbell-io/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff)]:
+- Updated dependencies [[`9be10f5`](https://github.com/magicbell/magicbell-js/commit/9be10f5f641888f4431b8c112155c5b9b3f0731b), [`d29b034`](https://github.com/magicbell/magicbell-js/commit/d29b034767ba539164b330f0b3fd94822b8817ff)]:
   - @magicbell/react-headless@4.4.7
 
 ## 10.9.8
 
 ### Patch Changes
 
-- [#210](https://github.com/magicbell-io/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell-io/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#210](https://github.com/magicbell/magicbell-js/pull/210) [`9280ca7`](https://github.com/magicbell/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.45`.
 
-- [`d199c74`](https://github.com/magicbell-io/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`d199c74`](https://github.com/magicbell/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.201`.
 
-- [`8649613`](https://github.com/magicbell-io/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`8649613`](https://github.com/magicbell/magicbell-js/commit/864961352717771f8676c87d793e2ab26720cd5d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.20`.
 
-- Updated dependencies [[`ad7250e`](https://github.com/magicbell-io/magicbell-js/commit/ad7250edf64d2c80b3d80aa352dc9b32c83817b2), [`9280ca7`](https://github.com/magicbell-io/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656), [`d199c74`](https://github.com/magicbell-io/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9)]:
+- Updated dependencies [[`ad7250e`](https://github.com/magicbell/magicbell-js/commit/ad7250edf64d2c80b3d80aa352dc9b32c83817b2), [`9280ca7`](https://github.com/magicbell/magicbell-js/commit/9280ca79f6a51936cccaeb61cb78f0eabfb5c656), [`d199c74`](https://github.com/magicbell/magicbell-js/commit/d199c74d38c4dfe6e7d0bdcf63a4e8e19da9dda9)]:
   - @magicbell/webpush@1.4.1
   - @magicbell/react-headless@4.4.6
 
@@ -196,19 +196,19 @@
 
 ### Patch Changes
 
-- [#206](https://github.com/magicbell-io/magicbell-js/pull/206) [`22a17bb`](https://github.com/magicbell-io/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#206](https://github.com/magicbell/magicbell-js/pull/206) [`22a17bb`](https://github.com/magicbell/magicbell-js/commit/22a17bb0d1ee8fdfb76ab139c4a9f1243a2280b5) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `react-use` to `^17.4.0`.
 
-- [#207](https://github.com/magicbell-io/magicbell-js/pull/207) [`f694679`](https://github.com/magicbell-io/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#207](https://github.com/magicbell/magicbell-js/pull/207) [`f694679`](https://github.com/magicbell/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `tiny-invariant` to `^1.3.1`.
 
-- [#205](https://github.com/magicbell-io/magicbell-js/pull/205) [`430ea0b`](https://github.com/magicbell-io/magicbell-js/commit/430ea0b48adf863a8a1abd19cc5575bb5397624c) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#205](https://github.com/magicbell/magicbell-js/pull/205) [`430ea0b`](https://github.com/magicbell/magicbell-js/commit/430ea0b48adf863a8a1abd19cc5575bb5397624c) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@babel/core` to `^7.23.3`.
 
-- Updated dependencies [[`ef5248c`](https://github.com/magicbell-io/magicbell-js/commit/ef5248ce58525ac9f7113a5070822945b18a67cc), [`f694679`](https://github.com/magicbell-io/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8)]:
+- Updated dependencies [[`ef5248c`](https://github.com/magicbell/magicbell-js/commit/ef5248ce58525ac9f7113a5070822945b18a67cc), [`f694679`](https://github.com/magicbell/magicbell-js/commit/f6946794d559d7479288616dd69ae7d20d857ab8)]:
   - @magicbell/react-headless@4.4.5
 
 ## 10.9.6
@@ -222,25 +222,25 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`669e353`](https://github.com/magicbell-io/magicbell-js/commit/669e353af6facb124e1e608e23c69e46ff56a736), [`947f177`](https://github.com/magicbell-io/magicbell-js/commit/947f17789da9508f6ed561e1e6666964068e98ad)]:
+- Updated dependencies [[`669e353`](https://github.com/magicbell/magicbell-js/commit/669e353af6facb124e1e608e23c69e46ff56a736), [`947f177`](https://github.com/magicbell/magicbell-js/commit/947f17789da9508f6ed561e1e6666964068e98ad)]:
   - @magicbell/webpush@1.4.0
 
 ## 10.9.4
 
 ### Patch Changes
 
-- [#191](https://github.com/magicbell-io/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell-io/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#191](https://github.com/magicbell/magicbell-js/pull/191) [`9c30c22`](https://github.com/magicbell/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/rosie` to `^0.0.43`.
 
-- Updated dependencies [[`9c30c22`](https://github.com/magicbell-io/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d)]:
+- Updated dependencies [[`9c30c22`](https://github.com/magicbell/magicbell-js/commit/9c30c22f9f0a7e9facf10e89d8777a1eed4ce03d)]:
   - @magicbell/react-headless@4.4.3
 
 ## 10.9.3
 
 ### Patch Changes
 
-- [#194](https://github.com/magicbell-io/magicbell-js/pull/194) [`12dbaed`](https://github.com/magicbell-io/magicbell-js/commit/12dbaed2ce4d8b19d7090b568a1ce0e9e510b1e6) Thanks [@smeijer](https://github.com/smeijer)! - Add `isOpen` prop to `MagicBell` provider, together with the existing `onToggle` prop, this allows for controlled open/closed states.
+- [#194](https://github.com/magicbell/magicbell-js/pull/194) [`12dbaed`](https://github.com/magicbell/magicbell-js/commit/12dbaed2ce4d8b19d7090b568a1ce0e9e510b1e6) Thanks [@smeijer](https://github.com/smeijer)! - Add `isOpen` prop to `MagicBell` provider, together with the existing `onToggle` prop, this allows for controlled open/closed states.
 
   ```tsx
   function App() {
@@ -281,7 +281,7 @@
 
 ### Patch Changes
 
-- [#189](https://github.com/magicbell-io/magicbell-js/pull/189) [`c6054af`](https://github.com/magicbell-io/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043) Thanks [@smeijer](https://github.com/smeijer)! - support react strict mode
+- [#189](https://github.com/magicbell/magicbell-js/pull/189) [`c6054af`](https://github.com/magicbell/magicbell-js/commit/c6054afd4db0879b51ee4142d8295766cf983043) Thanks [@smeijer](https://github.com/smeijer)! - support react strict mode
 
 - Updated dependencies []:
   - @magicbell/react-headless@4.4.1
@@ -290,53 +290,53 @@
 
 ### Minor Changes
 
-- [#185](https://github.com/magicbell-io/magicbell-js/pull/185) [`78b62cb`](https://github.com/magicbell-io/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8) Thanks [@smeijer](https://github.com/smeijer)! - Listen to realtime events using SSE, and drop the Ably dependency
+- [#185](https://github.com/magicbell/magicbell-js/pull/185) [`78b62cb`](https://github.com/magicbell/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8) Thanks [@smeijer](https://github.com/smeijer)! - Listen to realtime events using SSE, and drop the Ably dependency
 
 ### Patch Changes
 
-- [#188](https://github.com/magicbell-io/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell-io/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#188](https://github.com/magicbell/magicbell-js/pull/188) [`f12d410`](https://github.com/magicbell/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.10`.
 
-- Updated dependencies [[`78b62cb`](https://github.com/magicbell-io/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8), [`f12d410`](https://github.com/magicbell-io/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a)]:
+- Updated dependencies [[`78b62cb`](https://github.com/magicbell/magicbell-js/commit/78b62cb571aba9d5eeb96015491b1cfbbb1c7fb8), [`f12d410`](https://github.com/magicbell/magicbell-js/commit/f12d4107bca195936832a466ec846fe0b657871a)]:
   - @magicbell/react-headless@4.4.0
 
 ## 10.8.3
 
 ### Patch Changes
 
-- [`79d3019`](https://github.com/magicbell-io/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`79d3019`](https://github.com/magicbell/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `immer` to `^9.0.21`.
 
-- [`0a40f2d`](https://github.com/magicbell-io/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`0a40f2d`](https://github.com/magicbell/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.198`.
 
-- [`ffb1b21`](https://github.com/magicbell-io/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`ffb1b21`](https://github.com/magicbell/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `sinon` to `^13.0.2`.
 
-- [`39ad36e`](https://github.com/magicbell-io/magicbell-js/commit/39ad36ed59f0949f7b06810534560a61e27f3d25) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`39ad36e`](https://github.com/magicbell/magicbell-js/commit/39ad36ed59f0949f7b06810534560a61e27f3d25) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `react-infinite-scroll-component` to `^6.1.0`.
 
-- [`0b63278`](https://github.com/magicbell-io/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`0b63278`](https://github.com/magicbell/magicbell-js/commit/0b6327842b529efcd7de89825f9a51015d34dcd3) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.16`.
 
-- [`5088009`](https://github.com/magicbell-io/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
+- [`5088009`](https://github.com/magicbell/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d) Thanks [@renovate[bot]](https://github.com/renovate%5Bbot%5D)! - Updated dependencies:
 
   - updated `dayjs` to `^1.11.9`.
 
-- Updated dependencies [[`79d3019`](https://github.com/magicbell-io/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49), [`0a40f2d`](https://github.com/magicbell-io/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2), [`6159725`](https://github.com/magicbell-io/magicbell-js/commit/6159725eddf22be5787ae1441131ef7aad97632e), [`ffb1b21`](https://github.com/magicbell-io/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68), [`f83b52c`](https://github.com/magicbell-io/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840), [`cda7f21`](https://github.com/magicbell-io/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5), [`5088009`](https://github.com/magicbell-io/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d)]:
+- Updated dependencies [[`79d3019`](https://github.com/magicbell/magicbell-js/commit/79d3019482c53644e44b016b41bad723ddd1bd49), [`0a40f2d`](https://github.com/magicbell/magicbell-js/commit/0a40f2d5f4eded31784caf7476771b90694684f2), [`6159725`](https://github.com/magicbell/magicbell-js/commit/6159725eddf22be5787ae1441131ef7aad97632e), [`ffb1b21`](https://github.com/magicbell/magicbell-js/commit/ffb1b213607f1ba5ff0d86c9478d758f89924a68), [`f83b52c`](https://github.com/magicbell/magicbell-js/commit/f83b52ccec1bf7479709252ccdda83522e736840), [`cda7f21`](https://github.com/magicbell/magicbell-js/commit/cda7f215d8d5cc71faf150ebc6843805a1572fb5), [`5088009`](https://github.com/magicbell/magicbell-js/commit/50880093f31b88e34a74d2f75b7860de1ac4b88d)]:
   - @magicbell/react-headless@4.3.2
 
 ## 10.8.2
 
 ### Patch Changes
 
-- Updated dependencies [[`4b458f8`](https://github.com/magicbell-io/magicbell-js/commit/4b458f85ae019acb57dd3b82539f32f89a4a96e7)]:
+- Updated dependencies [[`4b458f8`](https://github.com/magicbell/magicbell-js/commit/4b458f85ae019acb57dd3b82539f32f89a4a96e7)]:
   - @magicbell/webpush@1.3.1
 
 ## 10.8.1
@@ -350,30 +350,30 @@
 
 ### Minor Changes
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Use `magicbell` client for api requests. This change includes the addition of automatic retry of failed requests. Requests are retried up to 3 times with exponential backoff.
 
 ### Patch Changes
 
-- [#168](https://github.com/magicbell-io/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Mark `apiKey` and either `userEmail` or `userExternalId` as required. Note that this is an update in type definitions only, the implementation is not changed.
+- [#168](https://github.com/magicbell/magicbell-js/pull/168) [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5) Thanks [@smeijer](https://github.com/smeijer)! - Mark `apiKey` and either `userEmail` or `userExternalId` as required. Note that this is an update in type definitions only, the implementation is not changed.
 
-- Updated dependencies [[`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`b835ff3`](https://github.com/magicbell-io/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770), [`b835ff3`](https://github.com/magicbell-io/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770), [`ce6ecc2`](https://github.com/magicbell-io/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5)]:
+- Updated dependencies [[`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5), [`b835ff3`](https://github.com/magicbell/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770), [`b835ff3`](https://github.com/magicbell/magicbell-js/commit/b835ff33aa3f19d1855d69235db70ff4774c2770), [`ce6ecc2`](https://github.com/magicbell/magicbell-js/commit/ce6ecc2cb207effe9755ea1883f696dcf5d5aad5)]:
   - @magicbell/react-headless@4.3.0
 
 ## 10.7.5
 
 ### Patch Changes
 
-- [#160](https://github.com/magicbell-io/magicbell-js/pull/160) [`cb7c02a`](https://github.com/magicbell-io/magicbell-js/commit/cb7c02aaf3f1f22e43367b3a10e29393a36827a6) Thanks [@moxley01](https://github.com/moxley01)! - Updates React package README with minor fixes
+- [#160](https://github.com/magicbell/magicbell-js/pull/160) [`cb7c02a`](https://github.com/magicbell/magicbell-js/commit/cb7c02aaf3f1f22e43367b3a10e29393a36827a6) Thanks [@moxley01](https://github.com/moxley01)! - Updates React package README with minor fixes
 
 ## 10.7.4
 
 ### Patch Changes
 
-- [#153](https://github.com/magicbell-io/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell-io/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#153](https://github.com/magicbell/magicbell-js/pull/153) [`6aa5cee`](https://github.com/magicbell/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.195`.
 
-- Updated dependencies [[`6aa5cee`](https://github.com/magicbell-io/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8), [`2c7ba0c`](https://github.com/magicbell-io/magicbell-js/commit/2c7ba0c652317b626708561c1436f0439efe22fd)]:
+- Updated dependencies [[`6aa5cee`](https://github.com/magicbell/magicbell-js/commit/6aa5cee31e0a413207007803e7ad6a109a664cd8), [`2c7ba0c`](https://github.com/magicbell/magicbell-js/commit/2c7ba0c652317b626708561c1436f0439efe22fd)]:
   - @magicbell/react-headless@4.2.8
   - @magicbell/webpush@1.3.0
 
@@ -381,22 +381,22 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`03f2d30`](https://github.com/magicbell-io/magicbell-js/commit/03f2d3077a8e2affd02c8f2eb9e67253e793bb63)]:
+- Updated dependencies [[`03f2d30`](https://github.com/magicbell/magicbell-js/commit/03f2d3077a8e2affd02c8f2eb9e67253e793bb63)]:
   - @magicbell/webpush@1.2.0
 
 ## 10.7.2
 
 ### Patch Changes
 
-- [#113](https://github.com/magicbell-io/magicbell-js/pull/113) [`6e5297e`](https://github.com/magicbell-io/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#113](https://github.com/magicbell/magicbell-js/pull/113) [`6e5297e`](https://github.com/magicbell/magicbell-js/commit/6e5297e06b70df0c66af346953ca2bfd56aadc80) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/sinon` to `^10.0.15`.
 
-- [#111](https://github.com/magicbell-io/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell-io/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
+- [#111](https://github.com/magicbell/magicbell-js/pull/111) [`8987a92`](https://github.com/magicbell/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716) Thanks [@renovate](https://github.com/apps/renovate)! - Updated dependencies:
 
   - updated `@types/lodash` to `^4.14.194`.
 
-- [#120](https://github.com/magicbell-io/magicbell-js/pull/120) [`9e98288`](https://github.com/magicbell-io/magicbell-js/commit/9e982889f37e70702f24dcc87296406d25623a8c) Thanks [@smeijer](https://github.com/smeijer)! - Updates the `PushNotificationsSubscriber` component to use our `@magicbell/webpush`
+- [#120](https://github.com/magicbell/magicbell-js/pull/120) [`9e98288`](https://github.com/magicbell/magicbell-js/commit/9e982889f37e70702f24dcc87296406d25623a8c) Thanks [@smeijer](https://github.com/smeijer)! - Updates the `PushNotificationsSubscriber` component to use our `@magicbell/webpush`
   SDK. This change makes it compatible with the latest browsers and our updated API.
 
   ```jsx
@@ -411,7 +411,7 @@
   }
   ```
 
-- Updated dependencies [[`c030ce4`](https://github.com/magicbell-io/magicbell-js/commit/c030ce41e094c19b62cbabbbe62f8e3b0ceeb31f), [`8987a92`](https://github.com/magicbell-io/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716), [`5bd3ac7`](https://github.com/magicbell-io/magicbell-js/commit/5bd3ac767602d06409dafcd9a144e5c18fbfd55c), [`549c8a9`](https://github.com/magicbell-io/magicbell-js/commit/549c8a911bdb8bb4467c90398de6d130451be818)]:
+- Updated dependencies [[`c030ce4`](https://github.com/magicbell/magicbell-js/commit/c030ce41e094c19b62cbabbbe62f8e3b0ceeb31f), [`8987a92`](https://github.com/magicbell/magicbell-js/commit/8987a92fe0d48999514228d09a2c89cfcc6e4716), [`5bd3ac7`](https://github.com/magicbell/magicbell-js/commit/5bd3ac767602d06409dafcd9a144e5c18fbfd55c), [`549c8a9`](https://github.com/magicbell/magicbell-js/commit/549c8a911bdb8bb4467c90398de6d130451be818)]:
   - @magicbell/react-headless@4.2.7
   - @magicbell/webpush@1.0.0
 
@@ -419,13 +419,13 @@
 
 ### Patch Changes
 
-- [#107](https://github.com/magicbell-io/magicbell-js/pull/107) [`eb256a1`](https://github.com/magicbell-io/magicbell-js/commit/eb256a1d0bc11f628975d5ce1e40e20c97fc0d47) Thanks [@smeijer](https://github.com/smeijer)! - fix: use accent color for dialog buttons
+- [#107](https://github.com/magicbell/magicbell-js/pull/107) [`eb256a1`](https://github.com/magicbell/magicbell-js/commit/eb256a1d0bc11f628975d5ce1e40e20c97fc0d47) Thanks [@smeijer](https://github.com/smeijer)! - fix: use accent color for dialog buttons
 
 ## 10.7.0
 
 ### Minor Changes
 
-- [#103](https://github.com/magicbell-io/magicbell-js/pull/103) [`e83a694`](https://github.com/magicbell-io/magicbell-js/commit/e83a694e3f681e3edd6aeb7708e430811e14bc15) Thanks [@smeijer](https://github.com/smeijer)! - feat: Add support for theming the enable-push-subscriptions dialog.
+- [#103](https://github.com/magicbell/magicbell-js/pull/103) [`e83a694`](https://github.com/magicbell/magicbell-js/commit/e83a694e3f681e3edd6aeb7708e430811e14bc15) Thanks [@smeijer](https://github.com/smeijer)! - feat: Add support for theming the enable-push-subscriptions dialog.
 
   ```typescript jsx
   const theme = {
@@ -445,7 +445,7 @@
 
 ### Minor Changes
 
-- [#88](https://github.com/magicbell-io/magicbell-js/pull/88) [`7f9ecbc`](https://github.com/magicbell-io/magicbell-js/commit/7f9ecbc3594af2035b4fa063adc593a7fe4c722c) Thanks [@TD-4242](https://github.com/TD-4242)! - feat: support css variables as theme color value
+- [#88](https://github.com/magicbell/magicbell-js/pull/88) [`7f9ecbc`](https://github.com/magicbell/magicbell-js/commit/7f9ecbc3594af2035b4fa063adc593a7fe4c722c) Thanks [@TD-4242](https://github.com/TD-4242)! - feat: support css variables as theme color value
 
   ```tsx
   import MagicBell, { NotificationInbox } from '@magicbell/magicbell-react';
@@ -465,27 +465,27 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`fbbbae7`](https://github.com/magicbell-io/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529)]:
+- Updated dependencies [[`fbbbae7`](https://github.com/magicbell/magicbell-js/commit/fbbbae744e0b39b9caca32fd329b148709749529)]:
   - @magicbell/react-headless@4.2.6
 
 ## 10.5.1
 
 ### Patch Changes
 
-- Updated dependencies [[`6eb5705`](https://github.com/magicbell-io/magicbell-js/commit/6eb5705c502ab64caa32ce1d5ffa79d1fd671b06)]:
+- Updated dependencies [[`6eb5705`](https://github.com/magicbell/magicbell-js/commit/6eb5705c502ab64caa32ce1d5ffa79d1fd671b06)]:
   - @magicbell/react-headless@4.2.5
 
 ## 10.5.0
 
 ### Minor Changes
 
-- [#62](https://github.com/magicbell-io/magicbell-js/pull/62) [`2d96a3d`](https://github.com/magicbell-io/magicbell-js/commit/2d96a3d5426f62dd3a89c286f0c6c2d7195de612) Thanks [@pianomansam](https://github.com/pianomansam)! - feat: don't open action-url when notification click handler returns false
+- [#62](https://github.com/magicbell/magicbell-js/pull/62) [`2d96a3d`](https://github.com/magicbell/magicbell-js/commit/2d96a3d5426f62dd3a89c286f0c6c2d7195de612) Thanks [@pianomansam](https://github.com/pianomansam)! - feat: don't open action-url when notification click handler returns false
 
 ## 10.4.0
 
 ### Minor Changes
 
-- [`4347cf3`](https://github.com/magicbell-io/magicbell-js/commit/4347cf322d7b057769771fd3f06dad60b98d18aa) Thanks [@smeijer](https://github.com/smeijer)! - feat: category labels in the preferences pane are now translatable.
+- [`4347cf3`](https://github.com/magicbell/magicbell-js/commit/4347cf322d7b057769771fd3f06dad60b98d18aa) Thanks [@smeijer](https://github.com/smeijer)! - feat: category labels in the preferences pane are now translatable.
 
   ```typescript jsx
   const customLocale = {
@@ -512,40 +512,40 @@
 
 ### Patch Changes
 
-- [#46](https://github.com/magicbell-io/magicbell-js/pull/46) [`017b0cd`](https://github.com/magicbell-io/magicbell-js/commit/017b0cd52ed004de24d98d3a99ac5503031d4e66) Thanks [@smeijer](https://github.com/smeijer)! - fix: wait for `markAsRead` before opening notification `action_url`.
+- [#46](https://github.com/magicbell/magicbell-js/pull/46) [`017b0cd`](https://github.com/magicbell/magicbell-js/commit/017b0cd52ed004de24d98d3a99ac5503031d4e66) Thanks [@smeijer](https://github.com/smeijer)! - fix: wait for `markAsRead` before opening notification `action_url`.
 
   This fixes a race-condition where the page reload and fetching new notifications is faster than marking the notification as read, which would result in showing the notification as 'unread' upon page (re)load.
 
-- Updated dependencies [[`8d30258`](https://github.com/magicbell-io/magicbell-js/commit/8d302586175a1219c743b0135038538a591e0a0c)]:
+- Updated dependencies [[`8d30258`](https://github.com/magicbell/magicbell-js/commit/8d302586175a1219c743b0135038538a591e0a0c)]:
   - @magicbell/react-headless@4.2.4
 
 ## 10.3.4
 
 ### Patch Changes
 
-- [#26](https://github.com/magicbell-io/magicbell-js/pull/26) [`2f295b0`](https://github.com/magicbell-io/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7) Thanks [@smeijer](https://github.com/smeijer)! - Remove react-dom from peer-dependencies, so we don't cause trouble in react-native projects.
+- [#26](https://github.com/magicbell/magicbell-js/pull/26) [`2f295b0`](https://github.com/magicbell/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7) Thanks [@smeijer](https://github.com/smeijer)! - Remove react-dom from peer-dependencies, so we don't cause trouble in react-native projects.
 
-- Updated dependencies [[`2f295b0`](https://github.com/magicbell-io/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7)]:
+- Updated dependencies [[`2f295b0`](https://github.com/magicbell/magicbell-js/commit/2f295b0a02bf735e0f594f0bd0985b1523615ac7)]:
   - @magicbell/react-headless@4.2.3
 
 ## 10.3.3
 
 ### Patch Changes
 
-- [#13](https://github.com/magicbell-io/magicbell-js/pull/13) [`1cb984c`](https://github.com/magicbell-io/magicbell-js/commit/1cb984cfac485254c286385d8a750bc3c62cfbbb) Thanks [@3v0k4](https://github.com/3v0k4)! - Fix embeddable web notifications: since embeddable aliases axios (redaxios) and redaxios does not implement `.getUri`, the code was failing for the embeddable package (that uses redaxios) but not for the react package (that uses axios).
+- [#13](https://github.com/magicbell/magicbell-js/pull/13) [`1cb984c`](https://github.com/magicbell/magicbell-js/commit/1cb984cfac485254c286385d8a750bc3c62cfbbb) Thanks [@3v0k4](https://github.com/3v0k4)! - Fix embeddable web notifications: since embeddable aliases axios (redaxios) and redaxios does not implement `.getUri`, the code was failing for the embeddable package (that uses redaxios) but not for the react package (that uses axios).
 
 ## 10.3.2
 
 ### Patch Changes
 
-- Updated dependencies [[`08f4abb`](https://github.com/magicbell-io/magicbell-js/commit/08f4abb6605de603688e970c49218e5aa41ebc08)]
+- Updated dependencies [[`08f4abb`](https://github.com/magicbell/magicbell-js/commit/08f4abb6605de603688e970c49218e5aa41ebc08)]
   - @magicbell/react-headless@4.2.2
 
 ## 10.3.1
 
 ### Patch Changes
 
-- [`36d7ef7`](https://github.com/magicbell-io/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the notification click handler does not get invoked when clicking buttons and links inside the notification content.
+- [`36d7ef7`](https://github.com/magicbell/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5) Thanks [@smeijer](https://github.com/smeijer)! - ensure that the notification click handler does not get invoked when clicking buttons and links inside the notification content.
 
-- Updated dependencies [[`36d7ef7`](https://github.com/magicbell-io/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5)]:
+- Updated dependencies [[`36d7ef7`](https://github.com/magicbell/magicbell-js/commit/36d7ef726317efac1cbe30a97afdf26c5a4e7cd5)]:
   - @magicbell/react-headless@4.2.1

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/magicbell-io/magicbell-react/branch/main/graph/badge.svg?token=T3u1e0sLpC)](https://codecov.io/gh/magicbell-io/magicbell-react)
+[![codecov](https://codecov.io/gh/magicbell/magicbell-react/branch/main/graph/badge.svg?token=T3u1e0sLpC)](https://codecov.io/gh/magicbell/magicbell-react)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![minified](https://badgen.net/bundlephobia/min/@magicbell/magicbell-react@latest)](https://bundlephobia.com/result?p=@magicbell/magicbell-react)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,10 +34,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/react/tests/factories/NotificationPreferencesFactory.ts
+++ b/packages/react/tests/factories/NotificationPreferencesFactory.ts
@@ -1,5 +1,5 @@
 // TODO: Consider creating a test library and/or exposing our existing test
-// data: specifically https://github.com/magicbell-io/react-headless/blob/main/tests/factories/NotificationPreferencesFactory.ts
+// data: specifically https://github.com/magicbell/react-headless/blob/main/tests/factories/NotificationPreferencesFactory.ts
 // in this case.
 
 import IRemoteNotificationPreferences from '@magicbell/react-headless/src/types/IRemoteNotificationPreferences';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git",
+    "url": "git@github.com:magicbell/magicbell-js.git",
     "directory": "packages/utils"
   },
   "scripts": {

--- a/packages/webpush/CHANGELOG.md
+++ b/packages/webpush/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- [#284](https://github.com/magicbell-io/magicbell-js/pull/284) [`2095743`](https://github.com/magicbell-io/magicbell-js/commit/2095743f23e5fe35da335dfaa84e6808616f58f1) Thanks [@smeijer](https://github.com/smeijer)! - chore: type fix, apiKey isn't needed when using authToken
+- [#284](https://github.com/magicbell/magicbell-js/pull/284) [`2095743`](https://github.com/magicbell/magicbell-js/commit/2095743f23e5fe35da335dfaa84e6808616f58f1) Thanks [@smeijer](https://github.com/smeijer)! - chore: type fix, apiKey isn't needed when using authToken
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#283](https://github.com/magicbell-io/magicbell-js/pull/283) [`7bea88f`](https://github.com/magicbell-io/magicbell-js/commit/7bea88f45389329261843d7b2e0fb8d06fe62078) Thanks [@smeijer](https://github.com/smeijer)! - **BREAKING CHANGE!**
+- [#283](https://github.com/magicbell/magicbell-js/pull/283) [`7bea88f`](https://github.com/magicbell/magicbell-js/commit/7bea88f45389329261843d7b2e0fb8d06fe62078) Thanks [@smeijer](https://github.com/smeijer)! - **BREAKING CHANGE!**
 
   This is a complete revamp of how we're registering client push notification subscriptions, but given that the v1 API surface is small, migrating should be easy enough. You can find [the migration guide on our site](https://magicbell.com/docs/guides/migrations/upgrade-magicbell-webpush-to-v2).
 
@@ -120,19 +120,19 @@
 
 ### Patch Changes
 
-- [#252](https://github.com/magicbell-io/magicbell-js/pull/252) [`b37ed53`](https://github.com/magicbell-io/magicbell-js/commit/b37ed530d35dc5060e05d2b588d255f8648cc865) Thanks [@smeijer](https://github.com/smeijer)! - add entry point for unpkg
+- [#252](https://github.com/magicbell/magicbell-js/pull/252) [`b37ed53`](https://github.com/magicbell/magicbell-js/commit/b37ed530d35dc5060e05d2b588d255f8648cc865) Thanks [@smeijer](https://github.com/smeijer)! - add entry point for unpkg
 
 ## 1.4.1
 
 ### Patch Changes
 
-- [#212](https://github.com/magicbell-io/magicbell-js/pull/212) [`ad7250e`](https://github.com/magicbell-io/magicbell-js/commit/ad7250edf64d2c80b3d80aa352dc9b32c83817b2) Thanks [@smeijer](https://github.com/smeijer)! - fix bug when accessing undefined serviceWorker in Safari for iOS
+- [#212](https://github.com/magicbell/magicbell-js/pull/212) [`ad7250e`](https://github.com/magicbell/magicbell-js/commit/ad7250edf64d2c80b3d80aa352dc9b32c83817b2) Thanks [@smeijer](https://github.com/smeijer)! - fix bug when accessing undefined serviceWorker in Safari for iOS
 
 ## 1.4.0
 
 ### Minor Changes
 
-- [#197](https://github.com/magicbell-io/magicbell-js/pull/197) [`947f177`](https://github.com/magicbell-io/magicbell-js/commit/947f17789da9508f6ed561e1e6666964068e98ad) Thanks [@smeijer](https://github.com/smeijer)! - Add `getAuthToken` function to exchange API Key based user credentials for jwt token.
+- [#197](https://github.com/magicbell/magicbell-js/pull/197) [`947f177`](https://github.com/magicbell/magicbell-js/commit/947f17789da9508f6ed561e1e6666964068e98ad) Thanks [@smeijer](https://github.com/smeijer)! - Add `getAuthToken` function to exchange API Key based user credentials for jwt token.
 
   ```js
   import { getAuthToken } from '@magicbell/webpush';
@@ -154,19 +154,19 @@
 
 ### Patch Changes
 
-- [#199](https://github.com/magicbell-io/magicbell-js/pull/199) [`669e353`](https://github.com/magicbell-io/magicbell-js/commit/669e353af6facb124e1e608e23c69e46ff56a736) Thanks [@smeijer](https://github.com/smeijer)! - fix issue in `isSubscribed` method that caused it to be stuck waiting for the service worker `ready` event when no service worker was registered.
+- [#199](https://github.com/magicbell/magicbell-js/pull/199) [`669e353`](https://github.com/magicbell/magicbell-js/commit/669e353af6facb124e1e608e23c69e46ff56a736) Thanks [@smeijer](https://github.com/smeijer)! - fix issue in `isSubscribed` method that caused it to be stuck waiting for the service worker `ready` event when no service worker was registered.
 
 ## 1.3.1
 
 ### Patch Changes
 
-- [#175](https://github.com/magicbell-io/magicbell-js/pull/175) [`4b458f8`](https://github.com/magicbell-io/magicbell-js/commit/4b458f85ae019acb57dd3b82539f32f89a4a96e7) Thanks [@moxley01](https://github.com/moxley01)! - Fixes an issue where webpush 'isSubscribed' method throws an error in some mobile browsers.
+- [#175](https://github.com/magicbell/magicbell-js/pull/175) [`4b458f8`](https://github.com/magicbell/magicbell-js/commit/4b458f85ae019acb57dd3b82539f32f89a4a96e7) Thanks [@moxley01](https://github.com/moxley01)! - Fixes an issue where webpush 'isSubscribed' method throws an error in some mobile browsers.
 
 ## 1.3.0
 
 ### Minor Changes
 
-- [#155](https://github.com/magicbell-io/magicbell-js/pull/155) [`2c7ba0c`](https://github.com/magicbell-io/magicbell-js/commit/2c7ba0c652317b626708561c1436f0439efe22fd) Thanks [@moxley01](https://github.com/moxley01)! - Adds an 'isSubscribed' method that checks if the user is subscribed to push notifications in the current browser, e.g.
+- [#155](https://github.com/magicbell/magicbell-js/pull/155) [`2c7ba0c`](https://github.com/magicbell/magicbell-js/commit/2c7ba0c652317b626708561c1436f0439efe22fd) Thanks [@moxley01](https://github.com/moxley01)! - Adds an 'isSubscribed' method that checks if the user is subscribed to push notifications in the current browser, e.g.
 
   ```js
   import { isSubscribed } from '@magicbell/webpush';
@@ -188,7 +188,7 @@
 
 ### Minor Changes
 
-- [#126](https://github.com/magicbell-io/magicbell-js/pull/126) [`03f2d30`](https://github.com/magicbell-io/magicbell-js/commit/03f2d3077a8e2affd02c8f2eb9e67253e793bb63) Thanks [@smeijer](https://github.com/smeijer)! - Added warmup method to speedup subscription process. By prefetching config, you'll separate the subscription from config fetching, and thereby reduce the time to subscribe, which improves the user experience.
+- [#126](https://github.com/magicbell/magicbell-js/pull/126) [`03f2d30`](https://github.com/magicbell/magicbell-js/commit/03f2d3077a8e2affd02c8f2eb9e67253e793bb63) Thanks [@smeijer](https://github.com/smeijer)! - Added warmup method to speedup subscription process. By prefetching config, you'll separate the subscription from config fetching, and thereby reduce the time to subscribe, which improves the user experience.
 
   ```js
   import { prefetchConfig } from '@magicbell/webpush';
@@ -205,13 +205,13 @@
 
 ### Minor Changes
 
-- [#121](https://github.com/magicbell-io/magicbell-js/pull/121) [`4e567b9`](https://github.com/magicbell-io/magicbell-js/commit/4e567b93c231975caf941c8daf5d64ea92db5aff) Thanks [@smeijer](https://github.com/smeijer)! - Remove support for Safari's proprietary push notification protocol.
+- [#121](https://github.com/magicbell/magicbell-js/pull/121) [`4e567b9`](https://github.com/magicbell/magicbell-js/commit/4e567b93c231975caf941c8daf5d64ea92db5aff) Thanks [@smeijer](https://github.com/smeijer)! - Remove support for Safari's proprietary push notification protocol.
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#119](https://github.com/magicbell-io/magicbell-js/pull/119) [`549c8a9`](https://github.com/magicbell-io/magicbell-js/commit/549c8a911bdb8bb4467c90398de6d130451be818) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `registerServiceWorker` method that can be used to register a service
+- [#119](https://github.com/magicbell/magicbell-js/pull/119) [`549c8a9`](https://github.com/magicbell/magicbell-js/commit/549c8a911bdb8bb4467c90398de6d130451be818) Thanks [@smeijer](https://github.com/smeijer)! - feat: add `registerServiceWorker` method that can be used to register a service
   worker, prior to calling `subscribe`. This preflight allows for a faster
   subscription process.
 
@@ -234,25 +234,25 @@
 
 ### Patch Changes
 
-- [#104](https://github.com/magicbell-io/magicbell-js/pull/104) [`6454a1b`](https://github.com/magicbell-io/magicbell-js/commit/6454a1b0cb1de65e700bc065ab89c41f0e5c549a) Thanks [@smeijer](https://github.com/smeijer)! - fix: use jwt token for post request
+- [#104](https://github.com/magicbell/magicbell-js/pull/104) [`6454a1b`](https://github.com/magicbell/magicbell-js/commit/6454a1b0cb1de65e700bc065ab89c41f0e5c549a) Thanks [@smeijer](https://github.com/smeijer)! - fix: use jwt token for post request
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [`2dbd982`](https://github.com/magicbell-io/magicbell-js/commit/2dbd982b750736809525a00d083f06b5fe9cb9e2) Thanks [@smeijer](https://github.com/smeijer)! - fix: correct project param
+- [`2dbd982`](https://github.com/magicbell/magicbell-js/commit/2dbd982b750736809525a00d083f06b5fe9cb9e2) Thanks [@smeijer](https://github.com/smeijer)! - fix: correct project param
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [#99](https://github.com/magicbell-io/magicbell-js/pull/99) [`028456a`](https://github.com/magicbell-io/magicbell-js/commit/028456a1acd4a7e9487aa991d0e9e8da43f344ba) Thanks [@smeijer](https://github.com/smeijer)! - fix: include project param in subscribe method
+- [#99](https://github.com/magicbell/magicbell-js/pull/99) [`028456a`](https://github.com/magicbell/magicbell-js/commit/028456a1acd4a7e9487aa991d0e9e8da43f344ba) Thanks [@smeijer](https://github.com/smeijer)! - fix: include project param in subscribe method
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [#93](https://github.com/magicbell-io/magicbell-js/pull/93) [`5eeee58`](https://github.com/magicbell-io/magicbell-js/commit/5eeee58ef8f92a68bbe3d0407f1630d5531074ec) Thanks [@smeijer](https://github.com/smeijer)! - Publish `@magicbell/webpush`, this package provides a convenient interface to subscribe to browser/web push notifications using [MagicBell](https://magicbell.com).
+- [#93](https://github.com/magicbell/magicbell-js/pull/93) [`5eeee58`](https://github.com/magicbell/magicbell-js/commit/5eeee58ef8f92a68bbe3d0407f1630d5531074ec) Thanks [@smeijer](https://github.com/smeijer)! - Publish `@magicbell/webpush`, this package provides a convenient interface to subscribe to browser/web push notifications using [MagicBell](https://magicbell.com).
 
   ```js
   import { subscribe } from '@magicbell/webpush';

--- a/packages/webpush/package.json
+++ b/packages/webpush/package.json
@@ -28,10 +28,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:magicbell-io/magicbell-js.git"
+    "url": "git@github.com:magicbell/magicbell-js.git"
   },
   "bugs": {
-    "url": "https://github.com/magicbell-io/magicbell-js/issues"
+    "url": "https://github.com/magicbell/magicbell-js/issues"
   },
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
Fix all links pointing to our old github org name.