### PR TITLE
fix: ensure clicking menu doesn't open action url

### DIFF
--- a/.changeset/quiet-tools-thank.md
+++ b/.changeset/quiet-tools-thank.md
@@ -1,0 +1,6 @@
+---
+'@magicbell/magicbell-react': patch
+'@magicbell/embeddable': patch
+---
+
+ensure that clicking notification menu doesn't trigger action url

--- a/packages/playground/examples/shared/mocks.ts
+++ b/packages/playground/examples/shared/mocks.ts
@@ -137,11 +137,13 @@ const fakeNotifications = {
     notification({
       title: `Welcome to MagicBell Playground! 🎉`,
       content: 'Here you can explore, and play with, our various web SDKs.',
+      action_url: 'https://magicbell.com',
     }),
     notification({
       title: 'Make demos or reproductions. 👀',
       content:
         'Click the "Fork" button in the top right corner when you wish to save your changes. It will load the current playground - including all modifications - in CodeSandbox. The sandbox can then be easily shared with coworkers, or with us.',
+      action_url: 'https://example.com',
     }),
     notification({
       title: 'Escape the Sandbox. 🚀',

--- a/packages/react/src/components/ClickableNotification/ClickableNotification.tsx
+++ b/packages/react/src/components/ClickableNotification/ClickableNotification.tsx
@@ -17,6 +17,21 @@ export interface Props {
   prose?: boolean;
 }
 
+const actionableTags = new Set(['A', 'BUTTON', 'INPUT', 'TEXTAREA', 'SELECT']);
+function isActionableElement(event: MouseEvent) {
+  let el = event.target as HTMLElement;
+
+  while (el && el !== event.currentTarget) {
+    if (actionableTags.has(el.tagName.toUpperCase())) {
+      return true;
+    }
+
+    el = el.parentElement;
+  }
+
+  return false;
+}
+
 /**
  * Component that renders a notification. When the notification is clicked the
  * `onClick` callback is called and the notification is marked as read.
@@ -37,9 +52,9 @@ export default function ClickableNotification({ notification: rawNotification, o
 
     // We don't want to invoke the action url when the user clicks a link or button inside the notification.
     // Notification content should take precedence.
-    const isActionableElement = /^(a|button|input)$/i.test(event.target.tagName);
+    const isAction = isActionableElement(event);
+    if (isAction) return;
 
-    if (isActionableElement) return;
     const onClickResult = onClick?.(notification);
     if (onClickResult === false) return;
 


### PR DESCRIPTION
ensure that clicking notification menu doesn't trigger action url
