### PR TITLE
chore: split changesets

### DIFF
--- a/.changeset/healthy-bugs-greet.md
+++ b/.changeset/healthy-bugs-greet.md
@@ -14,10 +14,10 @@ import { MagicBellProvider } from '@magicbell/react-headless';
 const stores = [
   { id: 'default', defaultQueryParams: {} },
   { id: 'unread', defaultQueryParams: { read: false } },
--  { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
-+  { id: 'billing', defaultQueryParams: { category: 'billing' } },
--  { id: 'support', defaultQueryParams: { topics: ['support'] } },
-+  { id: 'support', defaultQueryParams: { topic: 'support' } },
+- { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
++ { id: 'billing', defaultQueryParams: { category: 'billing' } },
+- { id: 'support', defaultQueryParams: { topics: ['support'] } },
++ { id: 'support', defaultQueryParams: { topic: 'support' } },
 ];
 
 export default function Index({ children }) {

--- a/.changeset/healthy-bugs-greet.md
+++ b/.changeset/healthy-bugs-greet.md
@@ -1,0 +1,35 @@
+---
+'@magicbell/react-headless': major
+---
+
+**Breaking Change**!
+
+We've renamed the `categories` property to `category` and the `topics` property to `topic`, to reflect that these properties only support a single value. We haven't been supporting multiple categories or topics for a while now, and believe that renaming this property is the right thing to do. It requires a small change on your end, but the clear naming reduces the number of potential bugs caused by misunderstanding.
+
+If you make use of different stores or filters using the `categories` or `topics` properties, you'll need to rename them to their singular variants.
+
+```diff
+import { MagicBellProvider } from '@magicbell/react-headless';
+
+const stores = [
+  { id: 'default', defaultQueryParams: {} },
+  { id: 'unread', defaultQueryParams: { read: false } },
+-  { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
++  { id: 'billing', defaultQueryParams: { category: 'billing' } },
+-  { id: 'support', defaultQueryParams: { topics: ['support'] } },
++  { id: 'support', defaultQueryParams: { topic: 'support' } },
+];
+
+export default function Index({ children }) {
+  return (
+    <MagicBellProvider
+      apiKey="__MAGICBELL_API_KEY__"
+      userEmail="__MAGICBELL_USER_EMAIL__"
+      userKey="__MAGICBELL_USER_KEY__"
+      stores={stores}
+    >
+      {children}
+    </MagicBell>
+  );
+}
+```

--- a/.changeset/mean-chicken-rescue.md
+++ b/.changeset/mean-chicken-rescue.md
@@ -1,0 +1,5 @@
+---
+'playground': minor
+---
+
+update playground to match singular topic & category params

--- a/.changeset/selfish-guests-hope.md
+++ b/.changeset/selfish-guests-hope.md
@@ -1,8 +1,4 @@
 ---
-'@magicbell/react-headless': major
-'playground': major
-'magicbell': major
-'@magicbell/magicbell-react': major
 '@magicbell/cli': major
 ---
 
@@ -10,48 +6,11 @@
 
 We've renamed the `categories` property to `category` and the `topics` property to `topic`, to reflect that these properties only support a single value. We haven't been supporting multiple categories or topics for a while now, and believe that renaming this property is the right thing to do. It requires a small change on your end, but the clear naming reduces the number of potential bugs caused by misunderstanding.
 
-If you make use of different stores or tabs using the `categories` or `topics` properties, you'll need to rename them to their singular variants.
+If you make use of the `categories` or `topics` filters on `magicbell user notifications`, you'll need to rename them to their singular variants.
 
 ```diff
-import MagicBell, { FloatingNotificationInbox } from '@magicbell/magicbell-react';
-import React from 'react';
-
-const stores = [
-  { id: 'default', defaultQueryParams: {} },
-  { id: 'unread', defaultQueryParams: { read: false } },
--  { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
-+  { id: 'billing', defaultQueryParams: { category: 'billing' } },
--  { id: 'support', defaultQueryParams: { topics: ['support'] } },
-+  { id: 'support', defaultQueryParams: { topic: 'support' } },
-];
-
-const tabs = [
-  { storeId: 'default', label: 'Latest' },
-  { storeId: 'unread', label: 'Archive' },
-  { storeId: 'billing', label: 'Billing' },
-  { storeId: 'support', label: 'Issues' },
-];
-
-export default function Index() {
-  return (
-    <MagicBell
-      apiKey="__MAGICBELL_API_KEY__"
-      userEmail="__MAGICBELL_USER_EMAIL__"
-      userKey="__MAGICBELL_USER_KEY__"
-      stores={stores}
-      defaultIsOpen
-    >
-      {(props) => <FloatingNotificationInbox height={450} tabs={tabs} {...props} />}
-    </MagicBell>
-  );
-}
-```
-
-Likewise, when you filter notifications using our cli, you might need to change some arguments:
-
-```diff
-- magicbell user list notifications --topics support
-+ magicbell user list notifications --topic support
+- magicbell user notifications list --topics support
++ magicbell user notifications list --topic support
 
 - magicbell user notifications mark-all-read --topics billing
 + magicbell user notifications mark-all-read --topic billing

--- a/.changeset/ten-snakes-confess.md
+++ b/.changeset/ten-snakes-confess.md
@@ -1,0 +1,25 @@
+---
+'magicbell': major
+---
+
+**Breaking Change**!
+
+We've renamed the `categories` property to `category` and the `topics` property to `topic`, to reflect that these properties only support a single value. We haven't been supporting multiple categories or topics for a while now, and believe that renaming this property is the right thing to do. It requires a small change on your end, but the clear naming reduces the number of potential bugs caused by misunderstanding.
+
+If you use `topics` or `categories` filters in the `UserClient`, you'll need to update those params to their singular variant.
+
+```diff
+import { UserClient } from 'magicbell/user-client';
+
+const magicbell = new UserClient({
+  apiKey: 'your-api-key',
+  userEmail: 'you@example.com',
+});
+
+const notifications = await magicbell.notifications.list({
+-  categories: ['billing'],
++  category: 'billing',
+-  topics: ['invoice-1'],
++  topic: 'invoice-1',
+});
+```

--- a/.changeset/tidy-llamas-live.md
+++ b/.changeset/tidy-llamas-live.md
@@ -15,10 +15,10 @@ import React from 'react';
 const stores = [
   { id: 'default', defaultQueryParams: {} },
   { id: 'unread', defaultQueryParams: { read: false } },
--  { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
-+  { id: 'billing', defaultQueryParams: { category: 'billing' } },
--  { id: 'support', defaultQueryParams: { topics: ['support'] } },
-+  { id: 'support', defaultQueryParams: { topic: 'support' } },
+- { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
++ { id: 'billing', defaultQueryParams: { category: 'billing' } },
+- { id: 'support', defaultQueryParams: { topics: ['support'] } },
++ { id: 'support', defaultQueryParams: { topic: 'support' } },
 ];
 
 const tabs = [

--- a/.changeset/tidy-llamas-live.md
+++ b/.changeset/tidy-llamas-live.md
@@ -1,0 +1,43 @@
+---
+'@magicbell/magicbell-react': major
+---
+
+**Breaking Change**!
+
+We've renamed the `categories` property to `category` and the `topics` property to `topic`, to reflect that these properties only support a single value. We haven't been supporting multiple categories or topics for a while now, and believe that renaming this property is the right thing to do. It requires a small change on your end, but the clear naming reduces the number of potential bugs caused by misunderstanding.
+
+If you make use of different stores or tabs using the `categories` or `topics` properties, you'll need to rename them to their singular variants.
+
+```diff
+import MagicBell, { FloatingNotificationInbox } from '@magicbell/magicbell-react';
+import React from 'react';
+
+const stores = [
+  { id: 'default', defaultQueryParams: {} },
+  { id: 'unread', defaultQueryParams: { read: false } },
+-  { id: 'billing', defaultQueryParams: { categories: ['billing'] } },
++  { id: 'billing', defaultQueryParams: { category: 'billing' } },
+-  { id: 'support', defaultQueryParams: { topics: ['support'] } },
++  { id: 'support', defaultQueryParams: { topic: 'support' } },
+];
+
+const tabs = [
+  { storeId: 'default', label: 'Latest' },
+  { storeId: 'unread', label: 'Archive' },
+  { storeId: 'billing', label: 'Billing' },
+  { storeId: 'support', label: 'Issues' },
+];
+
+export default function Index() {
+  return (
+    <MagicBell
+      apiKey="__MAGICBELL_API_KEY__"
+      userEmail="__MAGICBELL_USER_EMAIL__"
+      userKey="__MAGICBELL_USER_KEY__"
+      stores={stores}
+    >
+      {(props) => <FloatingNotificationInbox height={450} tabs={tabs} {...props} />}
+    </MagicBell>
+  );
+}
+```


### PR DESCRIPTION
Split the changesets, so we get changelogs scoped per sdk.