### PR TITLE
fix: sparsely provide `accept-version` header

### DIFF
--- a/.changeset/famous-starfishes-play.md
+++ b/.changeset/famous-starfishes-play.md
@@ -1,0 +1,6 @@
+---
+'magicbell': patch
+'@magicbell/cli': patch
+---
+
+We now only include the `accept-version` header for endpoints that consume it.

--- a/packages/magicbell/src/client/headers.ts
+++ b/packages/magicbell/src/client/headers.ts
@@ -23,10 +23,14 @@ function setRequestHeaders(options: ClientOptions, request: Request) {
     getDefaultIdempotencyKey(request.method, options.maxRetries);
 
   // default headers
-  request.headers.set('accept-version', 'v2');
   request.headers.set('content-type', 'application/json');
   request.headers.set('accept', 'application/json');
   request.headers.set('idempotency-key', idempotencyKey);
+
+  // this is the only endpoint that will ever work with the accept-version: v2 header
+  if (new URL(request.url).pathname === '/notification_preferences') {
+    request.headers.set('accept-version', 'v2');
+  }
 
   // user provided headers
   for (const [key, value] of Object.entries(options.headers || {})) {


### PR DESCRIPTION
This ensures that the `accept-version: v2` header is only provided to endpoints that really use it, which is currently limited to the `GET /notification_preferences`.