### PR TITLE
ci: no compact preview releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,4 +95,4 @@ jobs:
       - name: Build
         run: yarn build
       - name: publish preview release
-        run: npx pkg-pr-new publish --template "./pkg-pr-issue-302" --compact './packages/*'
+        run: npx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
Compact releases using the pr number have signature issues when trying to install the same "pr" again after a new commit, making it impossible to update those previews to a later state.