### PR TITLE
Regenerating project client

### DIFF
--- a/.changeset/orange-dots-scream.md
+++ b/.changeset/orange-dots-scream.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/project-client': patch
+---
+
+Correctly flagging nullable properties. All of them were optional before so they are likely handled correctly already and this is just affecting response validation.

--- a/packages/project-client/README.md
+++ b/packages/project-client/README.md
@@ -81,7 +81,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.broadcasts.listBroadcasts({
-    pageSize: 8,
+    pageSize: 6,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });

--- a/packages/project-client/documentation/services/BroadcastsService.md
+++ b/packages/project-client/documentation/services/BroadcastsService.md
@@ -38,7 +38,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.broadcasts.listBroadcasts({
-    pageSize: 8,
+    pageSize: 6,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -141,8 +141,8 @@ import { Broadcast, Client } from '@magicbell/project-client';
   const statusStatus = StatusStatus.ENQUEUED;
 
   const summary: Summary = {
-    failures: 2,
-    total: 9,
+    failures: 10,
+    total: 8,
   };
 
   const broadcastStatus: BroadcastStatus = {

--- a/packages/project-client/documentation/services/ChannelsService.md
+++ b/packages/project-client/documentation/services/ChannelsService.md
@@ -80,10 +80,10 @@ import { Client, ProjectDeliveryConfig } from '@magicbell/project-client';
 
   const projectDeliveryConfigChannels: ProjectDeliveryConfigChannels = {
     channel: channelsChannel1,
-    delay: 8,
+    delay: 1,
     disabled: true,
     if: 'if',
-    priority: 3,
+    priority: 5,
   };
 
   const projectDeliveryConfig: ProjectDeliveryConfig = {
@@ -125,10 +125,10 @@ import { CategoryDeliveryConfig, Client } from '@magicbell/project-client';
 
   const categoryDeliveryConfigChannels: CategoryDeliveryConfigChannels = {
     channel: channelsChannel2,
-    delay: 6,
+    delay: 3,
     disabled: true,
     if: 'if',
-    priority: 1,
+    priority: 5,
   };
 
   const categoryDeliveryConfig: CategoryDeliveryConfig = {
@@ -174,7 +174,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.channels.getMobilePushApnsUserTokens('user_id', {
-    pageSize: 9,
+    pageSize: 3,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -282,7 +282,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.channels.getMobilePushExpoUserTokens('user_id', {
-    pageSize: 3,
+    pageSize: 2,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -390,7 +390,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.channels.getMobilePushFcmUserTokens('user_id', {
-    pageSize: 2,
+    pageSize: 3,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -498,7 +498,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.channels.getSlackUserTokens('user_id', {
-    pageSize: 7,
+    pageSize: 8,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -714,7 +714,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.channels.getWebPushUserTokens('user_id', {
-    pageSize: 1,
+    pageSize: 9,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });

--- a/packages/project-client/documentation/services/EventsService.md
+++ b/packages/project-client/documentation/services/EventsService.md
@@ -36,7 +36,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.events.getEvents({
-    pageSize: 8,
+    pageSize: 1,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });

--- a/packages/project-client/documentation/services/IntegrationsService.md
+++ b/packages/project-client/documentation/services/IntegrationsService.md
@@ -96,7 +96,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.integrations.listIntegrations({
-    pageSize: 3,
+    pageSize: 8,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });
@@ -165,12 +165,13 @@ const payloadVersion = PayloadVersion._1;
 const apnsConfig: ApnsConfig = {
   appId: "app_id",
   badge: badge,
-  certificate: "----- BEGINMYXRQV RJX--------
-C==
-------ENDPY------",
-  keyId: "quis irure",
+  certificate: "--------- BEGINF--------
+DufxW=
+------- ENDQPJ---
+",
+  keyId: "et in elit",
   payloadVersion: payloadVersion,
-  teamId: "commodo ma"
+  teamId: "consequat "
 };
 
   const { data } = await client.integrations.saveApnsIntegration(
@@ -526,10 +527,9 @@ const fcmConfig: FcmConfig = {
   clientEmail: "client_email",
   clientId: "client_id",
   clientX509CertUrl: "client_x509_cert_url",
-  privateKey: "BEGINSPJ WRG------
-cJGTsgilO=
--- ENDXLDHRV--------
-",
+  privateKey: "BEGINUQYD--------
+rSm==
+-------ENDTYIWA---",
   privateKeyId: "private_key_id",
   projectId: "project_id",
   tokenUri: "token_uri",
@@ -773,7 +773,7 @@ import { Client, InboxConfig } from '@magicbell/project-client';
 
   const banner: Banner = {
     backgroundColor: 'backgroundColor',
-    backgroundOpacity: 8.57,
+    backgroundOpacity: 3.98,
     fontSize: 'fontSize',
     textColor: 'textColor',
   };
@@ -1481,10 +1481,10 @@ import { Client, SlackConfig } from '@magicbell/project-client';
   });
 
   const slackConfig: SlackConfig = {
-    appId: 'EP2DZ',
-    clientId: '986001.1869975198',
-    clientSecret: 'Loremconsectetur dolorculpaquis ',
-    signingSecret: 'non officia velit ut aliquaExcep',
+    appId: 'QPB3C3EYQY4',
+    clientId: '01131.219',
+    clientSecret: 'mollit Ut pariaturex ut Duis dol',
+    signingSecret: 'officia commodoincididunt quisel',
   };
 
   const { data } = await client.integrations.saveSlackIntegration(slackConfig);
@@ -1835,7 +1835,7 @@ import { Client, TwilioConfig } from '@magicbell/project-client';
     accountSid: 'account_sid',
     apiKey: 'api_key',
     apiSecret: 'api_secret',
-    from: '+99300830465',
+    from: '+65321207213408',
     region: twilioConfigRegion,
   };
 

--- a/packages/project-client/documentation/services/JwtService.md
+++ b/packages/project-client/documentation/services/JwtService.md
@@ -78,7 +78,7 @@ import { Client, CreateProjectTokenRequest } from '@magicbell/project-client';
   });
 
   const createProjectTokenRequest: CreateProjectTokenRequest = {
-    expiry: 1,
+    expiry: 5,
     name: 'name',
   };
 
@@ -150,7 +150,7 @@ import { Client, CreateUserTokenRequest } from '@magicbell/project-client';
 
   const createUserTokenRequest: CreateUserTokenRequest = {
     email: 'email',
-    expiry: 1,
+    expiry: 6,
     externalId: 'external_id',
     name: 'name',
   };
@@ -225,7 +225,7 @@ import { Client } from '@magicbell/project-client';
   });
 
   const { data } = await client.jwt.fetchUserTokens('user_id', {
-    pageSize: 5,
+    pageSize: 9,
     pageAfter: 'page[after]',
     pageBefore: 'page[before]',
   });

--- a/packages/project-client/src/services/channels/models/token-metadata.ts
+++ b/packages/project-client/src/services/channels/models/token-metadata.ts
@@ -6,9 +6,9 @@ import { z } from 'zod';
 export const tokenMetadata = z.lazy(() => {
   return z.object({
     createdAt: z.string(),
-    discardedAt: z.string().optional(),
+    discardedAt: z.string().optional().nullable(),
     id: z.string(),
-    updatedAt: z.string().optional(),
+    updatedAt: z.string().optional().nullable(),
   });
 });
 
@@ -30,9 +30,9 @@ export const tokenMetadataResponse = z.lazy(() => {
   return z
     .object({
       created_at: z.string(),
-      discarded_at: z.string().optional(),
+      discarded_at: z.string().optional().nullable(),
       id: z.string(),
-      updated_at: z.string().optional(),
+      updated_at: z.string().optional().nullable(),
     })
     .transform((data) => ({
       createdAt: data['created_at'],

--- a/packages/project-client/src/services/events/models/event.ts
+++ b/packages/project-client/src/services/events/models/event.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 export const event = z.lazy(() => {
   return z.object({
     code: z.number().optional(),
-    context: z.any().optional(),
+    context: z.any().optional().nullable(),
     id: z.string(),
     level: z.string().optional(),
     log: z.string().optional().nullable(),
@@ -36,7 +36,7 @@ export const eventResponse = z.lazy(() => {
   return z
     .object({
       code: z.number().optional(),
-      context: z.any().optional(),
+      context: z.any().optional().nullable(),
       id: z.string(),
       level: z.string().optional(),
       log: z.string().optional().nullable(),

--- a/packages/project-client/src/services/integrations/models/reply-to.ts
+++ b/packages/project-client/src/services/integrations/models/reply-to.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 export const replyTo = z.lazy(() => {
   return z.object({
     email: z.string(),
-    name: z.string().optional(),
+    name: z.string().optional().nullable(),
   });
 });
 
@@ -26,7 +26,7 @@ export const replyToResponse = z.lazy(() => {
   return z
     .object({
       email: z.string(),
-      name: z.string().optional(),
+      name: z.string().optional().nullable(),
     })
     .transform((data) => ({
       email: data['email'],

--- a/packages/project-client/src/services/integrations/models/sendgrid-config-from.ts
+++ b/packages/project-client/src/services/integrations/models/sendgrid-config-from.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 export const sendgridConfigFrom = z.lazy(() => {
   return z.object({
     email: z.string(),
-    name: z.string().optional(),
+    name: z.string().optional().nullable(),
   });
 });
 
@@ -26,7 +26,7 @@ export const sendgridConfigFromResponse = z.lazy(() => {
   return z
     .object({
       email: z.string(),
-      name: z.string().optional(),
+      name: z.string().optional().nullable(),
     })
     .transform((data) => ({
       email: data['email'],

--- a/packages/project-client/src/services/integrations/models/ses-config-from.ts
+++ b/packages/project-client/src/services/integrations/models/ses-config-from.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 export const sesConfigFrom = z.lazy(() => {
   return z.object({
     email: z.string(),
-    name: z.string().optional(),
+    name: z.string().optional().nullable(),
   });
 });
 
@@ -26,7 +26,7 @@ export const sesConfigFromResponse = z.lazy(() => {
   return z
     .object({
       email: z.string(),
-      name: z.string().optional(),
+      name: z.string().optional().nullable(),
     })
     .transform((data) => ({
       email: data['email'],


### PR DESCRIPTION
This incorporates the schema changes to correctly flag  `nullable` properties (https://github.com/magicbell/magicbell/pull/5419).

The API responses did not change, and this just fixes schema validation that was previously throwing errors e.g. when a tokens `discarded_at` was `null`.
