### PR TITLE
fix: bind original stack to custom errors

### DIFF
--- a/packages/magicbell/src/client/client.ts
+++ b/packages/magicbell/src/client/client.ts
@@ -87,6 +87,7 @@ export class Client {
           statusText: error?.response?.statusText,
           responseBody: body,
           ...body?.errors?.[0],
+          stack: error.stack,
         });
       });
   }

--- a/packages/magicbell/src/client/error.ts
+++ b/packages/magicbell/src/client/error.ts
@@ -36,6 +36,7 @@ type ErrorConfig = {
   responseBody?: unknown;
   message: string;
   suggestion?: string;
+  stack?: string;
 };
 
 /**
@@ -98,6 +99,7 @@ export class MagicBellError extends Error {
     this.message = raw.message;
     this.suggestion = raw.suggestion;
     this.docsUrl = raw.docs_url || raw.help_link;
+    this.stack = raw.stack;
   }
 }
 


### PR DESCRIPTION
improve errors by binding the original stack to our custom errors