### PR TITLE
fix: remove delete push subscription function

### DIFF
--- a/.changeset/rich-lions-work.md
+++ b/.changeset/rich-lions-work.md
@@ -1,0 +1,6 @@
+---
+'magicbell': patch
+'@magicbell/cli': patch
+---
+
+removed function to delete push subscriptions, as it doesn't exist on our v1 (current) api.

--- a/packages/cli/src/project-resources/users/push-subscriptions.ts
+++ b/packages/cli/src/project-resources/users/push-subscriptions.ts
@@ -29,15 +29,3 @@ usersPushSubscriptions
       await response.then((result) => printJson(result));
     }
   });
-
-usersPushSubscriptions
-  .command('delete')
-  .description("Delete user's push subscription")
-  .argument('<user-id>', 'The user id is the MagicBell user id. Accepts a UUID')
-  .argument('<subscription-id>', 'ID of the subscription.')
-  .action(async (userId, subscriptionId, opts, cmd) => {
-    const { options } = parseOptions(opts);
-
-    const response = await getClient(cmd).users.pushSubscriptions.delete(userId, subscriptionId, options);
-    printJson(response);
-  });

--- a/packages/magicbell/src/project-resources/users/push-subscriptions.ts
+++ b/packages/magicbell/src/project-resources/users/push-subscriptions.ts
@@ -55,27 +55,4 @@ export class UsersPushSubscriptions extends Resource {
       options,
     );
   }
-
-  /**
-   * Delete a user's push subscriptions. Identifies the user by the user's ID and the
-   * push subscription by the subscription's ID.
-   *
-   * @param userId - The user id is the MagicBell user id. Accepts a UUID
-   * @param subscriptionId - ID of the subscription.
-   *   The ID of a subscription can be obtained from the "Fetch user subscriptions" API
-   *   endpoint or from push events sent to the MagicBell React library.
-   *
-   * @param options - override client request options.
-   **/
-  delete(userId: string, subscriptionId: string, options?: RequestOptions): Promise<void> {
-    return this.request(
-      {
-        method: 'DELETE',
-        path: '{user_id}/push_subscriptions/{subscription_id}',
-      },
-      userId,
-      subscriptionId,
-      options,
-    );
-  }
 }


### PR DESCRIPTION
removed function to delete push subscriptions, as it doesn't exist on our v1 (current) api. It existed in our openapi spec, but the api was never created.
