### PR TITLE
feat: cap badge at 99+

### DIFF
--- a/.changeset/nice-peaches-love.md
+++ b/.changeset/nice-peaches-love.md
@@ -1,0 +1,5 @@
+---
+'@magicbell/magicbell-react': minor
+---
+
+The Badge is now capped at showing '99+' when there are 100 or more unread notifications.

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -40,10 +40,10 @@ export default function Badge({ count }: Props) {
   `;
 
   return (
-    <span css={[cleanslate, style]}>
+    <div css={[cleanslate, style]}>
       <div aria-label={`${count} unread items`} aria-live="polite" role="status">
-        {count}
+        {count > 99 ? '99+' : count}
       </div>
-    </span>
+    </div>
   );
 }


### PR DESCRIPTION
This caps the badge at showing `99+` when there are 100 or more unread notifications.