### PR TITLE
chore: upgrade codegen to nodenext module system

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -9,8 +9,8 @@
   ],
   "license": "SEE LICENSE IN LICENSE",
   "source": "./src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/codegen.esm.js",
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
@@ -28,14 +28,17 @@
     "url": "https://github.com/magicbell/magicbell-js.git",
     "directory": "packages/codegen"
   },
+  "type": "module",
+  "tshy": {
+    "project": "./tsconfig.build.json",
+    "exports": "./src/*.ts"
+  },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "run-s clean build:*",
-    "build:dev": "vite build -c ../../scripts/vite/vite.config.js",
-    "build:prod": "vite build -c ../../scripts/vite/vite.config.js --minify",
+    "build": "run-s clean build:bundle",
+    "build:bundle": "tshy",
     "generate:resources": "tsx scripts/generate-resources.ts",
-    "dev": "yarn build:dev && node dist/index.js",
-    "start": "yarn build:dev --watch",
+    "start": "tshy --watch",
     "size": "size-limit"
   },
   "dependencies": {
@@ -51,5 +54,89 @@
   },
   "devDependencies": {
     "@types/json-schema-merge-allof": "^0.6.5"
-  }
+  },
+  "exports": {
+    "./builders": {
+      "import": {
+        "types": "./dist/esm/builders.d.ts",
+        "default": "./dist/esm/builders.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/builders.d.ts",
+        "default": "./dist/commonjs/builders.js"
+      }
+    },
+    "./files": {
+      "import": {
+        "types": "./dist/esm/files.d.ts",
+        "default": "./dist/esm/files.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/files.d.ts",
+        "default": "./dist/commonjs/files.js"
+      }
+    },
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./openapi": {
+      "import": {
+        "types": "./dist/esm/openapi.d.ts",
+        "default": "./dist/esm/openapi.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/openapi.d.ts",
+        "default": "./dist/commonjs/openapi.js"
+      }
+    },
+    "./recast": {
+      "import": {
+        "types": "./dist/esm/recast.d.ts",
+        "default": "./dist/esm/recast.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/recast.d.ts",
+        "default": "./dist/commonjs/recast.js"
+      }
+    },
+    "./resources": {
+      "import": {
+        "types": "./dist/esm/resources.d.ts",
+        "default": "./dist/esm/resources.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/resources.d.ts",
+        "default": "./dist/commonjs/resources.js"
+      }
+    },
+    "./schema": {
+      "import": {
+        "types": "./dist/esm/schema.d.ts",
+        "default": "./dist/esm/schema.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/schema.d.ts",
+        "default": "./dist/commonjs/schema.js"
+      }
+    },
+    "./text": {
+      "import": {
+        "types": "./dist/esm/text.d.ts",
+        "default": "./dist/esm/text.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/text.d.ts",
+        "default": "./dist/commonjs/text.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/commonjs/index.d.ts"
 }

--- a/packages/codegen/src/builders.ts
+++ b/packages/codegen/src/builders.ts
@@ -1,10 +1,11 @@
 import { builders } from 'ast-types';
-import { ObjectExpressionBuilder } from 'ast-types/gen/builders';
-import * as K from 'ast-types/gen/kinds';
 import * as recast from 'recast';
-import * as recastTypeScriptParser from 'recast/parsers/typescript';
 
-import { wrapText } from './text';
+import { recastTypeScriptParser } from './polyfills/recast-module.js';
+import { wrapText } from './text.js';
+
+type ObjectExpressionBuilder = typeof builders.objectExpression;
+type CallExpressionArguments = Parameters<typeof builders.callExpression>[1][number];
 
 export function importDeclaration(specifiers: string | string[], source: string) {
   const specifierArray = Array.isArray(specifiers) ? specifiers : [specifiers];
@@ -120,7 +121,7 @@ export function newExpression(callee: string, ...args: string[]) {
   });
 }
 
-export function callExpression(callee: string, ...args: (K.ExpressionKind | K.SpreadElementKind | string)[]) {
+export function callExpression(callee: string, ...args: (CallExpressionArguments | string)[]) {
   return builders.callExpression.from({
     callee: builders.identifier(callee),
     arguments: args.map((x) => (typeof x === 'string' ? builders.identifier(x) : x)).filter(Boolean),

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,7 +1,7 @@
-export * as builders from './builders';
-export * from './files';
-export * from './openapi';
-export * as recast from './recast';
-export * from './resources';
-export * from './schema';
-export * from './text';
+export * as builders from './builders.js';
+export * from './files.js';
+export * from './openapi.js';
+export * as recast from './recast.js';
+export * from './resources.js';
+export * from './schema.js';
+export * from './text.js';

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -4,8 +4,8 @@ import fs from 'fs/promises';
 import mergeAllOf from 'json-schema-merge-allof';
 import { OpenAPI } from 'openapi-types';
 
-import { getByRef, getRequestBody, getResponseBody, isEmptySchema, ReferenceObject, SchemaObject } from './schema';
-import { camelCase, pascalCase, snakeCase } from './text';
+import { getByRef, getRequestBody, getResponseBody, isEmptySchema, ReferenceObject, SchemaObject } from './schema.js';
+import { camelCase, pascalCase, snakeCase } from './text.js';
 
 function findBestMatch(str: string, keys: string[]) {
   let bestMatch = '';

--- a/packages/codegen/src/polyfills/prettier-module-cjs.cts
+++ b/packages/codegen/src/polyfills/prettier-module-cjs.cts
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export const prettyMarkdown = require('prettier/parser-markdown');

--- a/packages/codegen/src/polyfills/prettier-module.ts
+++ b/packages/codegen/src/polyfills/prettier-module.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { createRequire } from 'module';
+
+// @ts-ignore
+const require = createRequire(import.meta.url);
+export const prettyMarkdown = require('prettier/parser-markdown');

--- a/packages/codegen/src/polyfills/recast-module-cjs.cts
+++ b/packages/codegen/src/polyfills/recast-module-cjs.cts
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export const recastTypeScriptParser = require('recast/parsers/typescript');

--- a/packages/codegen/src/polyfills/recast-module.ts
+++ b/packages/codegen/src/polyfills/recast-module.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { createRequire } from 'module';
+
+// @ts-ignore
+const require = createRequire(import.meta.url);
+export const recastTypeScriptParser = require('recast/parsers/typescript');

--- a/packages/codegen/src/recast.ts
+++ b/packages/codegen/src/recast.ts
@@ -1,8 +1,8 @@
 import { ASTNode } from 'ast-types';
 import * as recast from 'recast';
-import * as recastTypeScriptParser from 'recast/parsers/typescript';
 
-import { formatCode } from './text';
+import { recastTypeScriptParser } from './polyfills/recast-module.js';
+import { formatCode } from './text.js';
 
 const RECAST_OPTIONS: recast.Options = { tabWidth: 2, quote: 'single', wrapColumn: 120 };
 

--- a/packages/codegen/src/resources.ts
+++ b/packages/codegen/src/resources.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import { getOpenAPIDocument, getRootPathMethods, getRootPaths, Method } from './openapi';
-import { hyphenCase } from './text';
+import { getOpenAPIDocument, getRootPathMethods, getRootPaths, Method } from './openapi.js';
+import { hyphenCase } from './text.js';
 
 export type Resource = {
   path: string;

--- a/packages/codegen/src/text.ts
+++ b/packages/codegen/src/text.ts
@@ -1,7 +1,8 @@
 import { ESLint } from 'eslint';
 import path from 'path';
 import prettier from 'prettier';
-import prettyMarkdown from 'prettier/parser-markdown';
+
+import { prettyMarkdown } from './polyfills/prettier-module.js';
 
 export function formatMarkdown(document) {
   return prettier.format(document, {

--- a/packages/codegen/tsconfig.build.json
+++ b/packages/codegen/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.build.json",
-  "include": ["src", "types", "../../types"]
+  "include": ["src", "types", "../../types"],
+  "compilerOptions": {
+    "noEmit": false
+  }
 }


### PR DESCRIPTION
upgrade the codegen to support both cjs and esm modules