### PR TITLE
chore: use turbo to run codegens

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:example": "yarn --cwd example && yarn --cwd example start",
     "start:storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
     "start:playground": "yarn --cwd packages/playground start",
-    "generate:resources": "yarn --cwd packages/magicbell generate:resources && yarn --cwd packages/cli generate:resources",
+    "codegen": "turbo run codegen --parallel --no-cache",
     "build": "turbo run build",
     "build:example": "yarn --cwd example && yarn --cwd example build",
     "build:storybook": "build-storybook",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "build": "run-s clean build:prod",
     "build:prod": "vite build",
     "build:bin": "pkg dist/index.cjs --public --public-packages '*' --no-bytecode -o 'dist/bin/magicbell' --targets node18-linux-x64,node18-linux-arm64,node18-macos-x64,node18-macos-arm64,node18-win-x64,node18-win-arm64",
-    "generate:resources": "tsx scripts/generate-resources.ts --dest ./src",
+    "codegen": "tsx scripts/generate-resources.ts --dest ./src",
     "start": "yarn build:prod --watch",
     "size": "size-limit"
   },

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -70,7 +70,7 @@
     "build:entry:user-client": "cross-env ENTRY=src/user-client.ts vite build",
     "build:entry:crypto": "cross-env ENTRY=src/crypto.ts vite build",
     "build:entry:errors": "cross-env ENTRY=src/errors.ts vite build",
-    "generate:resources": "tsx scripts/generate-resources.ts --dest ./src",
+    "codegen": "tsx scripts/generate-resources.ts --dest ./src",
     "start": "npm run clean && run-p 'build:entry:* --watch'",
     "size": "size-limit"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,9 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]
     },
+    "codegen": {
+      "cache": false
+    },
     "start": {
       "cache": false
     },


### PR DESCRIPTION
This change allows us to run `yarn codegen`, to run `codegen` in every package that has one defined.