### PR TITLE
fix: don't mark notification as read on click menu

### DIFF
--- a/.changeset/few-boats-marry.md
+++ b/.changeset/few-boats-marry.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/magicbell-react': patch
+---
+
+notifications are no longer marked as read when the notification menu is clicked

--- a/packages/react/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/react/src/components/NotificationMenu/NotificationMenu.tsx
@@ -47,6 +47,7 @@ export default function NotificationMenu({ notification }: Props) {
       <button
         ref={refs.setReference}
         type="button"
+        data-magicbell-target="notification-menu"
         aria-label={t('notification.menu', 'Menu')}
         css={css`
           color: ${theme.textColor} !important;


### PR DESCRIPTION
fixes the issue where notifications move away from the "unread: true" tab when clicking the notification menu, as reportered in https://github.com/orgs/magicbell/discussions/231