### PR TITLE
feat: add more notification statuses

### DIFF
--- a/.changeset/gorgeous-cheetahs-suffer.md
+++ b/.changeset/gorgeous-cheetahs-suffer.md
@@ -1,6 +1,6 @@
 ---
-'magicbell': patch
-'@magicbell/cli': patch
+'magicbell': minor
+'@magicbell/cli': minor
 ---
 
 define more notification delivery statuses, added `skipped`, `dropped`, `failed`, and `delivered`.

--- a/.changeset/gorgeous-cheetahs-suffer.md
+++ b/.changeset/gorgeous-cheetahs-suffer.md
@@ -1,0 +1,6 @@
+---
+'magicbell': patch
+'@magicbell/cli': patch
+---
+
+define more notification delivery statuses, added `skipped`, `dropped`, `failed`, and `delivered`.

--- a/packages/magicbell/src/schemas/broadcasts/notifications.ts
+++ b/packages/magicbell/src/schemas/broadcasts/notifications.ts
@@ -181,7 +181,7 @@ export const ListBroadcastsNotificationsResponseSchema = {
                 status: {
                   type: 'string',
                   description: 'The status of the notification delivery.',
-                  enum: ['processing', 'scheduled', 'sent', 'invalid'],
+                  enum: ['processing', 'skipped', 'dropped', 'scheduled', 'sent', 'failed', 'delivered'],
                   nullable: false,
                 },
               },

--- a/packages/magicbell/src/schemas/users/notifications.ts
+++ b/packages/magicbell/src/schemas/users/notifications.ts
@@ -200,7 +200,7 @@ export const ListUsersNotificationsResponseSchema = {
                 status: {
                   type: 'string',
                   description: 'The status of the notification delivery.',
-                  enum: ['processing', 'scheduled', 'sent', 'invalid'],
+                  enum: ['processing', 'skipped', 'dropped', 'scheduled', 'sent', 'failed', 'delivered'],
                   nullable: false,
                 },
               },


### PR DESCRIPTION
define more notification delivery statuses, added `skipped`, `dropped`, `failed`, and `delivered`.
