### PR TITLE
fix: exclude all builtin modules

### DIFF
--- a/.changeset/light-jeans-drum.md
+++ b/.changeset/light-jeans-drum.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+ensure all native node modules are excluded from the bundle

--- a/packages/cli/vite.config.js
+++ b/packages/cli/vite.config.js
@@ -1,3 +1,5 @@
+import { builtinModules } from 'node:module';
+
 import { defineConfig } from 'vite';
 
 import baseConfig from '../../scripts/vite/vite.config.js';
@@ -8,6 +10,6 @@ export default defineConfig(async (configEnv) => {
   base.build.lib.fileName = () => 'index.cjs';
   base.build.sourcemap = false;
 
-  base.build.rollupOptions.external = ['fs', 'http', 'https', 'path', 'url', 'os', 'crypto', 'readline', 'process'];
+  base.build.rollupOptions.external = builtinModules;
   return base;
 });


### PR DESCRIPTION
This makes sure that all native node modules are seen as `external` (not excluded in the bundle) and thereby fixes the `TypeError: assert.equal is not a function`, which was caused by `signalExit` (which is included by `configstore`)