### PR TITLE
chore: project-client build script improvements and regen

### DIFF
--- a/packages/project-client/README.md
+++ b/packages/project-client/README.md
@@ -81,7 +81,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.broadcasts.listBroadcasts({
-    pageSize: 10,
+    pageSize: 9,
     pageBefore: 'page[before]',
     pageAfter: 'page[after]',
   });

--- a/packages/project-client/documentation/models/AccessToken.md
+++ b/packages/project-client/documentation/models/AccessToken.md
@@ -2,9 +2,9 @@
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| createdAt | string | ✅       |             |
-| token     | string | ✅       |             |
-| tokenId   | string | ✅       |             |
-| expiresAt | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| createdAt | `string` | ✅       |             |
+| token     | `string` | ✅       |             |
+| tokenId   | `string` | ✅       |             |
+| expiresAt | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ApnsConfig.md
+++ b/packages/project-client/documentation/models/ApnsConfig.md
@@ -2,19 +2,19 @@
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| appId       | string | ✅       |             |
-| badge       | Badge  | ✅       |             |
-| certificate | string | ✅       |             |
-| keyId       | string | ✅       |             |
-| teamId      | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| appId       | `string` | ✅       |             |
+| badge       | `Badge`  | ✅       |             |
+| certificate | `string` | ✅       |             |
+| keyId       | `string` | ✅       |             |
+| teamId      | `string` | ✅       |             |
 
 # Badge
 
 **Properties**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| UNREAD | string | ✅       | "unread"    |
-| UNSEEN | string | ✅       | "unseen"    |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| UNREAD | `string` | ✅       | "unread"    |
+| UNSEEN | `string` | ✅       | "unseen"    |

--- a/packages/project-client/documentation/models/ApnsToken.md
+++ b/packages/project-client/documentation/models/ApnsToken.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name           | Type                    | Required | Description |
-| :------------- | :---------------------- | :------- | :---------- |
-| deviceToken    | string                  | ✅       |             |
-| installationId | ApnsTokenInstallationId | ❌       |             |
+| Name           | Type                      | Required | Description |
+| :------------- | :------------------------ | :------- | :---------- |
+| deviceToken    | `string`                  | ✅       |             |
+| installationId | `ApnsTokenInstallationId` | ❌       |             |
 
 # ApnsTokenInstallationId
 
 **Properties**
 
-| Name        | Type   | Required | Description   |
-| :---------- | :----- | :------- | :------------ |
-| DEVELOPMENT | string | ✅       | "development" |
-| PRODUCTION  | string | ✅       | "production"  |
+| Name        | Type     | Required | Description   |
+| :---------- | :------- | :------- | :------------ |
+| DEVELOPMENT | `string` | ✅       | "development" |
+| PRODUCTION  | `string` | ✅       | "production"  |

--- a/packages/project-client/documentation/models/ApnsTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/ApnsTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                          | Required | Description |
-| :------- | :---------------------------- | :------- | :---------- |
-| data     | ApnsToken                     | ✅       |             |
-| metadata | ApnsTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                            | Required | Description |
+| :------- | :------------------------------ | :------- | :---------- |
+| data     | `ApnsToken`                     | ✅       |             |
+| metadata | `ApnsTokenWithMetadataMetadata` | ✅       |             |
 
 # ApnsTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfApnsToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfApnsToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                               | Required | Description |
-| :--- | :--------------------------------- | :------- | :---------- |
-| data | ArrayWithMetadataOfApnsTokenData[] | ✅       |             |
+| Name | Type                                 | Required | Description |
+| :--- | :----------------------------------- | :------- | :---------- |
+| data | `ArrayWithMetadataOfApnsTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfApnsTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | ApnsToken     | ✅       |             |
-| metadata | DataMetadata1 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `ApnsToken`     | ✅       |             |
+| metadata | `DataMetadata1` | ✅       |             |
 
 # DataMetadata1
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfExpoToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfExpoToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                               | Required | Description |
-| :--- | :--------------------------------- | :------- | :---------- |
-| data | ArrayWithMetadataOfExpoTokenData[] | ✅       |             |
+| Name | Type                                 | Required | Description |
+| :--- | :----------------------------------- | :------- | :---------- |
+| data | `ArrayWithMetadataOfExpoTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfExpoTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | ExpoToken     | ✅       |             |
-| metadata | DataMetadata2 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `ExpoToken`     | ✅       |             |
+| metadata | `DataMetadata2` | ✅       |             |
 
 # DataMetadata2
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfFcmToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfFcmToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                              | Required | Description |
-| :--- | :-------------------------------- | :------- | :---------- |
-| data | ArrayWithMetadataOfFcmTokenData[] | ✅       |             |
+| Name | Type                                | Required | Description |
+| :--- | :---------------------------------- | :------- | :---------- |
+| data | `ArrayWithMetadataOfFcmTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfFcmTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | FcmToken      | ✅       |             |
-| metadata | DataMetadata3 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `FcmToken`      | ✅       |             |
+| metadata | `DataMetadata3` | ✅       |             |
 
 # DataMetadata3
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfSlackToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfSlackToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                                | Required | Description |
-| :--- | :---------------------------------- | :------- | :---------- |
-| data | ArrayWithMetadataOfSlackTokenData[] | ✅       |             |
+| Name | Type                                  | Required | Description |
+| :--- | :------------------------------------ | :------- | :---------- |
+| data | `ArrayWithMetadataOfSlackTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfSlackTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | SlackToken    | ✅       |             |
-| metadata | DataMetadata4 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `SlackToken`    | ✅       |             |
+| metadata | `DataMetadata4` | ✅       |             |
 
 # DataMetadata4
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfTeamsToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfTeamsToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                                | Required | Description |
-| :--- | :---------------------------------- | :------- | :---------- |
-| data | ArrayWithMetadataOfTeamsTokenData[] | ✅       |             |
+| Name | Type                                  | Required | Description |
+| :--- | :------------------------------------ | :------- | :---------- |
+| data | `ArrayWithMetadataOfTeamsTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfTeamsTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | TeamsToken    | ✅       |             |
-| metadata | DataMetadata5 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `TeamsToken`    | ✅       |             |
+| metadata | `DataMetadata5` | ✅       |             |
 
 # DataMetadata5
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/ArrayWithMetadataOfWebPushToken.md
+++ b/packages/project-client/documentation/models/ArrayWithMetadataOfWebPushToken.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name | Type                                  | Required | Description |
-| :--- | :------------------------------------ | :------- | :---------- |
-| data | ArrayWithMetadataOfWebPushTokenData[] | ✅       |             |
+| Name | Type                                    | Required | Description |
+| :--- | :-------------------------------------- | :------- | :---------- |
+| data | `ArrayWithMetadataOfWebPushTokenData[]` | ✅       |             |
 
 # ArrayWithMetadataOfWebPushTokenData
 
 **Properties**
 
-| Name     | Type          | Required | Description |
-| :------- | :------------ | :------- | :---------- |
-| data     | WebPushToken  | ✅       |             |
-| metadata | DataMetadata6 | ✅       |             |
+| Name     | Type            | Required | Description |
+| :------- | :-------------- | :------- | :---------- |
+| data     | `WebPushToken`  | ✅       |             |
+| metadata | `DataMetadata6` | ✅       |             |
 
 # DataMetadata6
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/AwssnsConfig.md
+++ b/packages/project-client/documentation/models/AwssnsConfig.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name                 | Type   | Required | Description                          |
-| :------------------- | :----- | :------- | :----------------------------------- |
-| webhookSigningSecret | string | ✅       | The signing certificate from AWS SNS |
+| Name                 | Type     | Required | Description                          |
+| :------------------- | :------- | :------- | :----------------------------------- |
+| webhookSigningSecret | `string` | ✅       | The signing certificate from AWS SNS |

--- a/packages/project-client/documentation/models/Broadcast.md
+++ b/packages/project-client/documentation/models/Broadcast.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name             | Type      | Required | Description |
-| :--------------- | :-------- | :------- | :---------- |
-| recipients       | any[]     | ✅       |             |
-| title            | string    | ✅       |             |
-| actionUrl        | string    | ❌       |             |
-| category         | Category  | ❌       |             |
-| content          | string    | ❌       |             |
-| customAttributes | any       | ❌       |             |
-| overrides        | Overrides | ❌       |             |
-| topic            | Topic     | ❌       |             |
+| Name             | Type        | Required | Description |
+| :--------------- | :---------- | :------- | :---------- |
+| recipients       | `any[]`     | ✅       |             |
+| title            | `string`    | ✅       |             |
+| actionUrl        | `string`    | ❌       |             |
+| category         | `Category`  | ❌       |             |
+| content          | `string`    | ❌       |             |
+| customAttributes | `any`       | ❌       |             |
+| overrides        | `Overrides` | ❌       |             |
+| topic            | `Topic`     | ❌       |             |
 
 # Category
 
@@ -19,96 +19,96 @@
 
 **Properties**
 
-| Name      | Type      | Required | Description |
-| :-------- | :-------- | :------- | :---------- |
-| channels  | Channels  | ❌       |             |
-| providers | Providers | ❌       |             |
+| Name      | Type        | Required | Description |
+| :-------- | :---------- | :------- | :---------- |
+| channels  | `Channels`  | ❌       |             |
+| providers | `Providers` | ❌       |             |
 
 # Channels
 
 **Properties**
 
-| Name       | Type       | Required | Description |
-| :--------- | :--------- | :------- | :---------- |
-| email      | Email      | ❌       |             |
-| inApp      | InApp      | ❌       |             |
-| mobilePush | MobilePush | ❌       |             |
-| slack      | Slack      | ❌       |             |
-| sms        | Sms        | ❌       |             |
-| webPush    | WebPush    | ❌       |             |
+| Name       | Type         | Required | Description |
+| :--------- | :----------- | :------- | :---------- |
+| email      | `Email`      | ❌       |             |
+| inApp      | `InApp`      | ❌       |             |
+| mobilePush | `MobilePush` | ❌       |             |
+| slack      | `Slack`      | ❌       |             |
+| sms        | `Sms`        | ❌       |             |
+| webPush    | `WebPush`    | ❌       |             |
 
 # Email
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # InApp
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # MobilePush
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # Slack
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # Sms
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # WebPush
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| actionUrl | string | ❌       |             |
-| content   | string | ❌       |             |
-| title     | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| actionUrl | `string` | ❌       |             |
+| content   | `string` | ❌       |             |
+| title     | `string` | ❌       |             |
 
 # Providers
 
 **Properties**
 
-| Name      | Type | Required | Description |
-| :-------- | :--- | :------- | :---------- |
-| amazonSes | any  | ❌       |             |
-| android   | any  | ❌       |             |
-| ios       | any  | ❌       |             |
-| mailgun   | any  | ❌       |             |
-| postmark  | any  | ❌       |             |
-| sendgrid  | any  | ❌       |             |
-| slack     | any  | ❌       |             |
+| Name      | Type  | Required | Description |
+| :-------- | :---- | :------- | :---------- |
+| amazonSes | `any` | ❌       |             |
+| android   | `any` | ❌       |             |
+| ios       | `any` | ❌       |             |
+| mailgun   | `any` | ❌       |             |
+| postmark  | `any` | ❌       |             |
+| sendgrid  | `any` | ❌       |             |
+| slack     | `any` | ❌       |             |
 
 # Topic

--- a/packages/project-client/documentation/models/BroadcastListResponse.md
+++ b/packages/project-client/documentation/models/BroadcastListResponse.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name  | Type        | Required | Description |
-| :---- | :---------- | :------- | :---------- |
-| links | Links       | ✅       |             |
-| data  | Broadcast[] | ✅       |             |
+| Name  | Type          | Required | Description |
+| :---- | :------------ | :------- | :---------- |
+| links | `Links`       | ✅       |             |
+| data  | `Broadcast[]` | ✅       |             |
 
 # Links
 
 **Properties**
 
-| Name | Type   | Required | Description                                                                  |
-| :--- | :----- | :------- | :--------------------------------------------------------------------------- |
-| next | string | ✅       | The cursor to the next page of results. If null, there are no more results.  |
-| prev | string | ✅       | The cursor to the previous page of results. If null, this is the first page. |
+| Name | Type     | Required | Description                                                                  |
+| :--- | :------- | :------- | :--------------------------------------------------------------------------- |
+| next | `string` | ✅       | The cursor to the next page of results. If null, there are no more results.  |
+| prev | `string` | ✅       | The cursor to the previous page of results. If null, this is the first page. |

--- a/packages/project-client/documentation/models/CreateProjectTokenRequest.md
+++ b/packages/project-client/documentation/models/CreateProjectTokenRequest.md
@@ -2,7 +2,7 @@
 
 **Properties**
 
-| Name   | Type   | Required | Description                                            |
-| :----- | :----- | :------- | :----------------------------------------------------- |
-| name   | string | ✅       | The name of the token.                                 |
-| expiry | number | ❌       | The duration for which the token is valid (in seconds) |
+| Name   | Type     | Required | Description                                            |
+| :----- | :------- | :------- | :----------------------------------------------------- |
+| name   | `string` | ✅       | The name of the token.                                 |
+| expiry | `number` | ❌       | The duration for which the token is valid (in seconds) |

--- a/packages/project-client/documentation/models/CreateUserTokenRequest.md
+++ b/packages/project-client/documentation/models/CreateUserTokenRequest.md
@@ -2,9 +2,9 @@
 
 **Properties**
 
-| Name       | Type   | Required | Description                                                                                                                                                                                                       |
-| :--------- | :----- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| email      | string | ❌       | The user's email.                                                                                                                                                                                                 |
-| expiry     | number | ❌       | The duration for which the token is valid (in seconds)                                                                                                                                                            |
-| externalId | string | ❌       | A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable. |
-| name       | string | ❌       | The name of the token.                                                                                                                                                                                            |
+| Name       | Type     | Required | Description                                                                                                                                                                                                       |
+| :--------- | :------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| email      | `string` | ❌       | The user's email.                                                                                                                                                                                                 |
+| expiry     | `number` | ❌       | The duration for which the token is valid (in seconds)                                                                                                                                                            |
+| externalId | `string` | ❌       | A unique string that MagicBell can utilize to identify the user uniquely. We recommend setting this attribute to the ID of the user in your database. Provide the external id if the user's email is unavailable. |
+| name       | `string` | ❌       | The name of the token.                                                                                                                                                                                            |

--- a/packages/project-client/documentation/models/DiscardResult.md
+++ b/packages/project-client/documentation/models/DiscardResult.md
@@ -2,7 +2,7 @@
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| discardedAt | string | ❌       |             |
-| id          | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| discardedAt | `string` | ❌       |             |
+| id          | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/DiscardTokenResponse.md
+++ b/packages/project-client/documentation/models/DiscardTokenResponse.md
@@ -2,7 +2,7 @@
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| discardedAt | string | ✅       |             |
-| tokenId     | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| discardedAt | `string` | ✅       |             |
+| tokenId     | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/ExpoConfig.md
+++ b/packages/project-client/documentation/models/ExpoConfig.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| accessToken | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| accessToken | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/ExpoToken.md
+++ b/packages/project-client/documentation/models/ExpoToken.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| deviceToken | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| deviceToken | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/ExpoTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/ExpoTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                          | Required | Description |
-| :------- | :---------------------------- | :------- | :---------- |
-| data     | ExpoToken                     | ✅       |             |
-| metadata | ExpoTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                            | Required | Description |
+| :------- | :------------------------------ | :------- | :---------- |
+| data     | `ExpoToken`                     | ✅       |             |
+| metadata | `ExpoTokenWithMetadataMetadata` | ✅       |             |
 
 # ExpoTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/FcmConfig.md
+++ b/packages/project-client/documentation/models/FcmConfig.md
@@ -2,24 +2,24 @@
 
 **Properties**
 
-| Name                    | Type   | Required | Description |
-| :---------------------- | :----- | :------- | :---------- |
-| authProviderX509CertUrl | string | ✅       |             |
-| authUri                 | string | ✅       |             |
-| clientEmail             | string | ✅       |             |
-| clientId                | string | ✅       |             |
-| clientX509CertUrl       | string | ✅       |             |
-| privateKey              | string | ✅       |             |
-| privateKeyId            | string | ✅       |             |
-| projectId               | string | ✅       |             |
-| tokenUri                | string | ✅       |             |
-| type                    | Type\_ | ✅       |             |
-| universeDomain          | string | ✅       |             |
+| Name                    | Type     | Required | Description |
+| :---------------------- | :------- | :------- | :---------- |
+| authProviderX509CertUrl | `string` | ✅       |             |
+| authUri                 | `string` | ✅       |             |
+| clientEmail             | `string` | ✅       |             |
+| clientId                | `string` | ✅       |             |
+| clientX509CertUrl       | `string` | ✅       |             |
+| privateKey              | `string` | ✅       |             |
+| privateKeyId            | `string` | ✅       |             |
+| projectId               | `string` | ✅       |             |
+| tokenUri                | `string` | ✅       |             |
+| type                    | `Type_`  | ✅       |             |
+| universeDomain          | `string` | ✅       |             |
 
 # Type\_
 
 **Properties**
 
-| Name           | Type   | Required | Description       |
-| :------------- | :----- | :------- | :---------------- |
-| SERVICEACCOUNT | string | ✅       | "service_account" |
+| Name           | Type     | Required | Description       |
+| :------------- | :------- | :------- | :---------------- |
+| SERVICEACCOUNT | `string` | ✅       | "service_account" |

--- a/packages/project-client/documentation/models/FcmToken.md
+++ b/packages/project-client/documentation/models/FcmToken.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name           | Type                   | Required | Description |
-| :------------- | :--------------------- | :------- | :---------- |
-| deviceToken    | string                 | ✅       |             |
-| installationId | FcmTokenInstallationId | ❌       |             |
+| Name           | Type                     | Required | Description |
+| :------------- | :----------------------- | :------- | :---------- |
+| deviceToken    | `string`                 | ✅       |             |
+| installationId | `FcmTokenInstallationId` | ❌       |             |
 
 # FcmTokenInstallationId
 
 **Properties**
 
-| Name        | Type   | Required | Description   |
-| :---------- | :----- | :------- | :------------ |
-| DEVELOPMENT | string | ✅       | "development" |
-| PRODUCTION  | string | ✅       | "production"  |
+| Name        | Type     | Required | Description   |
+| :---------- | :------- | :------- | :------------ |
+| DEVELOPMENT | `string` | ✅       | "development" |
+| PRODUCTION  | `string` | ✅       | "production"  |

--- a/packages/project-client/documentation/models/FcmTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/FcmTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                         | Required | Description |
-| :------- | :--------------------------- | :------- | :---------- |
-| data     | FcmToken                     | ✅       |             |
-| metadata | FcmTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                           | Required | Description |
+| :------- | :----------------------------- | :------- | :---------- |
+| data     | `FcmToken`                     | ✅       |             |
+| metadata | `FcmTokenWithMetadataMetadata` | ✅       |             |
 
 # FcmTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/FetchTokensResponse.md
+++ b/packages/project-client/documentation/models/FetchTokensResponse.md
@@ -2,17 +2,17 @@
 
 **Properties**
 
-| Name   | Type     | Required | Description |
-| :----- | :------- | :------- | :---------- |
-| tokens | Tokens[] | ✅       |             |
+| Name   | Type       | Required | Description |
+| :----- | :--------- | :------- | :---------- |
+| tokens | `Tokens[]` | ✅       |             |
 
 # Tokens
 
 **Properties**
 
-| Name      | Type   | Required | Description |
-| :-------- | :----- | :------- | :---------- |
-| createdAt | string | ✅       |             |
-| expiresAt | string | ❌       |             |
-| id        | string | ❌       |             |
-| name      | string | ❌       |             |
+| Name      | Type     | Required | Description |
+| :-------- | :------- | :------- | :---------- |
+| createdAt | `string` | ✅       |             |
+| expiresAt | `string` | ❌       |             |
+| id        | `string` | ❌       |             |
+| name      | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/GithubConfig.md
+++ b/packages/project-client/documentation/models/GithubConfig.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name                 | Type   | Required | Description                                                |
-| :------------------- | :----- | :------- | :--------------------------------------------------------- |
-| webhookSigningSecret | string | ✅       | The signing secret to verify incoming requests from Github |
+| Name                 | Type     | Required | Description                                                |
+| :------------------- | :------- | :------- | :--------------------------------------------------------- |
+| webhookSigningSecret | `string` | ✅       | The signing secret to verify incoming requests from Github |

--- a/packages/project-client/documentation/models/InboxConfig.md
+++ b/packages/project-client/documentation/models/InboxConfig.md
@@ -2,186 +2,186 @@
 
 **Properties**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| images | Images | ✅       |             |
-| locale | string | ✅       |             |
-| theme  | Theme  | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| images | `Images` | ✅       |             |
+| locale | `string` | ✅       |             |
+| theme  | `Theme`  | ✅       |             |
 
 # Images
 
 **Properties**
 
-| Name          | Type   | Required | Description |
-| :------------ | :----- | :------- | :---------- |
-| emptyInboxUrl | string | ✅       |             |
+| Name          | Type     | Required | Description |
+| :------------ | :------- | :------- | :---------- |
+| emptyInboxUrl | `string` | ✅       |             |
 
 # Theme
 
 **Properties**
 
-| Name         | Type         | Required | Description |
-| :----------- | :----------- | :------- | :---------- |
-| banner       | Banner       | ❌       |             |
-| dialog       | Dialog       | ❌       |             |
-| footer       | Footer       | ❌       |             |
-| header       | Header       | ❌       |             |
-| icon         | Icon         | ❌       |             |
-| notification | Notification | ❌       |             |
-| unseenBadge  | UnseenBadge  | ❌       |             |
+| Name         | Type           | Required | Description |
+| :----------- | :------------- | :------- | :---------- |
+| banner       | `Banner`       | ❌       |             |
+| dialog       | `Dialog`       | ❌       |             |
+| footer       | `Footer`       | ❌       |             |
+| header       | `Header`       | ❌       |             |
+| icon         | `Icon`         | ❌       |             |
+| notification | `Notification` | ❌       |             |
+| unseenBadge  | `UnseenBadge`  | ❌       |             |
 
 # Banner
 
 **Properties**
 
-| Name              | Type   | Required | Description |
-| :---------------- | :----- | :------- | :---------- |
-| backgroundColor   | string | ✅       |             |
-| fontSize          | string | ✅       |             |
-| textColor         | string | ✅       |             |
-| backgroundOpacity | number | ❌       |             |
+| Name              | Type     | Required | Description |
+| :---------------- | :------- | :------- | :---------- |
+| backgroundColor   | `string` | ✅       |             |
+| fontSize          | `string` | ✅       |             |
+| textColor         | `string` | ✅       |             |
+| backgroundOpacity | `number` | ❌       |             |
 
 # Dialog
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| accentColor     | string | ✅       |             |
-| backgroundColor | string | ✅       |             |
-| textColor       | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| accentColor     | `string` | ✅       |             |
+| backgroundColor | `string` | ✅       |             |
+| textColor       | `string` | ✅       |             |
 
 # Footer
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
-| borderRadius    | string | ✅       |             |
-| fontSize        | string | ✅       |             |
-| textColor       | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |
+| borderRadius    | `string` | ✅       |             |
+| fontSize        | `string` | ✅       |             |
+| textColor       | `string` | ✅       |             |
 
 # Header
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
-| borderRadius    | string | ✅       |             |
-| fontFamily      | string | ✅       |             |
-| fontSize        | string | ✅       |             |
-| textColor       | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |
+| borderRadius    | `string` | ✅       |             |
+| fontFamily      | `string` | ✅       |             |
+| fontSize        | `string` | ✅       |             |
+| textColor       | `string` | ✅       |             |
 
 # Icon
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| borderColor | string | ✅       |             |
-| width       | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| borderColor | `string` | ✅       |             |
+| width       | `string` | ✅       |             |
 
 # Notification
 
 **Properties**
 
-| Name    | Type      | Required | Description |
-| :------ | :-------- | :------- | :---------- |
-| default | Default\_ | ✅       |             |
-| unread  | Unread    | ✅       |             |
-| unseen  | Unseen    | ✅       |             |
+| Name    | Type       | Required | Description |
+| :------ | :--------- | :------- | :---------- |
+| default | `Default_` | ✅       |             |
+| unread  | `Unread`   | ✅       |             |
+| unseen  | `Unseen`   | ✅       |             |
 
 # Default\_
 
 **Properties**
 
-| Name            | Type         | Required | Description |
-| :-------------- | :----------- | :------- | :---------- |
-| backgroundColor | string       | ✅       |             |
-| borderRadius    | string       | ✅       |             |
-| fontFamily      | string       | ✅       |             |
-| fontSize        | string       | ✅       |             |
-| margin          | string       | ✅       |             |
-| textColor       | string       | ✅       |             |
-| hover           | DefaultHover | ❌       |             |
-| state           | DefaultState | ❌       |             |
+| Name            | Type           | Required | Description |
+| :-------------- | :------------- | :------- | :---------- |
+| backgroundColor | `string`       | ✅       |             |
+| borderRadius    | `string`       | ✅       |             |
+| fontFamily      | `string`       | ✅       |             |
+| fontSize        | `string`       | ✅       |             |
+| margin          | `string`       | ✅       |             |
+| textColor       | `string`       | ✅       |             |
+| hover           | `DefaultHover` | ❌       |             |
+| state           | `DefaultState` | ❌       |             |
 
 # DefaultHover
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |
 
 # DefaultState
 
 **Properties**
 
-| Name  | Type   | Required | Description |
-| :---- | :----- | :------- | :---------- |
-| color | string | ✅       |             |
+| Name  | Type     | Required | Description |
+| :---- | :------- | :------- | :---------- |
+| color | `string` | ✅       |             |
 
 # Unread
 
 **Properties**
 
-| Name            | Type        | Required | Description |
-| :-------------- | :---------- | :------- | :---------- |
-| backgroundColor | string      | ✅       |             |
-| textColor       | string      | ✅       |             |
-| hover           | UnreadHover | ❌       |             |
-| state           | UnreadState | ❌       |             |
+| Name            | Type          | Required | Description |
+| :-------------- | :------------ | :------- | :---------- |
+| backgroundColor | `string`      | ✅       |             |
+| textColor       | `string`      | ✅       |             |
+| hover           | `UnreadHover` | ❌       |             |
+| state           | `UnreadState` | ❌       |             |
 
 # UnreadHover
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |
 
 # UnreadState
 
 **Properties**
 
-| Name  | Type   | Required | Description |
-| :---- | :----- | :------- | :---------- |
-| color | string | ✅       |             |
+| Name  | Type     | Required | Description |
+| :---- | :------- | :------- | :---------- |
+| color | `string` | ✅       |             |
 
 # Unseen
 
 **Properties**
 
-| Name            | Type        | Required | Description |
-| :-------------- | :---------- | :------- | :---------- |
-| backgroundColor | string      | ✅       |             |
-| textColor       | string      | ✅       |             |
-| hover           | UnseenHover | ❌       |             |
-| state           | UnseenState | ❌       |             |
+| Name            | Type          | Required | Description |
+| :-------------- | :------------ | :------- | :---------- |
+| backgroundColor | `string`      | ✅       |             |
+| textColor       | `string`      | ✅       |             |
+| hover           | `UnseenHover` | ❌       |             |
+| state           | `UnseenState` | ❌       |             |
 
 # UnseenHover
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |
 
 # UnseenState
 
 **Properties**
 
-| Name  | Type   | Required | Description |
-| :---- | :----- | :------- | :---------- |
-| color | string | ✅       |             |
+| Name  | Type     | Required | Description |
+| :---- | :------- | :------- | :---------- |
+| color | `string` | ✅       |             |
 
 # UnseenBadge
 
 **Properties**
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| backgroundColor | string | ✅       |             |
+| Name            | Type     | Required | Description |
+| :-------------- | :------- | :------- | :---------- |
+| backgroundColor | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/ListIntegrationsResponse.md
+++ b/packages/project-client/documentation/models/ListIntegrationsResponse.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name         | Type           | Required | Description |
-| :----------- | :------------- | :------- | :---------- |
-| integrations | Integrations[] | ❌       |             |
+| Name         | Type             | Required | Description |
+| :----------- | :--------------- | :------- | :---------- |
+| integrations | `Integrations[]` | ❌       |             |
 
 # Integrations
 
 **Properties**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| config | any    | ❌       |             |
-| id     | string | ❌       |             |
-| name   | string | ❌       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| config | `any`    | ❌       |             |
+| id     | `string` | ❌       |             |
+| name   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/MailgunConfig.md
+++ b/packages/project-client/documentation/models/MailgunConfig.md
@@ -2,17 +2,17 @@
 
 **Properties**
 
-| Name   | Type                | Required | Description |
-| :----- | :------------------ | :------- | :---------- |
-| apiKey | string              | ✅       |             |
-| domain | string              | ✅       |             |
-| region | MailgunConfigRegion | ✅       |             |
+| Name   | Type                  | Required | Description |
+| :----- | :-------------------- | :------- | :---------- |
+| apiKey | `string`              | ✅       |             |
+| domain | `string`              | ✅       |             |
+| region | `MailgunConfigRegion` | ✅       |             |
 
 # MailgunConfigRegion
 
 **Properties**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| US   | string | ✅       | "us"        |
-| EU   | string | ✅       | "eu"        |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| US   | `string` | ✅       | "us"        |
+| EU   | `string` | ✅       | "eu"        |

--- a/packages/project-client/documentation/models/PingConfig.md
+++ b/packages/project-client/documentation/models/PingConfig.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| url  | string | ✅       | URL to ping |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| url  | `string` | ✅       | URL to ping |

--- a/packages/project-client/documentation/models/SendgridConfig.md
+++ b/packages/project-client/documentation/models/SendgridConfig.md
@@ -2,26 +2,26 @@
 
 **Properties**
 
-| Name    | Type               | Required | Description              |
-| :------ | :----------------- | :------- | :----------------------- |
-| apiKey  | string             | ✅       | The API key for Sendgrid |
-| from    | SendgridConfigFrom | ❌       |                          |
-| replyTo | ReplyTo            | ❌       |                          |
+| Name    | Type                 | Required | Description              |
+| :------ | :------------------- | :------- | :----------------------- |
+| apiKey  | `string`             | ✅       | The API key for Sendgrid |
+| from    | `SendgridConfigFrom` | ❌       |                          |
+| replyTo | `ReplyTo`            | ❌       |                          |
 
 # SendgridConfigFrom
 
 **Properties**
 
-| Name  | Type   | Required | Description                    |
-| :---- | :----- | :------- | :----------------------------- |
-| email | string | ✅       | The email address to send from |
-| name  | string | ❌       | The name to send from          |
+| Name  | Type     | Required | Description                    |
+| :---- | :------- | :------- | :----------------------------- |
+| email | `string` | ✅       | The email address to send from |
+| name  | `string` | ❌       | The name to send from          |
 
 # ReplyTo
 
 **Properties**
 
-| Name  | Type   | Required | Description                   |
-| :---- | :----- | :------- | :---------------------------- |
-| email | string | ✅       | The email address to reply to |
-| name  | string | ❌       | The name to reply to          |
+| Name  | Type     | Required | Description                   |
+| :---- | :------- | :------- | :---------------------------- |
+| email | `string` | ✅       | The email address to reply to |
+| name  | `string` | ❌       | The name to reply to          |

--- a/packages/project-client/documentation/models/SesConfig.md
+++ b/packages/project-client/documentation/models/SesConfig.md
@@ -2,19 +2,19 @@
 
 **Properties**
 
-| Name      | Type          | Required | Description                                      |
-| :-------- | :------------ | :------- | :----------------------------------------------- |
-| keyId     | string        | ✅       | AWS Access Key ID                                |
-| region    | string        | ✅       | AWS Region                                       |
-| secretKey | string        | ✅       | AWS Secret Key                                   |
-| endpoint  | string        | ❌       | HTTP endpoint to send requests to (testing only) |
-| from      | SesConfigFrom | ❌       |                                                  |
+| Name      | Type            | Required | Description                                      |
+| :-------- | :-------------- | :------- | :----------------------------------------------- |
+| keyId     | `string`        | ✅       | AWS Access Key ID                                |
+| region    | `string`        | ✅       | AWS Region                                       |
+| secretKey | `string`        | ✅       | AWS Secret Key                                   |
+| endpoint  | `string`        | ❌       | HTTP endpoint to send requests to (testing only) |
+| from      | `SesConfigFrom` | ❌       |                                                  |
 
 # SesConfigFrom
 
 **Properties**
 
-| Name  | Type   | Required | Description                    |
-| :---- | :----- | :------- | :----------------------------- |
-| email | string | ✅       | The email address to send from |
-| name  | string | ❌       | The name to send from          |
+| Name  | Type     | Required | Description                    |
+| :---- | :------- | :------- | :----------------------------- |
+| email | `string` | ✅       | The email address to send from |
+| name  | `string` | ❌       | The name to send from          |

--- a/packages/project-client/documentation/models/SlackConfig.md
+++ b/packages/project-client/documentation/models/SlackConfig.md
@@ -2,9 +2,9 @@
 
 **Properties**
 
-| Name          | Type   | Required | Description |
-| :------------ | :----- | :------- | :---------- |
-| appId         | string | ✅       |             |
-| clientId      | string | ✅       |             |
-| clientSecret  | string | ✅       |             |
-| signingSecret | string | ✅       |             |
+| Name          | Type     | Required | Description |
+| :------------ | :------- | :------- | :---------- |
+| appId         | `string` | ✅       |             |
+| clientId      | `string` | ✅       |             |
+| clientSecret  | `string` | ✅       |             |
+| signingSecret | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/SlackToken.md
+++ b/packages/project-client/documentation/models/SlackToken.md
@@ -2,25 +2,25 @@
 
 **Properties**
 
-| Name    | Type              | Required | Description |
-| :------ | :---------------- | :------- | :---------- |
-| oauth   | Oauth             | ❌       |             |
-| webhook | SlackTokenWebhook | ❌       |             |
+| Name    | Type                | Required | Description |
+| :------ | :------------------ | :------- | :---------- |
+| oauth   | `Oauth`             | ❌       |             |
+| webhook | `SlackTokenWebhook` | ❌       |             |
 
 # Oauth
 
 **Properties**
 
-| Name           | Type   | Required | Description |
-| :------------- | :----- | :------- | :---------- |
-| channelId      | string | ✅       |             |
-| installationId | string | ✅       |             |
-| scope          | string | ❌       |             |
+| Name           | Type     | Required | Description |
+| :------------- | :------- | :------- | :---------- |
+| channelId      | `string` | ✅       |             |
+| installationId | `string` | ✅       |             |
+| scope          | `string` | ❌       |             |
 
 # SlackTokenWebhook
 
 **Properties**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| url  | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| url  | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/SlackTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/SlackTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                           | Required | Description |
-| :------- | :----------------------------- | :------- | :---------- |
-| data     | SlackToken                     | ✅       |             |
-| metadata | SlackTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                             | Required | Description |
+| :------- | :------------------------------- | :------- | :---------- |
+| data     | `SlackToken`                     | ✅       |             |
+| metadata | `SlackTokenWithMetadataMetadata` | ✅       |             |
 
 # SlackTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/StripeConfig.md
+++ b/packages/project-client/documentation/models/StripeConfig.md
@@ -2,6 +2,6 @@
 
 **Properties**
 
-| Name                 | Type   | Required | Description                                                |
-| :------------------- | :----- | :------- | :--------------------------------------------------------- |
-| webhookSigningSecret | string | ✅       | The signing secret to verify incoming requests from Stripe |
+| Name                 | Type     | Required | Description                                                |
+| :------------------- | :------- | :------- | :--------------------------------------------------------- |
+| webhookSigningSecret | `string` | ✅       | The signing secret to verify incoming requests from Stripe |

--- a/packages/project-client/documentation/models/TeamsToken.md
+++ b/packages/project-client/documentation/models/TeamsToken.md
@@ -2,14 +2,14 @@
 
 **Properties**
 
-| Name    | Type              | Required | Description |
-| :------ | :---------------- | :------- | :---------- |
-| webhook | TeamsTokenWebhook | ❌       |             |
+| Name    | Type                | Required | Description |
+| :------ | :------------------ | :------- | :---------- |
+| webhook | `TeamsTokenWebhook` | ❌       |             |
 
 # TeamsTokenWebhook
 
 **Properties**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| url  | string | ❌       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| url  | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/TeamsTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/TeamsTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                           | Required | Description |
-| :------- | :----------------------------- | :------- | :---------- |
-| data     | TeamsToken                     | ✅       |             |
-| metadata | TeamsTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                             | Required | Description |
+| :------- | :------------------------------- | :------- | :---------- |
+| data     | `TeamsToken`                     | ✅       |             |
+| metadata | `TeamsTokenWithMetadataMetadata` | ✅       |             |
 
 # TeamsTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/TwilioConfig.md
+++ b/packages/project-client/documentation/models/TwilioConfig.md
@@ -2,13 +2,13 @@
 
 **Properties**
 
-| Name       | Type               | Required | Description                                     |
-| :--------- | :----------------- | :------- | :---------------------------------------------- |
-| accountSid | string             | ✅       | The SID for your Twilio account                 |
-| apiKey     | string             | ✅       | The API key for Twilio                          |
-| apiSecret  | string             | ✅       | The API Secret for Twilio                       |
-| from       | string             | ✅       | The phone number to send from, in E.164 format  |
-| region     | TwilioConfigRegion | ❌       | The region to use for Twilio, defaults to 'us1' |
+| Name       | Type                 | Required | Description                                     |
+| :--------- | :------------------- | :------- | :---------------------------------------------- |
+| accountSid | `string`             | ✅       | The SID for your Twilio account                 |
+| apiKey     | `string`             | ✅       | The API key for Twilio                          |
+| apiSecret  | `string`             | ✅       | The API Secret for Twilio                       |
+| from       | `string`             | ✅       | The phone number to send from, in E.164 format  |
+| region     | `TwilioConfigRegion` | ❌       | The region to use for Twilio, defaults to 'us1' |
 
 # TwilioConfigRegion
 
@@ -16,8 +16,8 @@ The region to use for Twilio, defaults to 'us1'
 
 **Properties**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| US1  | string | ✅       | "us1"       |
-| IE1  | string | ✅       | "ie1"       |
-| AU1  | string | ✅       | "au1"       |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| US1  | `string` | ✅       | "us1"       |
+| IE1  | `string` | ✅       | "ie1"       |
+| AU1  | `string` | ✅       | "au1"       |

--- a/packages/project-client/documentation/models/WebPushToken.md
+++ b/packages/project-client/documentation/models/WebPushToken.md
@@ -2,16 +2,16 @@
 
 **Properties**
 
-| Name     | Type   | Required | Description |
-| :------- | :----- | :------- | :---------- |
-| endpoint | string | ✅       |             |
-| keys     | Keys   | ✅       |             |
+| Name     | Type     | Required | Description |
+| :------- | :------- | :------- | :---------- |
+| endpoint | `string` | ✅       |             |
+| keys     | `Keys`   | ✅       |             |
 
 # Keys
 
 **Properties**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| auth   | string | ✅       |             |
-| p256dh | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| auth   | `string` | ✅       |             |
+| p256dh | `string` | ✅       |             |

--- a/packages/project-client/documentation/models/WebPushTokenWithMetadata.md
+++ b/packages/project-client/documentation/models/WebPushTokenWithMetadata.md
@@ -2,18 +2,18 @@
 
 **Properties**
 
-| Name     | Type                             | Required | Description |
-| :------- | :------------------------------- | :------- | :---------- |
-| data     | WebPushToken                     | ✅       |             |
-| metadata | WebPushTokenWithMetadataMetadata | ✅       |             |
+| Name     | Type                               | Required | Description |
+| :------- | :--------------------------------- | :------- | :---------- |
+| data     | `WebPushToken`                     | ✅       |             |
+| metadata | `WebPushTokenWithMetadataMetadata` | ✅       |             |
 
 # WebPushTokenWithMetadataMetadata
 
 **Properties**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| createdAt   | string | ✅       |             |
-| id          | string | ✅       |             |
-| discardedAt | string | ❌       |             |
-| updatedAt   | string | ❌       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| createdAt   | `string` | ✅       |             |
+| id          | `string` | ✅       |             |
+| discardedAt | `string` | ❌       |             |
+| updatedAt   | `string` | ❌       |             |

--- a/packages/project-client/documentation/models/WebpushConfig.md
+++ b/packages/project-client/documentation/models/WebpushConfig.md
@@ -2,7 +2,7 @@
 
 **Properties**
 
-| Name       | Type   | Required | Description |
-| :--------- | :----- | :------- | :---------- |
-| privateKey | string | ✅       |             |
-| publicKey  | string | ✅       |             |
+| Name       | Type     | Required | Description |
+| :--------- | :------- | :------- | :---------- |
+| privateKey | `string` | ✅       |             |
+| publicKey  | `string` | ✅       |             |

--- a/packages/project-client/documentation/services/BroadcastsService.md
+++ b/packages/project-client/documentation/services/BroadcastsService.md
@@ -17,11 +17,11 @@ Returns a list of broadcasts
 
 **Parameters**
 
-| Name       | Type   | Required | Description |
-| :--------- | :----- | :------- | :---------- |
-| pageSize   | number | ❌       |             |
-| pageBefore | string | ❌       |             |
-| pageAfter  | string | ❌       |             |
+| Name       | Type     | Required | Description |
+| :--------- | :------- | :------- | :---------- |
+| pageSize   | `number` | ❌       |             |
+| pageBefore | `string` | ❌       |             |
+| pageAfter  | `string` | ❌       |             |
 
 **Return Type**
 
@@ -38,7 +38,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.broadcasts.listBroadcasts({
-    pageSize: 10,
+    pageSize: 9,
     pageBefore: 'page[before]',
     pageAfter: 'page[after]',
   });
@@ -56,9 +56,9 @@ Handles the create notification request.
 
 **Parameters**
 
-| Name | Type                                | Required | Description       |
-| :--- | :---------------------------------- | :------- | :---------------- |
-| body | [Broadcast](../models/Broadcast.md) | ❌       | The request body. |
+| Name | Type                                  | Required | Description       |
+| :--- | :------------------------------------ | :------- | :---------------- |
+| body | `[Broadcast](../models/Broadcast.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -74,42 +74,42 @@ import { Broadcast, Client } from '@magicbell/project-client';
     token: 'YOUR_TOKEN',
   });
 
-  const category = 'RiB';
+  const category = 'mviFvt';
 
   const email: Email = {
-    actionUrl: 'labore esse nisi',
-    content: 'non incididunt Duis magna minim',
-    title: 'aliqua ea elit deserunt',
+    actionUrl: 'Utullamco aute dolore magna in',
+    content: 'incididunt',
+    title: 'dolor Excepteur id ad sit',
   };
 
   const inApp: InApp = {
-    actionUrl: 'commodo laborum proident non ea',
-    content: 'et ut sed do',
-    title: 'sint',
+    actionUrl: 'esse laboris ea',
+    content: 'est enim',
+    title: 'aliquip',
   };
 
   const mobilePush: MobilePush = {
-    actionUrl: 'sunt tempor voluptate occaecat',
-    content: 'sed cupidatat do aliquip nisi',
-    title: 'adipisicing culpa',
+    actionUrl: 'quis ipsum',
+    content: 'fugiat Lorem mollit cupidatat',
+    title: 'laborum sunt Ut mollit',
   };
 
   const slack: Slack = {
-    actionUrl: 'et adipisicing Duis fugiat',
-    content: 'ex sed aliquip esse Duis',
-    title: 'est ipsum ea',
+    actionUrl: 'labore qui ullamco amet Lorem',
+    content: 'tempor reprehenderit enim dolor',
+    title: 'eu nisi velit fugiat',
   };
 
   const sms: Sms = {
-    actionUrl: 'et proident amet ipsum irure',
-    content: 'magna Ut',
-    title: 'in',
+    actionUrl: 'culpa',
+    content: 'anim cillum eiusmod',
+    title: 'adipisicing anim reprehenderit',
   };
 
   const webPush: WebPush = {
-    actionUrl: 'amet in Ut occaecat',
-    content: 'enim ut',
-    title: 'in dolor eiusmod laborum minim',
+    actionUrl: 'nonaliqua ipsum dolor',
+    content: 'consequat laboris do eu',
+    title: 'aliquip',
   };
 
   const channels: Channels = {
@@ -136,16 +136,16 @@ import { Broadcast, Client } from '@magicbell/project-client';
     providers: providers,
   };
 
-  const topic = 'cM5OPs/SsM';
+  const topic = 'oFVCUBZ_sT';
 
   const broadcast: Broadcast = {
-    actionUrl: 'minim ut',
+    actionUrl: 'sed sunt',
     category: category,
-    content: 'qui deserunt sed',
+    content: 'nostrud sit dolor',
     customAttributes: {},
     overrides: overrides,
     recipients: [{}],
-    title: 'tempor et quis',
+    title: 'ex Duis',
     topic: topic,
   };
 
@@ -164,9 +164,9 @@ Returns a broadcast
 
 **Parameters**
 
-| Name        | Type   | Required | Description |
-| :---------- | :----- | :------- | :---------- |
-| broadcastId | string | ✅       |             |
+| Name        | Type     | Required | Description |
+| :---------- | :------- | :------- | :---------- |
+| broadcastId | `string` | ✅       |             |
 
 **Return Type**
 

--- a/packages/project-client/documentation/services/ChannelsService.md
+++ b/packages/project-client/documentation/services/ChannelsService.md
@@ -30,9 +30,9 @@ A list of all methods in the `ChannelsService` service. Click on the method name
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -61,10 +61,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -93,10 +93,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -125,9 +125,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -156,10 +156,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -188,10 +188,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -220,9 +220,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -251,10 +251,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -283,10 +283,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -315,9 +315,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -346,10 +346,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -378,10 +378,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -410,9 +410,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -441,10 +441,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -473,10 +473,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -505,9 +505,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -536,10 +536,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -568,10 +568,10 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| userId  | string | ✅       |             |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| userId  | `string` | ✅       |             |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 

--- a/packages/project-client/documentation/services/IntegrationsService.md
+++ b/packages/project-client/documentation/services/IntegrationsService.md
@@ -123,9 +123,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                  | Required | Description       |
-| :--- | :------------------------------------ | :------- | :---------------- |
-| body | [ApnsConfig](../models/ApnsConfig.md) | ❌       | The request body. |
+| Name | Type                                    | Required | Description       |
+| :--- | :-------------------------------------- | :------- | :---------------- |
+| body | `[ApnsConfig](../models/ApnsConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -144,11 +144,11 @@ import { ApnsConfig, Client } from '@magicbell/project-client';
   const badge = Badge.UNREAD;
 
   const apnsConfig: ApnsConfig = {
-    appId: 'D4EQ/tIASto0nj1AzqgjxEjFdO6Src0N',
+    appId: 'ZabA6uTnpv8S3Obr6slNb|wfbQCxeGJ9TTf;gEpHhFigXjWvQ8I6kN3xOSJGiGC',
     badge: badge,
     certificate: 'certificate',
-    keyId: 'velit exdo',
-    teamId: 'sed labore',
+    keyId: 'eiusmod pa',
+    teamId: 'adipisicin',
   };
 
   const { data } = await client.integrations.saveApnsIntegration(input);
@@ -185,9 +185,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -237,9 +237,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                      | Required | Description       |
-| :--- | :---------------------------------------- | :------- | :---------------- |
-| body | [AwssnsConfig](../models/AwssnsConfig.md) | ❌       | The request body. |
+| Name | Type                                        | Required | Description       |
+| :--- | :------------------------------------------ | :------- | :---------------- |
+| body | `[AwssnsConfig](../models/AwssnsConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -256,7 +256,7 @@ import { AwssnsConfig, Client } from '@magicbell/project-client';
   });
 
   const awssnsConfig: AwssnsConfig = {
-    webhookSigningSecret: 'u',
+    webhookSigningSecret: 'voluptate',
   };
 
   const { data } = await client.integrations.saveAwssnsIntegration(input);
@@ -293,9 +293,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -345,9 +345,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                  | Required | Description       |
-| :--- | :------------------------------------ | :------- | :---------------- |
-| body | [ExpoConfig](../models/ExpoConfig.md) | ❌       | The request body. |
+| Name | Type                                    | Required | Description       |
+| :--- | :-------------------------------------- | :------- | :---------------- |
+| body | `[ExpoConfig](../models/ExpoConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -364,7 +364,7 @@ import { Client, ExpoConfig } from '@magicbell/project-client';
   });
 
   const expoConfig: ExpoConfig = {
-    accessToken: 'officia fugi',
+    accessToken: 'non dolor',
   };
 
   const { data } = await client.integrations.saveExpoIntegration(input);
@@ -401,9 +401,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -453,9 +453,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                | Required | Description       |
-| :--- | :---------------------------------- | :------- | :---------------- |
-| body | [FcmConfig](../models/FcmConfig.md) | ❌       | The request body. |
+| Name | Type                                  | Required | Description       |
+| :--- | :------------------------------------ | :------- | :---------------- |
+| body | `[FcmConfig](../models/FcmConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -521,9 +521,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -573,9 +573,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                      | Required | Description       |
-| :--- | :---------------------------------------- | :------- | :---------------- |
-| body | [GithubConfig](../models/GithubConfig.md) | ❌       | The request body. |
+| Name | Type                                        | Required | Description       |
+| :--- | :------------------------------------------ | :------- | :---------------- |
+| body | `[GithubConfig](../models/GithubConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -592,7 +592,7 @@ import { Client, GithubConfig } from '@magicbell/project-client';
   });
 
   const githubConfig: GithubConfig = {
-    webhookSigningSecret: 'ipsum',
+    webhookSigningSecret: 'ut',
   };
 
   const { data } = await client.integrations.saveGithubIntegration(input);
@@ -629,9 +629,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -681,9 +681,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                    | Required | Description       |
-| :--- | :-------------------------------------- | :------- | :---------------- |
-| body | [InboxConfig](../models/InboxConfig.md) | ❌       | The request body. |
+| Name | Type                                      | Required | Description       |
+| :--- | :---------------------------------------- | :------- | :---------------- |
+| body | `[InboxConfig](../models/InboxConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -705,7 +705,7 @@ import { Client, InboxConfig } from '@magicbell/project-client';
 
   const banner: Banner = {
     backgroundColor: 'backgroundColor',
-    backgroundOpacity: 9.19,
+    backgroundOpacity: 6.65,
     fontSize: 'fontSize',
     textColor: 'textColor',
   };
@@ -807,7 +807,7 @@ import { Client, InboxConfig } from '@magicbell/project-client';
 
   const inboxConfig: InboxConfig = {
     images: images,
-    locale: 'sit nostru',
+    locale: 'non',
     theme: theme,
   };
 
@@ -845,9 +845,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -897,9 +897,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                        | Required | Description       |
-| :--- | :------------------------------------------ | :------- | :---------------- |
-| body | [MailgunConfig](../models/MailgunConfig.md) | ❌       | The request body. |
+| Name | Type                                          | Required | Description       |
+| :--- | :-------------------------------------------- | :------- | :---------------- |
+| body | `[MailgunConfig](../models/MailgunConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -918,8 +918,8 @@ import { Client, MailgunConfig } from '@magicbell/project-client';
   const mailgunConfigRegion = MailgunConfigRegion.US;
 
   const mailgunConfig: MailgunConfig = {
-    apiKey: 'in ',
-    domain: 'consequat d',
+    apiKey: 'volupt',
+    domain: 'aliquip',
     region: mailgunConfigRegion,
   };
 
@@ -957,9 +957,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1009,9 +1009,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                  | Required | Description       |
-| :--- | :------------------------------------ | :------- | :---------------- |
-| body | [PingConfig](../models/PingConfig.md) | ❌       | The request body. |
+| Name | Type                                    | Required | Description       |
+| :--- | :-------------------------------------- | :------- | :---------------- |
+| body | `[PingConfig](../models/PingConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1028,7 +1028,7 @@ import { Client, PingConfig } from '@magicbell/project-client';
   });
 
   const pingConfig: PingConfig = {
-    url: 'ut incididunt irure Ut',
+    url: 'minim',
   };
 
   const { data } = await client.integrations.savePingEmailIntegration(input);
@@ -1065,9 +1065,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1117,9 +1117,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                          | Required | Description       |
-| :--- | :-------------------------------------------- | :------- | :---------------- |
-| body | [SendgridConfig](../models/SendgridConfig.md) | ❌       | The request body. |
+| Name | Type                                            | Required | Description       |
+| :--- | :---------------------------------------------- | :------- | :---------------- |
+| body | `[SendgridConfig](../models/SendgridConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1185,9 +1185,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1237,9 +1237,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                | Required | Description       |
-| :--- | :---------------------------------- | :------- | :---------------- |
-| body | [SesConfig](../models/SesConfig.md) | ❌       | The request body. |
+| Name | Type                                  | Required | Description       |
+| :--- | :------------------------------------ | :------- | :---------------- |
+| body | `[SesConfig](../models/SesConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1261,11 +1261,11 @@ import { Client, SesConfig } from '@magicbell/project-client';
   };
 
   const sesConfig: SesConfig = {
-    endpoint: 'dolore in occa',
+    endpoint: 'elit su',
     from: sesConfigFrom,
-    keyId: 'sit ex ',
-    region: 'in',
-    secretKey: 'do',
+    keyId: 'sit in occa',
+    region: 'cillum ',
+    secretKey: 'aute Ut cu',
   };
 
   const { data } = await client.integrations.saveSesIntegration(input);
@@ -1302,9 +1302,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1354,9 +1354,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                    | Required | Description       |
-| :--- | :-------------------------------------- | :------- | :---------------- |
-| body | [SlackConfig](../models/SlackConfig.md) | ❌       | The request body. |
+| Name | Type                                      | Required | Description       |
+| :--- | :---------------------------------------- | :------- | :---------------- |
+| body | `[SlackConfig](../models/SlackConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1373,10 +1373,10 @@ import { Client, SlackConfig } from '@magicbell/project-client';
   });
 
   const slackConfig: SlackConfig = {
-    appId: 'EC',
-    clientId: '707.8465562093',
-    clientSecret: 'et exercitation voluptate ametni',
-    signingSecret: 'exercitation Utmollitetad ullamc',
+    appId: 'DQ01',
+    clientId: '1361923.1921861',
+    clientSecret: 'cupidatat non suntdolore Excepte',
+    signingSecret: 'aliquip Excepteur laboris pariat',
   };
 
   const { data } = await client.integrations.saveSlackIntegration(input);
@@ -1413,9 +1413,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1465,9 +1465,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                      | Required | Description       |
-| :--- | :---------------------------------------- | :------- | :---------------- |
-| body | [StripeConfig](../models/StripeConfig.md) | ❌       | The request body. |
+| Name | Type                                        | Required | Description       |
+| :--- | :------------------------------------------ | :------- | :---------------- |
+| body | `[StripeConfig](../models/StripeConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1484,7 +1484,7 @@ import { Client, StripeConfig } from '@magicbell/project-client';
   });
 
   const stripeConfig: StripeConfig = {
-    webhookSigningSecret: 'in',
+    webhookSigningSecret: 'Excepteur Ut cupidatat co',
   };
 
   const { data } = await client.integrations.saveStripeIntegration(input);
@@ -1521,9 +1521,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1573,9 +1573,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type | Required | Description       |
-| :--- | :--- | :------- | :---------------- |
-| body | any  | ❌       | The request body. |
+| Name | Type  | Required | Description       |
+| :--- | :---- | :------- | :---------------- |
+| body | `any` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1627,9 +1627,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1679,9 +1679,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                      | Required | Description       |
-| :--- | :---------------------------------------- | :------- | :---------------- |
-| body | [TwilioConfig](../models/TwilioConfig.md) | ❌       | The request body. |
+| Name | Type                                        | Required | Description       |
+| :--- | :------------------------------------------ | :------- | :---------------- |
+| body | `[TwilioConfig](../models/TwilioConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1700,10 +1700,10 @@ import { Client, TwilioConfig } from '@magicbell/project-client';
   const twilioConfigRegion = TwilioConfigRegion.US1;
 
   const twilioConfig: TwilioConfig = {
-    accountSid: 'qui',
-    apiKey: 'velit',
-    apiSecret: 'cillum magna',
-    from: '+300',
+    accountSid: 'in id occaecat',
+    apiKey: 'ut est enim dolor es',
+    apiSecret: 'ad',
+    from: '+7881753143',
     region: twilioConfigRegion,
   };
 
@@ -1741,9 +1741,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 
@@ -1793,9 +1793,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                        | Required | Description       |
-| :--- | :------------------------------------------ | :------- | :---------------- |
-| body | [WebpushConfig](../models/WebpushConfig.md) | ❌       | The request body. |
+| Name | Type                                          | Required | Description       |
+| :--- | :-------------------------------------------- | :------- | :---------------- |
+| body | `[WebpushConfig](../models/WebpushConfig.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -1812,8 +1812,8 @@ import { Client, WebpushConfig } from '@magicbell/project-client';
   });
 
   const webpushConfig: WebpushConfig = {
-    privateKey: 'labore aliquip tempor enim magna',
-    publicKey: 'labore sunt',
+    privateKey: 'adipisicing consequat consectetur',
+    publicKey: 'magna esse',
   };
 
   const { data } = await client.integrations.saveWebPushIntegration(input);
@@ -1850,9 +1850,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type   | Required | Description |
-| :--- | :----- | :------- | :---------- |
-| id   | string | ✅       |             |
+| Name | Type     | Required | Description |
+| :--- | :------- | :------- | :---------- |
+| id   | `string` | ✅       |             |
 
 **Example Usage Code Snippet**
 

--- a/packages/project-client/documentation/services/JwtService.md
+++ b/packages/project-client/documentation/services/JwtService.md
@@ -43,9 +43,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                                                | Required | Description       |
-| :--- | :------------------------------------------------------------------ | :------- | :---------------- |
-| body | [CreateProjectTokenRequest](../models/CreateProjectTokenRequest.md) | ❌       | The request body. |
+| Name | Type                                                                  | Required | Description       |
+| :--- | :-------------------------------------------------------------------- | :------- | :---------------- |
+| body | `[CreateProjectTokenRequest](../models/CreateProjectTokenRequest.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -62,8 +62,8 @@ import { Client, CreateProjectTokenRequest } from '@magicbell/project-client';
   });
 
   const createProjectTokenRequest: CreateProjectTokenRequest = {
-    expiry: 3,
-    name: 'mollit elit commodo Lorem ullamco',
+    expiry: 9,
+    name: 'eu aliquip',
   };
 
   const { data } = await client.jwt.createProjectJwt(input);
@@ -79,9 +79,9 @@ import { Client, CreateProjectTokenRequest } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -110,9 +110,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name | Type                                                          | Required | Description       |
-| :--- | :------------------------------------------------------------ | :------- | :---------------- |
-| body | [CreateUserTokenRequest](../models/CreateUserTokenRequest.md) | ❌       | The request body. |
+| Name | Type                                                            | Required | Description       |
+| :--- | :-------------------------------------------------------------- | :------- | :---------------- |
+| body | `[CreateUserTokenRequest](../models/CreateUserTokenRequest.md)` | ❌       | The request body. |
 
 **Return Type**
 
@@ -129,10 +129,10 @@ import { Client, CreateUserTokenRequest } from '@magicbell/project-client';
   });
 
   const createUserTokenRequest: CreateUserTokenRequest = {
-    email: 'ut sunt ullamco sint',
-    expiry: 6,
-    externalId: 'commodo dolore cupidatat et ut',
-    name: 'do ea dolore',
+    email: 'fugiat ex',
+    expiry: 7,
+    externalId: 'exercitation pariatur',
+    name: 'in in ut ut',
   };
 
   const { data } = await client.jwt.createUserJwt(input);
@@ -148,9 +148,9 @@ import { Client, CreateUserTokenRequest } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name    | Type   | Required | Description |
-| :------ | :----- | :------- | :---------- |
-| tokenId | string | ✅       |             |
+| Name    | Type     | Required | Description |
+| :------ | :------- | :------- | :---------- |
+| tokenId | `string` | ✅       |             |
 
 **Return Type**
 
@@ -179,9 +179,9 @@ import { Client } from '@magicbell/project-client';
 
 **Parameters**
 
-| Name   | Type   | Required | Description |
-| :----- | :----- | :------- | :---------- |
-| userId | string | ✅       |             |
+| Name   | Type     | Required | Description |
+| :----- | :------- | :------- | :---------- |
+| userId | `string` | ✅       |             |
 
 **Return Type**
 

--- a/packages/project-client/package.json
+++ b/packages/project-client/package.json
@@ -35,20 +35,20 @@
     "dist",
     "README.md"
   ],
-  "tshy": {
-    "project": "./tsconfig.build.json",
-    "exports": "./src/index.ts"
-  },
   "scripts": {
     "build": "tshy",
     "codegen": "tsx scripts/build.ts",
-    "start": "rm -rf dist/ && tsc -w"
+    "start": "tshy --watch"
   },
   "dependencies": {
     "zod": "3.23.8"
   },
   "devDependencies": {
     "typescript": "^5.5.3"
+  },
+  "tshy": {
+    "project": "./tsconfig.build.json",
+    "exports": "./src/index.ts"
   },
   "type": "module"
 }

--- a/packages/project-client/scripts/build.ts
+++ b/packages/project-client/scripts/build.ts
@@ -162,4 +162,4 @@ async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.j
   execSync(`yarn build`, { stdio: 'inherit' });
 }
 
-build(args.spec);
+build(args.spec || process.env.V2_SPEC_URL || process.env.SPEC_URL);

--- a/packages/project-client/scripts/build.ts
+++ b/packages/project-client/scripts/build.ts
@@ -128,7 +128,6 @@ async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.j
   // patch package.json
   let pkgJson = JSON.parse(await fs.readFile('./package.json', { encoding: 'utf-8' }));
   pkgJson.version = initialPkgJson.version;
-  pkgJson.scripts.codegen = 'tsx scripts/build.ts';
 
   pkgJson.scripts = {
     build: 'tshy',

--- a/packages/project-client/scripts/build.ts
+++ b/packages/project-client/scripts/build.ts
@@ -141,6 +141,10 @@ async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.j
     exports: './src/index.ts',
   };
 
+  delete pkgJson['src'];
+  delete pkgJson['unpkg'];
+  delete pkgJson['browser'];
+
   for (const key of Object.keys(pkgJson.devDependencies)) {
     if (/eslint|prettier/.test(key)) {
       delete pkgJson.devDependencies[key];

--- a/packages/project-client/scripts/build.ts
+++ b/packages/project-client/scripts/build.ts
@@ -100,6 +100,7 @@ const { values: args } = parseArgs({
 });
 
 async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.json') {
+  const initialPkgJson = JSON.parse(await fs.readFile('./package.json', { encoding: 'utf-8' }));
   const liblabConfig = JSON.parse(await fs.readFile('./liblab.config.json', { encoding: 'utf-8' }));
   let swaggerJSON = await readFileOrUrl(specfile);
   const spec = JSON.parse(swaggerJSON);
@@ -126,6 +127,7 @@ async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.j
 
   // patch package.json
   let pkgJson = JSON.parse(await fs.readFile('./package.json', { encoding: 'utf-8' }));
+  pkgJson.version = initialPkgJson.version;
   pkgJson.scripts.codegen = 'tsx scripts/build.ts';
 
   pkgJson.scripts = {

--- a/packages/project-client/scripts/mods/mb-header-handler.ts
+++ b/packages/project-client/scripts/mods/mb-header-handler.ts
@@ -27,6 +27,8 @@ export class HeaderHandler implements RequestHandler {
         explode: false,
         encode: false,
         style: SerializationStyle.SIMPLE,
+        isLimit: false,
+        isOffset: false,
       });
     }
 

--- a/packages/project-client/src/http/client.ts
+++ b/packages/project-client/src/http/client.ts
@@ -27,11 +27,45 @@ export class HttpClient {
     return this.requestHandlerChain.callChain(request);
   }
 
+  public async callPaginated<FullResponse, Page>(request: Request<FullResponse, Page>): Promise<HttpResponse<Page>> {
+    const response = await this.call<FullResponse>(request as any);
+
+    if (!response.data) {
+      throw new Error('now response data to paginate through');
+    }
+
+    return {
+      ...response,
+      data: this.getPage<FullResponse, Page>(request, response.data),
+    };
+  }
+
   setBaseUrl(url: string): void {
     this.config.baseUrl = url;
   }
 
   setConfig(config: SdkConfig): void {
     this.config = config;
+  }
+
+  private getPage<FullResponse, Page>(request: Request<FullResponse, Page>, data: FullResponse): Page {
+    if (!request.pagination) {
+      throw new Error('getPage called for request without pagination property');
+    }
+
+    let curr: any = data;
+    for (const segment of request.pagination?.pagePath || []) {
+      curr = curr[segment];
+    }
+
+    const page = request.pagination?.pageSchema?.parse(curr);
+    if (!page) {
+      throw new Error(
+        `error getting page data. Curr: ${JSON.stringify(curr)}. PagePath: ${
+          request.pagination?.pagePath
+        }. Data: ${JSON.stringify(data)}`,
+      );
+    }
+    return page;
   }
 }

--- a/packages/project-client/src/http/handlers/auth-handler.ts
+++ b/packages/project-client/src/http/handlers/auth-handler.ts
@@ -27,6 +27,8 @@ export class AuthHandler implements RequestHandler {
       explode: false,
       encode: false,
       style: SerializationStyle.SIMPLE,
+      isLimit: false,
+      isOffset: false,
     });
 
     return request;

--- a/packages/project-client/src/http/handlers/mb-header-handler.ts
+++ b/packages/project-client/src/http/handlers/mb-header-handler.ts
@@ -27,6 +27,8 @@ export class HeaderHandler implements RequestHandler {
         explode: false,
         encode: false,
         style: SerializationStyle.SIMPLE,
+        isLimit: false,
+        isOffset: false,
       });
     }
 

--- a/packages/project-client/src/http/index.ts
+++ b/packages/project-client/src/http/index.ts
@@ -1,1 +1,9 @@
-export type { RequestConfig, RetryOptions, SdkConfig, ValidationOptions } from './types.ts';
+export type {
+  HttpMetadata,
+  HttpMethod,
+  HttpResponse,
+  RequestConfig,
+  RetryOptions,
+  SdkConfig,
+  ValidationOptions,
+} from './types.ts';

--- a/packages/project-client/src/http/transport/request.ts
+++ b/packages/project-client/src/http/transport/request.ts
@@ -7,7 +7,7 @@ import { PathSerializer } from '../serialization/path-serializer.js';
 import { QuerySerializer } from '../serialization/query-serializer.js';
 import { ContentType, HttpMethod, RetryOptions, SdkConfig, ValidationOptions } from '../types.js';
 
-export interface CreateRequestParameters<T> {
+export interface CreateRequestParameters<FullResponse, Page = unknown[]> {
   baseUrl: string;
   method: HttpMethod;
   body?: any;
@@ -16,12 +16,13 @@ export interface CreateRequestParameters<T> {
   pathParams: Map<string, RequestParameter>;
   path: string;
   config: SdkConfig;
-  responseSchema: ZodType<T, any, any>;
+  responseSchema: ZodType<FullResponse, any, any>;
   requestSchema: ZodType;
   requestContentType: ContentType;
   responseContentType: ContentType;
   validation: ValidationOptions;
   retry: RetryOptions;
+  pagination?: RequestPagination<Page>;
 }
 
 export interface RequestParameter {
@@ -30,9 +31,17 @@ export interface RequestParameter {
   explode: boolean;
   encode: boolean;
   style: SerializationStyle;
+  isLimit: boolean;
+  isOffset: boolean;
 }
 
-export class Request<T> {
+export interface RequestPagination<Page> {
+  pageSize: number;
+  pagePath: string[];
+  pageSchema?: ZodType<Page, any, any>;
+}
+
+export class Request<T = unknown, PageSchema = unknown[]> {
   public baseUrl = '';
 
   public headers: Map<string, RequestParameter> = new Map();
@@ -61,9 +70,11 @@ export class Request<T> {
 
   public retry: RetryOptions = {} as any;
 
+  public pagination?: RequestPagination<PageSchema>;
+
   private readonly pathPattern: string;
 
-  constructor(params: CreateRequestParameters<T>) {
+  constructor(params: CreateRequestParameters<T, PageSchema>) {
     this.baseUrl = params.baseUrl;
     this.method = params.method;
     this.pathPattern = params.path;
@@ -79,6 +90,7 @@ export class Request<T> {
     this.responseContentType = params.responseContentType;
     this.retry = params.retry;
     this.validation = params.validation;
+    this.pagination = params.pagination;
   }
 
   addHeaderParam(key: string, param: RequestParameter): void {
@@ -204,7 +216,43 @@ export class Request<T> {
     return new HeaderSerializer().serialize(this.headers);
   }
 
+  public nextPage() {
+    if (!this.pagination) {
+      return;
+    }
+
+    const offsetParam = this.getOffsetParam();
+    if (!offsetParam) {
+      return;
+    }
+
+    offsetParam.value = Number(offsetParam.value) + this.pagination.pageSize;
+  }
+
   private constructPath(): string {
     return new PathSerializer().serialize(this.pathPattern, this.pathParams);
+  }
+
+  private getOffsetParam(): RequestParameter | undefined {
+    const offsetParam = this.getAllParams().find((param) => param.isOffset);
+    return offsetParam;
+  }
+
+  private getAllParams(): RequestParameter[] {
+    const allParams: RequestParameter[] = [];
+
+    this.headers.forEach((val, key) => {
+      allParams.push(val);
+    });
+
+    this.queryParams.forEach((val, key) => {
+      allParams.push(val);
+    });
+
+    this.pathParams.forEach((val, key) => {
+      allParams.push(val);
+    });
+
+    return allParams;
   }
 }

--- a/packages/project-client/src/http/transport/transport-hook-adapter.ts
+++ b/packages/project-client/src/http/transport/transport-hook-adapter.ts
@@ -78,6 +78,8 @@ export class TransportHookAdapter<T> {
         encode: requestParam?.encode ?? false,
         style: requestParam?.style || SerializationStyle.NONE,
         explode: requestParam?.explode ?? false,
+        isLimit: requestParam?.isLimit ?? false,
+        isOffset: requestParam?.isOffset ?? false,
       });
     });
     return transportParams;

--- a/packages/project-client/src/services/broadcasts/broadcasts.ts
+++ b/packages/project-client/src/services/broadcasts/broadcasts.ts
@@ -20,8 +20,8 @@ export class BroadcastsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<BroadcastListResponse>> {
     const request = new RequestBuilder<BroadcastListResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/broadcasts')
       .setRequestSchema(z.any())
@@ -53,8 +53,8 @@ export class BroadcastsService extends BaseService {
    */
   async createBroadcast(body: Broadcast, requestConfig?: RequestConfig): Promise<HttpResponse<Broadcast>> {
     const request = new RequestBuilder<Broadcast>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('POST')
       .setPath('/broadcasts')
       .setRequestSchema(broadcastRequest)
@@ -77,8 +77,8 @@ export class BroadcastsService extends BaseService {
    */
   async fetchBroadcast(broadcastId: string, requestConfig?: RequestConfig): Promise<HttpResponse<Broadcast>> {
     const request = new RequestBuilder<Broadcast>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/broadcasts/{broadcast_id}')
       .setRequestSchema(z.any())

--- a/packages/project-client/src/services/channels/channels.ts
+++ b/packages/project-client/src/services/channels/channels.ts
@@ -46,8 +46,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfApnsToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfApnsToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/apns/tokens')
       .setRequestSchema(z.any())
@@ -77,8 +77,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ApnsTokenWithMetadata>> {
     const request = new RequestBuilder<ApnsTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/apns/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -112,8 +112,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/mobile_push/apns/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -145,8 +145,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfExpoToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfExpoToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/expo/tokens')
       .setRequestSchema(z.any())
@@ -176,8 +176,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ExpoTokenWithMetadata>> {
     const request = new RequestBuilder<ExpoTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/expo/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -211,8 +211,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/mobile_push/expo/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -244,8 +244,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfFcmToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfFcmToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/fcm/tokens')
       .setRequestSchema(z.any())
@@ -275,8 +275,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<FcmTokenWithMetadata>> {
     const request = new RequestBuilder<FcmTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/mobile_push/fcm/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -310,8 +310,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/mobile_push/fcm/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -343,8 +343,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfSlackToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfSlackToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/slack/tokens')
       .setRequestSchema(z.any())
@@ -374,8 +374,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<SlackTokenWithMetadata>> {
     const request = new RequestBuilder<SlackTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/slack/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -409,8 +409,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/slack/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -442,8 +442,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfTeamsToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfTeamsToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/teams/tokens')
       .setRequestSchema(z.any())
@@ -473,8 +473,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<TeamsTokenWithMetadata>> {
     const request = new RequestBuilder<TeamsTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/teams/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -508,8 +508,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/teams/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -541,8 +541,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<ArrayWithMetadataOfWebPushToken>> {
     const request = new RequestBuilder<ArrayWithMetadataOfWebPushToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/web_push/tokens')
       .setRequestSchema(z.any())
@@ -572,8 +572,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<WebPushTokenWithMetadata>> {
     const request = new RequestBuilder<WebPushTokenWithMetadata>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/users/{user_id}/channels/web_push/tokens/{token_id}')
       .setRequestSchema(z.any())
@@ -607,8 +607,8 @@ export class ChannelsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<DiscardResult>> {
     const request = new RequestBuilder<DiscardResult>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/users/{user_id}/channels/web_push/tokens/{token_id}')
       .setRequestSchema(z.any())

--- a/packages/project-client/src/services/integrations/integrations.ts
+++ b/packages/project-client/src/services/integrations/integrations.ts
@@ -26,8 +26,8 @@ export class IntegrationsService extends BaseService {
    */
   async listIntegrations(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations')
       .setRequestSchema(z.any())
@@ -47,8 +47,8 @@ export class IntegrationsService extends BaseService {
    */
   async getApnsIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/apns')
       .setRequestSchema(z.any())
@@ -68,8 +68,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveApnsIntegration(body: ApnsConfig, requestConfig?: RequestConfig): Promise<HttpResponse<ApnsConfig>> {
     const request = new RequestBuilder<ApnsConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/apns')
       .setRequestSchema(apnsConfigRequest)
@@ -91,8 +91,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteApnsIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/apns')
       .setRequestSchema(z.any())
@@ -113,8 +113,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteApnsIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/apns/{id}')
       .setRequestSchema(z.any())
@@ -138,8 +138,8 @@ export class IntegrationsService extends BaseService {
    */
   async getAwssnsIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/awssns')
       .setRequestSchema(z.any())
@@ -159,8 +159,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveAwssnsIntegration(body: AwssnsConfig, requestConfig?: RequestConfig): Promise<HttpResponse<AwssnsConfig>> {
     const request = new RequestBuilder<AwssnsConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/awssns')
       .setRequestSchema(awssnsConfigRequest)
@@ -182,8 +182,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteAwssnsIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/awssns')
       .setRequestSchema(z.any())
@@ -204,8 +204,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteAwssnsIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/awssns/{id}')
       .setRequestSchema(z.any())
@@ -229,8 +229,8 @@ export class IntegrationsService extends BaseService {
    */
   async getExpoIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/expo')
       .setRequestSchema(z.any())
@@ -250,8 +250,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveExpoIntegration(body: ExpoConfig, requestConfig?: RequestConfig): Promise<HttpResponse<ExpoConfig>> {
     const request = new RequestBuilder<ExpoConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/expo')
       .setRequestSchema(expoConfigRequest)
@@ -273,8 +273,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteExpoIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/expo')
       .setRequestSchema(z.any())
@@ -295,8 +295,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteExpoIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/expo/{id}')
       .setRequestSchema(z.any())
@@ -320,8 +320,8 @@ export class IntegrationsService extends BaseService {
    */
   async getFcmIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/fcm')
       .setRequestSchema(z.any())
@@ -341,8 +341,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveFcmIntegration(body: FcmConfig, requestConfig?: RequestConfig): Promise<HttpResponse<FcmConfig>> {
     const request = new RequestBuilder<FcmConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/fcm')
       .setRequestSchema(fcmConfigRequest)
@@ -364,8 +364,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteFcmIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/fcm')
       .setRequestSchema(z.any())
@@ -386,8 +386,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteFcmIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/fcm/{id}')
       .setRequestSchema(z.any())
@@ -411,8 +411,8 @@ export class IntegrationsService extends BaseService {
    */
   async getGithubIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/github')
       .setRequestSchema(z.any())
@@ -432,8 +432,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveGithubIntegration(body: GithubConfig, requestConfig?: RequestConfig): Promise<HttpResponse<GithubConfig>> {
     const request = new RequestBuilder<GithubConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/github')
       .setRequestSchema(githubConfigRequest)
@@ -455,8 +455,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteGithubIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/github')
       .setRequestSchema(z.any())
@@ -477,8 +477,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteGithubIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/github/{id}')
       .setRequestSchema(z.any())
@@ -502,8 +502,8 @@ export class IntegrationsService extends BaseService {
    */
   async getInboxIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/inbox')
       .setRequestSchema(z.any())
@@ -523,8 +523,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveInboxIntegration(body: InboxConfig, requestConfig?: RequestConfig): Promise<HttpResponse<InboxConfig>> {
     const request = new RequestBuilder<InboxConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/inbox')
       .setRequestSchema(inboxConfigRequest)
@@ -546,8 +546,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteInboxIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/inbox')
       .setRequestSchema(z.any())
@@ -568,8 +568,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteInboxIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/inbox/{id}')
       .setRequestSchema(z.any())
@@ -593,8 +593,8 @@ export class IntegrationsService extends BaseService {
    */
   async getMailgunIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/mailgun')
       .setRequestSchema(z.any())
@@ -617,8 +617,8 @@ export class IntegrationsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<MailgunConfig>> {
     const request = new RequestBuilder<MailgunConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/mailgun')
       .setRequestSchema(mailgunConfigRequest)
@@ -640,8 +640,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteMailgunIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/mailgun')
       .setRequestSchema(z.any())
@@ -662,8 +662,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteMailgunIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/mailgun/{id}')
       .setRequestSchema(z.any())
@@ -687,8 +687,8 @@ export class IntegrationsService extends BaseService {
    */
   async getPingEmailIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/ping_email')
       .setRequestSchema(z.any())
@@ -708,8 +708,8 @@ export class IntegrationsService extends BaseService {
    */
   async savePingEmailIntegration(body: PingConfig, requestConfig?: RequestConfig): Promise<HttpResponse<PingConfig>> {
     const request = new RequestBuilder<PingConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/ping_email')
       .setRequestSchema(pingConfigRequest)
@@ -731,8 +731,8 @@ export class IntegrationsService extends BaseService {
    */
   async deletePingEmailIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/ping_email')
       .setRequestSchema(z.any())
@@ -753,8 +753,8 @@ export class IntegrationsService extends BaseService {
    */
   async deletePingEmailIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/ping_email/{id}')
       .setRequestSchema(z.any())
@@ -778,8 +778,8 @@ export class IntegrationsService extends BaseService {
    */
   async getSendgridIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/sendgrid')
       .setRequestSchema(z.any())
@@ -802,8 +802,8 @@ export class IntegrationsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<SendgridConfig>> {
     const request = new RequestBuilder<SendgridConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/sendgrid')
       .setRequestSchema(sendgridConfigRequest)
@@ -825,8 +825,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSendgridIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/sendgrid')
       .setRequestSchema(z.any())
@@ -847,8 +847,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSendgridIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/sendgrid/{id}')
       .setRequestSchema(z.any())
@@ -872,8 +872,8 @@ export class IntegrationsService extends BaseService {
    */
   async getSesIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/ses')
       .setRequestSchema(z.any())
@@ -893,8 +893,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveSesIntegration(body: SesConfig, requestConfig?: RequestConfig): Promise<HttpResponse<SesConfig>> {
     const request = new RequestBuilder<SesConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/ses')
       .setRequestSchema(sesConfigRequest)
@@ -916,8 +916,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSesIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/ses')
       .setRequestSchema(z.any())
@@ -938,8 +938,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSesIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/ses/{id}')
       .setRequestSchema(z.any())
@@ -963,8 +963,8 @@ export class IntegrationsService extends BaseService {
    */
   async getSlackIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/slack')
       .setRequestSchema(z.any())
@@ -984,8 +984,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveSlackIntegration(body: SlackConfig, requestConfig?: RequestConfig): Promise<HttpResponse<SlackConfig>> {
     const request = new RequestBuilder<SlackConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/slack')
       .setRequestSchema(slackConfigRequest)
@@ -1007,8 +1007,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSlackIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/slack')
       .setRequestSchema(z.any())
@@ -1029,8 +1029,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteSlackIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/slack/{id}')
       .setRequestSchema(z.any())
@@ -1054,8 +1054,8 @@ export class IntegrationsService extends BaseService {
    */
   async getStripeIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/stripe')
       .setRequestSchema(z.any())
@@ -1075,8 +1075,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveStripeIntegration(body: StripeConfig, requestConfig?: RequestConfig): Promise<HttpResponse<StripeConfig>> {
     const request = new RequestBuilder<StripeConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/stripe')
       .setRequestSchema(stripeConfigRequest)
@@ -1098,8 +1098,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteStripeIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/stripe')
       .setRequestSchema(z.any())
@@ -1120,8 +1120,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteStripeIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/stripe/{id}')
       .setRequestSchema(z.any())
@@ -1145,8 +1145,8 @@ export class IntegrationsService extends BaseService {
    */
   async getTemplatesIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/templates')
       .setRequestSchema(z.any())
@@ -1166,8 +1166,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveTemplatesIntegration(body: any, requestConfig?: RequestConfig): Promise<HttpResponse<any>> {
     const request = new RequestBuilder<any>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/templates')
       .setRequestSchema(z.any())
@@ -1189,8 +1189,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteTemplatesIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/templates')
       .setRequestSchema(z.any())
@@ -1211,8 +1211,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteTemplatesIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/templates/{id}')
       .setRequestSchema(z.any())
@@ -1236,8 +1236,8 @@ export class IntegrationsService extends BaseService {
    */
   async getTwilioIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/twilio')
       .setRequestSchema(z.any())
@@ -1257,8 +1257,8 @@ export class IntegrationsService extends BaseService {
    */
   async saveTwilioIntegration(body: TwilioConfig, requestConfig?: RequestConfig): Promise<HttpResponse<TwilioConfig>> {
     const request = new RequestBuilder<TwilioConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/twilio')
       .setRequestSchema(twilioConfigRequest)
@@ -1280,8 +1280,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteTwilioIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/twilio')
       .setRequestSchema(z.any())
@@ -1302,8 +1302,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteTwilioIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/twilio/{id}')
       .setRequestSchema(z.any())
@@ -1327,8 +1327,8 @@ export class IntegrationsService extends BaseService {
    */
   async getWebPushIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<ListIntegrationsResponse>> {
     const request = new RequestBuilder<ListIntegrationsResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/integrations/web_push')
       .setRequestSchema(z.any())
@@ -1351,8 +1351,8 @@ export class IntegrationsService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<WebpushConfig>> {
     const request = new RequestBuilder<WebpushConfig>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('PUT')
       .setPath('/integrations/web_push')
       .setRequestSchema(webpushConfigRequest)
@@ -1374,8 +1374,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteWebPushIntegration(requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/web_push')
       .setRequestSchema(z.any())
@@ -1396,8 +1396,8 @@ export class IntegrationsService extends BaseService {
    */
   async deleteWebPushIntegrationById(id: string, requestConfig?: RequestConfig): Promise<HttpResponse<undefined>> {
     const request = new RequestBuilder<undefined>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/integrations/web_push/{id}')
       .setRequestSchema(z.any())

--- a/packages/project-client/src/services/jwt/jwt.ts
+++ b/packages/project-client/src/services/jwt/jwt.ts
@@ -16,8 +16,8 @@ export class JwtService extends BaseService {
    */
   async fetchProjectTokens(requestConfig?: RequestConfig): Promise<HttpResponse<FetchTokensResponse>> {
     const request = new RequestBuilder<FetchTokensResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/jwt/project')
       .setRequestSchema(z.any())
@@ -40,8 +40,8 @@ export class JwtService extends BaseService {
     requestConfig?: RequestConfig,
   ): Promise<HttpResponse<AccessToken>> {
     const request = new RequestBuilder<AccessToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('POST')
       .setPath('/jwt/project')
       .setRequestSchema(createProjectTokenRequestRequest)
@@ -64,8 +64,8 @@ export class JwtService extends BaseService {
    */
   async discardProjectJwt(tokenId: string, requestConfig?: RequestConfig): Promise<HttpResponse<DiscardTokenResponse>> {
     const request = new RequestBuilder<DiscardTokenResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/jwt/project/{token_id}')
       .setRequestSchema(z.any())
@@ -89,8 +89,8 @@ export class JwtService extends BaseService {
    */
   async createUserJwt(body: CreateUserTokenRequest, requestConfig?: RequestConfig): Promise<HttpResponse<AccessToken>> {
     const request = new RequestBuilder<AccessToken>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('POST')
       .setPath('/jwt/user')
       .setRequestSchema(createUserTokenRequestRequest)
@@ -113,8 +113,8 @@ export class JwtService extends BaseService {
    */
   async discardUserJwt(tokenId: string, requestConfig?: RequestConfig): Promise<HttpResponse<DiscardTokenResponse>> {
     const request = new RequestBuilder<DiscardTokenResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('DELETE')
       .setPath('/jwt/user/{token_id}')
       .setRequestSchema(z.any())
@@ -139,8 +139,8 @@ export class JwtService extends BaseService {
    */
   async fetchUserTokens(userId: string, requestConfig?: RequestConfig): Promise<HttpResponse<FetchTokensResponse>> {
     const request = new RequestBuilder<FetchTokensResponse>()
-      .setConfig(this.config)
       .setBaseUrl(this.config)
+      .setConfig(this.config)
       .setMethod('GET')
       .setPath('/jwt/user/{user_id}')
       .setRequestSchema(z.any())

--- a/packages/user-client/scripts/build.ts
+++ b/packages/user-client/scripts/build.ts
@@ -164,4 +164,4 @@ async function build(specfile = 'https://public.magicbell.com/specs/openapi.v2.j
   execSync(`yarn build`, { stdio: 'inherit' });
 }
 
-build(args.spec);
+build(args.spec || process.env.V2_SPEC_URL || process.env.SPEC_URL);


### PR DESCRIPTION
- allow overriding spec url via env var - `V2_SPEC_URL || SPEC_URL`
- pin the package version, so codegen doesn't change it upon regen
- upgrade the custom headers patch to be compatible with changed liblab
- regenerate the `project-client`