### PR TITLE
fix(cli): Fixing contents of NPM package

### DIFF
--- a/.changeset/chilly-fans-cover.md
+++ b/.changeset/chilly-fans-cover.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/cli': patch
+---
+
+Fixes @magicbell/cli NPM package content

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
   "sideEffects": false,
   "files": [
     "/bin/magicbell.js",
-    "/dist/index.cjs",
+    "/dist",
     "LICENSE"
   ],
   "homepage": "https://magicbell.com",


### PR DESCRIPTION
https://registry.npmjs.org/@magicbell/cli/-/cli-4.1.0.tgz is missing the `dist` folder (probably caused by the switch to tshy?)

https://registry.npmjs.org/@magicbell/cli/-/cli-4.0.0.tgz still had it.


## Test Plan:

Ran `npm publish --dry-run` inside the cli package and saw all files in the `dist` folder being added.