### PR TITLE
Rename socket to realtime, add documentation

### DIFF
--- a/.changeset/six-comics-juggle.md
+++ b/.changeset/six-comics-juggle.md
@@ -1,0 +1,5 @@
+---
+'magicbell-js': minor
+---
+
+feat!: rename Socket class to Realtime for better discoverability, and add documentation

--- a/packages/magicbell-js/.gitignore
+++ b/packages/magicbell-js/.gitignore
@@ -1,5 +1,5 @@
 docs-dist
 out
 /project-client/package.json
-/socket/package.json
+/realtime/package.json
 /user-client/package.json

--- a/packages/magicbell-js/README.md
+++ b/packages/magicbell-js/README.md
@@ -285,3 +285,57 @@ The SDK includes several models that represent the data structures used in API r
 </details>
 
 <!-- AUTO-GENERATED-CONTENT:END (user-client) -->
+
+# Realtime
+
+The Realtime client enables real-time notification delivery through WebSocket connections. When new notifications are created for a user, they are instantly pushed to connected clients without requiring polling.
+
+## Authentication
+
+The Realtime client requires a user access token for authentication. This can be provided either directly or through an existing `UserClient` instance.
+
+## Sample Usage
+
+```ts
+import { Realtime } from 'magicbell-js/realtime';
+
+const realtime = new Realtime({ token: 'USER_ACCESS_TOKEN' });
+
+realtime.listen((notification) => {
+  console.log('New notification received:', notification.title);
+  // Handle the notification (update UI, show toast, etc.)
+});
+
+// When done listening
+realtime.disconnect();
+```
+
+## Using with UserClient
+
+You can also initialize the Realtime client with an existing `UserClient`:
+
+```ts
+import { Client } from 'magicbell-js/user-client';
+import { Realtime } from 'magicbell-js/realtime';
+
+const userClient = new Client({ token: 'USER_ACCESS_TOKEN' });
+const realtime = new Realtime(userClient);
+
+realtime.listen((notification) => {
+  console.log('New notification:', notification);
+});
+```
+
+## Connection Management
+
+The Realtime client automatically handles connection management, including reconnection attempts when the connection is lost:
+
+```ts
+// Check if currently connected
+if (realtime.isListening()) {
+  console.log('Connected to real-time notifications');
+}
+
+// Disconnect when no longer needed
+realtime.disconnect();
+```

--- a/packages/magicbell-js/package.json
+++ b/packages/magicbell-js/package.json
@@ -26,14 +26,14 @@
         "default": "./dist/commonjs/project-client.js"
       }
     },
-    "./socket": {
+    "./realtime": {
       "import": {
-        "types": "./dist/esm/socket.d.ts",
-        "default": "./dist/esm/socket.js"
+        "types": "./dist/esm/realtime.d.ts",
+        "default": "./dist/esm/realtime.js"
       },
       "require": {
-        "types": "./dist/commonjs/socket.d.ts",
-        "default": "./dist/commonjs/socket.js"
+        "types": "./dist/commonjs/realtime.d.ts",
+        "default": "./dist/commonjs/realtime.js"
       }
     },
     "./user-client": {
@@ -54,7 +54,7 @@
     "README.md",
     "/project-client/package.json",
     "/user-client/package.json",
-    "/socket/package.json"
+    "/realtime/package.json"
   ],
   "scripts": {
     "build": "run-s build:bundle build:node10 build:docs build:attw",

--- a/packages/magicbell-js/src/realtime.ts
+++ b/packages/magicbell-js/src/realtime.ts
@@ -1,6 +1,6 @@
 import { type Notification, Client } from './user-client.js';
 
-export class Socket {
+export class Realtime {
   #client: Client;
   #socketUrl = 'wss://ws.magicbell.com';
   #inboxToken: string | undefined;


### PR DESCRIPTION
Renames the "socket" client to "realtime" client, to better match likely search demand.

Also adds documentation for the new API. Marked as a minor bump due to the API being undocumented until now.