### PR TITLE
chore: setup preview releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,4 +70,4 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: yarn build
       - name: publish preview release
-        run: npx pkg-pr-new publish --no-template $(ls -d ./packages/*)
+        run: npx pkg-pr-new publish --no-template --compact $(ls -d ./packages/*)


### PR DESCRIPTION
This is in addition to #311. The `--compact` flag needed the packages to be updated at npm first so it could read the proper repository URL from them.