### PR TITLE
chore: pin typescript version

### DIFF
--- a/example/floating-inbox/package.json
+++ b/example/floating-inbox/package.json
@@ -27,6 +27,6 @@
     "@types/react-dom": "^18.2.17",
     "vite": "latest",
     "vite-preset-react": "latest",
-    "typescript": "^5.7.3"
+    "typescript": "5.7.3"
   }
 }

--- a/example/nextjs-webpush/package.json
+++ b/example/nextjs-webpush/package.json
@@ -25,6 +25,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.4.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "5.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -110,5 +110,8 @@
     "vitest": "^3.1.1",
     "vitest-github-actions-reporter": "^0.11.1",
     "zx": "^8.5.0"
+  },
+  "resolutions": {
+    "typescript": "5.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "tslib": "^2.8.0",
     "tsx": "^4.19.0",
     "turbo": "^2.3.1",
-    "typescript": "^5.7.3",
+    "typescript": "5.7.3",
     "vite": "^5.4.0",
     "vite-plugin-banner": "^0.8.0",
     "vite-plugin-replace": "^0.1.1",

--- a/packages/magicbell-js/package.json
+++ b/packages/magicbell-js/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@magicbell/codegen": "^0.4.0",
-    "typescript": "^5.7.3"
+    "typescript": "5.7.3"
   },
   "docs": {
     "name": "JavaScript SDK"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,7 +15,7 @@
     "clsx": "^2.1.0",
     "glob": "^8.1.0",
     "next": "15.4.1",
-    "next-runtime": "^2.4.1",
+    "next-runtime": "^2.4.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-popper": "^2.3.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "clean": "rimraf .next .turbo",
-    "build": "next build",
+    "_build": "next build",
     "start": "next-remote-watch ./examples"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,10 +3732,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
-"@types/node@^20.17.11":
-  version "20.19.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.10.tgz#8bee5d6fa97221d50d767fa5707a3dd6503e8f19"
-  integrity sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==
+"@types/node@^22.13.9":
+  version "22.18.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.0.tgz#9e4709be4f104e3568f7dd1c71e2949bf147a47b"
+  integrity sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==
   dependencies:
     undici-types "~6.21.0"
 
@@ -8438,10 +8438,10 @@ next-remote-watch@^1.0.0:
     commander "^5.0.0"
     express "^4.17.1"
 
-next-runtime@^2.4.1:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/next-runtime/-/next-runtime-2.4.3.tgz#2972d8e40801eb244d29dbb204ad6344f7fa067f"
-  integrity sha512-8xH8pNhN2CRhm8WznG9ItumV98ugoUcxkG9bN/wutQSt34re+Uk3nAGIZnvOENZpL1XUA/o3q1suIE/E+YxyPw==
+next-runtime@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/next-runtime/-/next-runtime-2.4.4.tgz#f8f6949be62d620e9697bc2099495e70a2f38a4c"
+  integrity sha512-sjnZakRzVfW99B7r28QiwhT7qW7Gyb8YF6PS6CHupA9N4K/Z5TFk6nwZ+/uH8X/oiLQUiZodyi37kIMGhsqfhQ==
   dependencies:
     "@types/accepts" "^1"
     "@types/body-parser" "^1"
@@ -10883,7 +10883,12 @@ typescript@5.6.1-rc:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.1-rc.tgz#d5e4d7d8170174fed607b74cc32aba3d77018e02"
   integrity sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==
 
-typescript@^5.5.3, typescript@^5.7.3:
+typescript@5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+
+typescript@^5.5.3:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
@@ -11532,10 +11537,10 @@ yoctocolors-cjs@^2.1.2:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
-zod@3.25.71:
-  version "3.25.71"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.71.tgz#f87a19c06b061426564607726c05a4d3b9ac3fa9"
-  integrity sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==
+zod@3.22.0:
+  version "3.22.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.0.tgz#2478211a9bf477eb2d7d2ce031b5f8ff0d596407"
+  integrity sha512-y5KZY/ssf5n7hCGDGGtcJO/EBJEm5Pa+QQvFBeyMOtnFYOSflalxIFFvdaYevPhePcmcKC4aTbFkCcXN7D0O8Q==
 
 zustand@^3.5.10:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,10 +3732,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
-"@types/node@^22.13.9":
-  version "22.18.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.0.tgz#9e4709be4f104e3568f7dd1c71e2949bf147a47b"
-  integrity sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==
+"@types/node@^20.17.11":
+  version "20.19.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.11.tgz#728cab53092bd5f143beed7fbba7ba99de3c16c4"
+  integrity sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==
   dependencies:
     undici-types "~6.21.0"
 
@@ -8438,7 +8438,7 @@ next-remote-watch@^1.0.0:
     commander "^5.0.0"
     express "^4.17.1"
 
-next-runtime@^2.4.4:
+next-runtime@^2.4.1:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/next-runtime/-/next-runtime-2.4.4.tgz#f8f6949be62d620e9697bc2099495e70a2f38a4c"
   integrity sha512-sjnZakRzVfW99B7r28QiwhT7qW7Gyb8YF6PS6CHupA9N4K/Z5TFk6nwZ+/uH8X/oiLQUiZodyi37kIMGhsqfhQ==
@@ -11537,10 +11537,10 @@ yoctocolors-cjs@^2.1.2:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
-zod@3.22.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.0.tgz#2478211a9bf477eb2d7d2ce031b5f8ff0d596407"
-  integrity sha512-y5KZY/ssf5n7hCGDGGtcJO/EBJEm5Pa+QQvFBeyMOtnFYOSflalxIFFvdaYevPhePcmcKC4aTbFkCcXN7D0O8Q==
+zod@3.25.71:
+  version "3.25.71"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.71.tgz#f87a19c06b061426564607726c05a4d3b9ac3fa9"
+  integrity sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==
 
 zustand@^3.5.10:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8438,7 +8438,7 @@ next-remote-watch@^1.0.0:
     commander "^5.0.0"
     express "^4.17.1"
 
-next-runtime@^2.4.1:
+next-runtime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/next-runtime/-/next-runtime-2.4.4.tgz#f8f6949be62d620e9697bc2099495e70a2f38a4c"
   integrity sha512-sjnZakRzVfW99B7r28QiwhT7qW7Gyb8YF6PS6CHupA9N4K/Z5TFk6nwZ+/uH8X/oiLQUiZodyi37kIMGhsqfhQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10878,20 +10878,10 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typescript@5.6.1-rc:
-  version "5.6.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.1-rc.tgz#d5e4d7d8170174fed607b74cc32aba3d77018e02"
-  integrity sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==
-
-typescript@5.7.3:
+typescript@5.6.1-rc, typescript@5.7.3, typescript@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
-
-typescript@^5.5.3:
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
-  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 ua-parser-js@^0.7.30:
   version "0.7.40"


### PR DESCRIPTION
Pins the typescript version down to 5.7.3, because 5.9.2 throws an

```
Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBuffer'.
```
