### PR TITLE
ci: fix ArrayBuffer type issues

### DIFF
--- a/packages/magicbell-js/src/project-client/http/handlers/response-validation-handler.ts
+++ b/packages/magicbell-js/src/project-client/http/handlers/response-validation-handler.ts
@@ -37,7 +37,7 @@ export class ResponseValidationHandler implements RequestHandler {
       .filter((line) => line.startsWith('data: '))
       .map((part) => ({
         ...response,
-        raw: encoder.encode(part),
+        raw: encoder.encode(part).buffer,
       }));
   }
 

--- a/packages/magicbell-js/src/project-client/http/transport/request-fetch-adapter.ts
+++ b/packages/magicbell-js/src/project-client/http/transport/request-fetch-adapter.ts
@@ -65,7 +65,7 @@ export class RequestFetchAdapter<T> implements HttpAdapter {
       for (const line of lineDecoder.splitLines(value)) {
         yield {
           metadata,
-          raw: line,
+          raw: line.buffer,
         };
       }
     }
@@ -73,7 +73,7 @@ export class RequestFetchAdapter<T> implements HttpAdapter {
     for (const line of lineDecoder.flush()) {
       yield {
         metadata,
-        raw: line,
+        raw: line.buffer,
       };
     }
   }

--- a/packages/magicbell-js/src/project-client/http/utils/line-decoder.ts
+++ b/packages/magicbell-js/src/project-client/http/utils/line-decoder.ts
@@ -7,11 +7,11 @@ export class LineDecoder {
    * Splits the given chunk into lines.
    * Stores incomplete lines in a buffer and returns them when the next chunk arrives.
    */
-  public splitLines(chunk: Uint8Array): Uint8Array[] {
+  public splitLines(chunk: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer>[] {
     this.lineBuffer += this.decoder.decode(chunk);
 
     let lineEndIndex;
-    const lines: Uint8Array[] = [];
+    const lines: Uint8Array<ArrayBuffer>[] = [];
     while ((lineEndIndex = this.lineBuffer.indexOf('\n')) >= 0) {
       const line = this.lineBuffer.slice(0, lineEndIndex + 1); // Include the newline character
       this.lineBuffer = this.lineBuffer.slice(lineEndIndex + 1);
@@ -24,7 +24,7 @@ export class LineDecoder {
   }
 
   /** Returns the remaining lines in the buffer. */
-  public flush(): Uint8Array[] {
+  public flush(): Uint8Array<ArrayBuffer>[] {
     if (this.lineBuffer.length === 0) {
       return [];
     }

--- a/packages/magicbell-js/src/user-client/http/handlers/response-validation-handler.ts
+++ b/packages/magicbell-js/src/user-client/http/handlers/response-validation-handler.ts
@@ -37,7 +37,7 @@ export class ResponseValidationHandler implements RequestHandler {
       .filter((line) => line.startsWith('data: '))
       .map((part) => ({
         ...response,
-        raw: encoder.encode(part),
+        raw: encoder.encode(part).buffer,
       }));
   }
 

--- a/packages/magicbell-js/src/user-client/http/transport/request-fetch-adapter.ts
+++ b/packages/magicbell-js/src/user-client/http/transport/request-fetch-adapter.ts
@@ -65,7 +65,7 @@ export class RequestFetchAdapter<T> implements HttpAdapter {
       for (const line of lineDecoder.splitLines(value)) {
         yield {
           metadata,
-          raw: line,
+          raw: line.buffer,
         };
       }
     }
@@ -73,7 +73,7 @@ export class RequestFetchAdapter<T> implements HttpAdapter {
     for (const line of lineDecoder.flush()) {
       yield {
         metadata,
-        raw: line,
+        raw: line.buffer,
       };
     }
   }

--- a/packages/magicbell-js/src/user-client/http/utils/line-decoder.ts
+++ b/packages/magicbell-js/src/user-client/http/utils/line-decoder.ts
@@ -7,11 +7,11 @@ export class LineDecoder {
    * Splits the given chunk into lines.
    * Stores incomplete lines in a buffer and returns them when the next chunk arrives.
    */
-  public splitLines(chunk: Uint8Array): Uint8Array[] {
+  public splitLines(chunk: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer>[] {
     this.lineBuffer += this.decoder.decode(chunk);
 
     let lineEndIndex;
-    const lines: Uint8Array[] = [];
+    const lines: Uint8Array<ArrayBuffer>[] = [];
     while ((lineEndIndex = this.lineBuffer.indexOf('\n')) >= 0) {
       const line = this.lineBuffer.slice(0, lineEndIndex + 1); // Include the newline character
       this.lineBuffer = this.lineBuffer.slice(lineEndIndex + 1);
@@ -24,7 +24,7 @@ export class LineDecoder {
   }
 
   /** Returns the remaining lines in the buffer. */
-  public flush(): Uint8Array[] {
+  public flush(): Uint8Array<ArrayBuffer>[] {
     if (this.lineBuffer.length === 0) {
       return [];
     }


### PR DESCRIPTION
## Background
renovate bot [updated the TypeScript version](https://github.com/magicbell/magicbell-js/commit/09b5fb71d4c2a3b108d522d9a121e51317660cfc#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL10887-R10889) from 5.8.3 -> 5.9.2

TypeScript 5.9 changes how ArrayBuffer are handled:

ArrayBuffer has been changed is no longer a supertype of several different TypedArray types. 
This also includes subtypes of UInt8Array, such as Buffer from Node.js.

Further Information:
https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes

## Changes
The PR updates 
`Uint8Array` -> `Uint8Array<ArrayBuffer>`
and 
`someFunc(data)` ->  `someFunc(data.buffer)`

At multiple places causing TypeScript errors.