### PR TITLE
Resolve 'tiny-invariant' import error

### DIFF
--- a/.changeset/busy-crabs-peel.md
+++ b/.changeset/busy-crabs-peel.md
@@ -1,0 +1,5 @@
+---
+'magicbell-js': patch
+---
+
+Fixes invariant import error

--- a/packages/magicbell-js/src/socket.ts
+++ b/packages/magicbell-js/src/socket.ts
@@ -163,7 +163,7 @@ export class Socket {
     invariant(data?.token, 'Unexpected server response, missing token');
 
     this.#inboxToken = data.token;
-    return this.#inboxToken;
+    return data.token;
   }
 }
 
@@ -171,7 +171,7 @@ function isOK(response: { status: number }) {
   return response.status >= 200 && response.status < 300;
 }
 
-function invariant(condition: any, message: string) {
+function invariant(condition: any, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }

--- a/packages/magicbell-js/src/socket.ts
+++ b/packages/magicbell-js/src/socket.ts
@@ -1,5 +1,3 @@
-import invariant from 'tiny-invariant';
-
 import { type Notification, Client } from './user-client.js';
 
 export class Socket {
@@ -171,6 +169,12 @@ export class Socket {
 
 function isOK(response: { status: number }) {
   return response.status >= 200 && response.status < 300;
+}
+
+function invariant(condition: any, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
 }
 
 function getSessionId() {


### PR DESCRIPTION
There was a dependency "tiny-invariant" that was not being resolved because it has not been added as a dependency to "packages/magicbell-js". The error was not showing up in local development only because it was being resolved in the root node_modules. 

