### PR TITLE
chore: drop source field

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -7,7 +7,6 @@
     "Stephan Meijer <stephan.meijer@gmail.com>"
   ],
   "license": "SEE LICENSE IN LICENSE",
-  "source": "./src/index.ts",
   "module": "./dist/esm/index.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/magicbell/package.json
+++ b/packages/magicbell/package.json
@@ -11,7 +11,6 @@
     "project": "./tsconfig.build.json",
     "exports": "./src/*.ts"
   },
-  "source": "./src/index.ts",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
   "exports": {

--- a/packages/project-client/package.json
+++ b/packages/project-client/package.json
@@ -29,7 +29,6 @@
   },
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist",

--- a/packages/user-client/package.json
+++ b/packages/user-client/package.json
@@ -30,7 +30,6 @@
   },
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Some tools use the `source` field in dev mode, meaning we should either publish `/src` or drop `source` from package.json. I chose the later, so install sizes stay small(er).