### PR TITLE
feat: dedupe parallel requests

### DIFF
--- a/.changeset/cuddly-bottles-pretend.md
+++ b/.changeset/cuddly-bottles-pretend.md
@@ -1,0 +1,5 @@
+---
+'magicbell': minor
+---
+
+We now dedupe identical requests that are made within the same second.

--- a/packages/magicbell/src/client/cache.ts
+++ b/packages/magicbell/src/client/cache.ts
@@ -1,0 +1,50 @@
+import { RequestArgs } from './types.js';
+
+function sortObj(obj: Record<string, unknown>) {
+  const entries = Object.entries(obj || {});
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries.sort());
+}
+
+export class Cache {
+  #records = new Map<string, { promise: Promise<any>; timestamp: number }>();
+  #ttl: number;
+
+  constructor(options: { ttl: number }) {
+    this.#ttl = options.ttl || 1000;
+  }
+
+  getRequestKey(args: Omit<RequestArgs, 'path' | 'params'> & { url: URL }): string {
+    const { method, url, data, headers } = args;
+
+    return JSON.stringify({
+      method,
+      url: url.toString(),
+      data: sortObj(data),
+      headers: sortObj(headers),
+    });
+  }
+
+  #flush() {
+    const currentTimestamp = Date.now();
+    for (const [key, { timestamp }] of this.#records.entries()) {
+      if (currentTimestamp - timestamp > this.#ttl) {
+        this.#records.delete(key);
+      }
+    }
+  }
+
+  get(key: string) {
+    this.#flush();
+
+    const record = this.#records.get(key);
+    if (record) {
+      return record.promise;
+    }
+    return null;
+  }
+
+  set(key: string, promise: Promise<any>) {
+    this.#records.set(key, { promise, timestamp: Date.now() });
+  }
+}

--- a/packages/magicbell/src/client/cache.ts
+++ b/packages/magicbell/src/client/cache.ts
@@ -11,7 +11,7 @@ export class Cache {
   #ttl: number;
 
   constructor(options: { ttl: number }) {
-    this.#ttl = options.ttl || 1000;
+    this.#ttl = options.ttl ?? 1000;
   }
 
   getRequestKey(args: Omit<RequestArgs, 'path' | 'params'> & { url: URL }): string {
@@ -28,7 +28,7 @@ export class Cache {
   #flush() {
     const currentTimestamp = Date.now();
     for (const [key, { timestamp }] of this.#records.entries()) {
-      if (currentTimestamp - timestamp > this.#ttl) {
+      if (currentTimestamp - timestamp >= this.#ttl) {
         this.#records.delete(key);
       }
     }
@@ -45,6 +45,7 @@ export class Cache {
   }
 
   set(key: string, promise: Promise<any>) {
+    if (this.#ttl <= 0) return;
     this.#records.set(key, { promise, timestamp: Date.now() });
   }
 }

--- a/packages/magicbell/src/client/client.test.ts
+++ b/packages/magicbell/src/client/client.test.ts
@@ -46,6 +46,7 @@ test('requests are retried in case of recoverable errors', async () => {
   const client = new Client({
     apiKey: 'my-api-key',
     maxRetryDelay: 0,
+    cacheTTL: 0,
   });
 
   await expect(
@@ -70,6 +71,7 @@ test('retried requests get an idempotency-key header', async () => {
     apiKey: 'my-api-key',
     maxRetryDelay: 0,
     maxRetries: 3,
+    cacheTTL: 0,
   });
 
   // verify that this request is done using 3 identical idempotencyKeys
@@ -100,6 +102,7 @@ test('requests are not retried in case of unrecoverable errors', async () => {
   const client = new Client({
     apiKey: 'my-api-key',
     maxRetryDelay: 0,
+    cacheTTL: 0,
   });
 
   await expect(
@@ -123,6 +126,7 @@ test('client accepts custom headers', async () => {
       'X-Custom-Header': 'foo',
       host: 'api.magicbell.com',
     },
+    cacheTTL: 0,
   });
 
   // verify that this request is done using 3 identical idempotencyKeys
@@ -141,6 +145,7 @@ test("custom headers don't override controlled ones", async () => {
     headers: {
       'x-magicbell-api-key': 'bar',
     },
+    cacheTTL: 0,
   });
 
   // verify that this request is done using 3 identical idempotencyKeys
@@ -157,6 +162,7 @@ test('custom headers can be provided per request basis', async () => {
     headers: {
       'x-custom-header-one': 'one',
     },
+    cacheTTL: 0,
   });
 
   await client.request({
@@ -171,12 +177,13 @@ test('custom headers can be provided per request basis', async () => {
   expect(status.lastRequest.headers.get('x-custom-header-two')).toEqual('two');
 });
 
-test('requests within the same second are deduped', async () => {
+test('requests within the same ttl are deduped', async () => {
   const status = server.intercept('all', () => ({ id: Math.random() }));
 
   const client = new Client({
     apiKey: 'my-api-key',
     maxRetryDelay: 0,
+    cacheTTL: 1_000,
   });
 
   const res1 = await client.request({ method: 'GET', path: '/me' });

--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -18,6 +18,7 @@ export const DEFAULT_OPTIONS: Partial<ClientOptions> = {
   maxRetries: 3,
   maxRetryDelay: 60,
   telemetry: true,
+  cacheTTL: 1000,
 };
 
 export class Client {
@@ -27,9 +28,9 @@ export class Client {
   constructor(options: ClientOptions) {
     assertHasValidOptions(options);
     assertHasSomeOptions(options, ['token', 'apiKey']);
-    this.#cache = new Cache({ ttl: 1000 });
 
     this.#options = { ...DEFAULT_OPTIONS, ...options };
+    this.#cache = new Cache({ ttl: this.#options.cacheTTL });
   }
 
   hasFlag(flag: FeatureFlag) {

--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -4,6 +4,7 @@ import ky from '@smeijer/ky';
 import urlJoin from 'url-join';
 
 import { tryParse } from '../lib/utils.js';
+import { Cache } from './cache.js';
 import { createError } from './error.js';
 import { withRequestHeaders } from './headers.js';
 import { withRequestLogging } from './log.js';
@@ -21,10 +22,12 @@ export const DEFAULT_OPTIONS: Partial<ClientOptions> = {
 
 export class Client {
   #options: ClientOptions;
+  #cache: Cache;
 
   constructor(options: ClientOptions) {
     assertHasValidOptions(options);
     assertHasSomeOptions(options, ['token', 'apiKey']);
+    this.#cache = new Cache({ ttl: 1000 });
 
     this.#options = { ...DEFAULT_OPTIONS, ...options };
   }
@@ -46,8 +49,9 @@ export class Client {
     // don't just use `new URL(path, host)` as that will strip the path from the host
     const url = new URL(urlJoin(requestOptions.host, path));
 
-    for (const [key, value] of Object.entries(params || {})) {
-      url.searchParams.append(key, Array.isArray(value) ? value.join(',') : value);
+    for (const [key, value] of Object.entries(params || {}).sort()) {
+      const val = Array.isArray(value) ? [...value].sort().join(',') : value;
+      url.searchParams.append(key, val);
     }
 
     const hooks = mergeHooks(
@@ -57,7 +61,15 @@ export class Client {
       this.#options.hooks,
     );
 
-    return ky(url, {
+    const requestKey = this.#cache.getRequestKey({ method, url, data, headers: reqHeaders });
+
+    // Check if there's already a pending request
+    let promise = this.#cache.get(requestKey);
+    if (promise) {
+      return promise;
+    }
+
+    promise = ky(url, {
       method,
       body: data && JSON.stringify(data),
       retry: {
@@ -89,5 +101,9 @@ export class Client {
           ...body?.errors?.[0],
         });
       });
+
+    // Cache the promise so we can dedupe parallel requests
+    this.#cache.set(requestKey, promise);
+    return promise;
   }
 }

--- a/packages/magicbell/src/client/options.ts
+++ b/packages/magicbell/src/client/options.ts
@@ -20,6 +20,7 @@ const optionValidators: Record<keyof ClientOptions, (value: unknown) => boolean>
   features: isObject,
   headers: isObject,
   hooks: isObject,
+  cacheTTL: isNumber,
 };
 
 export function isOptionsHash(object) {

--- a/packages/magicbell/src/client/resource.test.ts
+++ b/packages/magicbell/src/client/resource.test.ts
@@ -50,6 +50,7 @@ class FakeResource extends Resource {
 const client = new Client({
   host: 'https://example.com',
   apiKey: 'my-api-key',
+  cacheTTL: 0,
 });
 
 const fakeResource = new FakeResource(client);

--- a/packages/magicbell/src/client/types.ts
+++ b/packages/magicbell/src/client/types.ts
@@ -23,6 +23,7 @@ export type ClientOptions = {
   features?: Record<string, never>;
   headers?: Record<string, string>;
   hooks?: Hooks;
+  cacheTTL?: number;
 };
 
 export type FeatureFlag = keyof ClientOptions['features'];

--- a/packages/magicbell/src/resources/listen.test.ts
+++ b/packages/magicbell/src/resources/listen.test.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
     yield { type: 'notifications/new', data: { id: 3 } };
   });
 
-  const client = new Client({ apiKey: 'my-api-key' });
+  const client = new Client({ apiKey: 'my-api-key', cacheTTL: 0 });
   listen = createListener(client, { sseHost: sse.host });
 });
 

--- a/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx
+++ b/packages/react-headless/src/components/MagicBellProvider/MagicBellProvider.tsx
@@ -19,6 +19,7 @@ export type MagicBellProviderProps = {
   stores?: StoreConfig[];
   serverURL?: string;
   disableRealtime?: boolean;
+  apiClientCacheTTL?: number;
 } & (
   | { apiKey: string; userEmail: string; userKey?: string; token?: never }
   | { apiKey: string; userExternalId: string; userKey?: string; token?: never }

--- a/packages/react-headless/src/hooks/useNotifications.ts
+++ b/packages/react-headless/src/hooks/useNotifications.ts
@@ -75,7 +75,8 @@ export default function useNotifications(storeId = 'default'): NotificationStore
 
   useEffect(() => {
     if (!store) return;
-    if (config.lastFetchedAt && !store.lastFetchedAt) fetch({ page: 1 });
+    if (!config.lastFetchedAt || store.lastFetchedAt) return;
+    void fetch({ page: 1 });
   }, [config.lastFetchedAt, store, fetch]);
 
   const markAllAsReadFn = useCallback<NotificationStore['markAllAsRead']>(

--- a/packages/react-headless/src/stores/clientSettings.ts
+++ b/packages/react-headless/src/stores/clientSettings.ts
@@ -13,6 +13,7 @@ export type ClientSettings = {
   serverURL: string;
   getClient(): InstanceType<typeof UserClient>;
   appInfo?: { name: string; version: string };
+  apiClientCacheTTL?: number;
 } & ({ userEmail: string } | { userExternalId: string });
 
 /**
@@ -35,6 +36,7 @@ const clientSettings = createStore<ClientSettings>((set, get) => {
     clientId: Math.random().toString(36).substring(2) + Date.now(),
     serverURL: 'https://api.magicbell.com',
     appInfo: undefined,
+    apiClientCacheTTL: 1000,
 
     getClient() {
       const state = get();
@@ -53,6 +55,7 @@ const clientSettings = createStore<ClientSettings>((set, get) => {
             name: pkg.name,
             version: pkg.version,
           },
+          cacheTTL: state.apiClientCacheTTL,
         });
       }
 

--- a/packages/react-headless/tests/src/components/RealtimeListener.spec.tsx
+++ b/packages/react-headless/tests/src/components/RealtimeListener.spec.tsx
@@ -17,6 +17,7 @@ beforeAll(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/hooks/useBell.spec.ts
+++ b/packages/react-headless/tests/src/hooks/useBell.spec.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 
   const { result } = renderHook(() => useNotificationStoresCollection());

--- a/packages/react-headless/tests/src/hooks/useMagicBellEvent.spec.ts
+++ b/packages/react-headless/tests/src/hooks/useMagicBellEvent.spec.ts
@@ -13,6 +13,7 @@ beforeAll(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/hooks/useNotification.spec.ts
+++ b/packages/react-headless/tests/src/hooks/useNotification.spec.ts
@@ -14,6 +14,7 @@ beforeAll(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/hooks/useNotificationFactory.spec.ts
+++ b/packages/react-headless/tests/src/hooks/useNotificationFactory.spec.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/hooks/useNotifications.spec.ts
+++ b/packages/react-headless/tests/src/hooks/useNotifications.spec.ts
@@ -15,6 +15,7 @@ beforeAll(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/lib/ajax.spec.ts
+++ b/packages/react-headless/tests/src/lib/ajax.spec.ts
@@ -9,6 +9,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/lib/realtime.spec.ts
+++ b/packages/react-headless/tests/src/lib/realtime.spec.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/stores/config/useConfig.spec.ts
+++ b/packages/react-headless/tests/src/stores/config/useConfig.spec.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
+++ b/packages/react-headless/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
+++ b/packages/react-headless/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: faker.internet.email(),
+    apiClientCacheTTL: 0,
   });
 
   // useNotificationPreferences is a singleton so we clear the state before each test

--- a/packages/react-headless/tests/src/stores/notifications/NotificationRepository.spec.ts
+++ b/packages/react-headless/tests/src/stores/notifications/NotificationRepository.spec.ts
@@ -8,6 +8,7 @@ beforeEach(() => {
     serverURL: 'https://api.magicbell.com',
     apiKey: 'fake-key',
     userEmail: 'person@example.com',
+    apiClientCacheTTL: 0,
   });
 });
 

--- a/packages/react-headless/tests/src/stores/notifications/useNotificationStoresCollection.spec.ts
+++ b/packages/react-headless/tests/src/stores/notifications/useNotificationStoresCollection.spec.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
       serverURL: 'https://api.magicbell.com',
       apiKey: 'fake-key',
       userEmail: faker.internet.email(),
+      apiClientCacheTTL: 0,
     });
   });
 });

--- a/packages/react/src/components/MagicBell/MagicBell.tsx
+++ b/packages/react/src/components/MagicBell/MagicBell.tsx
@@ -42,6 +42,7 @@ export type Props = {
   onToggle?: (isOpen: boolean) => void;
   isOpen?: boolean;
   bellCounter?: 'unread' | 'unseen';
+  apiClientCacheTTL?: number;
 } & ({ userExternalId: string } | { userEmail: string });
 
 const defaultInbox = (props) => <FloatingNotificationInbox height={500} {...props} />;

--- a/packages/react/src/components/MagicBellProvider/MagicBellProvider.tsx
+++ b/packages/react/src/components/MagicBellProvider/MagicBellProvider.tsx
@@ -25,6 +25,7 @@ export type MagicBellProviderProps = {
   }>;
   serverURL?: string;
   disableRealtime?: boolean;
+  apiClientCacheTTL?: number;
 } & ({ userExternalId: string } | { userEmail: string });
 
 const internals = {

--- a/packages/react/tests/__utils__/render.tsx
+++ b/packages/react/tests/__utils__/render.tsx
@@ -23,7 +23,15 @@ export function renderWithProviders(node: ReactElement, options?: Partial<Render
   const { apiKey, locale, theme, images, stores } = Object.assign(defaultOptions, options);
 
   return TLRender(
-    <MagicBellProvider apiKey={apiKey} userEmail="-" stores={stores} images={images} locale={locale} theme={theme}>
+    <MagicBellProvider
+      apiKey={apiKey}
+      userEmail="-"
+      stores={stores}
+      images={images}
+      locale={locale}
+      theme={theme}
+      apiClientCacheTTL={0}
+    >
       {node}
     </MagicBellProvider>,
   );

--- a/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/packages/react/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -25,7 +25,7 @@ const server = setupMockServer(
 
 function MagicBell(props: ComponentProps<typeof MagicBellProvider>) {
   // apply defaults to disable theme fetching
-  return <MagicBellProvider theme={{}} locale="en" images={{}} {...props} />;
+  return <MagicBellProvider theme={{}} locale="en" images={{}} apiClientCacheTTL={0} {...props} />;
 }
 
 test("renders the notification bell, but not it's default children", async () => {


### PR DESCRIPTION
We now dedupe identical requests that are made within the same second. This benefits react apps which tend to re-render the inbox, causing multiple requests where a single one would do.
